### PR TITLE
Added sbt flags to fix Docker build

### DIFF
--- a/compiler/install
+++ b/compiler/install
@@ -42,7 +42,10 @@ sed -i.bak -e "s/val commit = .*/val commit = \"$commit\"/" \
   $util/Version.scala
 
 echo "Building jar files"
-sbt assembly
+# The --batch and -Dsbt.server.forcestart=true flags were added to get the
+# build to work without user interaction in a Docker container. See
+# https://github.com/sbt/sbt/issues/6101#issuecomment-924554619.
+sbt --batch -Dsbt.server.forcestart=true assembly
 
 echo "Restoring Version.scala"
 cp $util/Version.scala.bak $util/Version.scala


### PR DESCRIPTION
On CADRE our cross compilation process occurs inside Yocto based Docker containers. In order to get `fpp` building in that I needed to resolve https://github.com/sbt/sbt/issues/6101. Specifically I used the solution in https://github.com/sbt/sbt/issues/6101#issuecomment-924554619. Admittedly this is a copy-paste-hey-it-worked solution so I'm not sure if it's something long-term to mainline.