### PR TITLE
lestarch: adding release script, versioning, and fixes

### DIFF
--- a/compiler/install
+++ b/compiler/install
@@ -42,7 +42,7 @@ fpp-to-cpp
 fpp-to-xml
 "
 
-commit=`git log | awk 'NR == 1 { print $2 }'`
+commit=`git describe --tags --always`
 util=lib/src/main/scala/util
 echo "Updating commit to $commit"
 sed -i.bak -e "s/val commit = .*/val commit = \"$commit\"/" \
@@ -65,6 +65,6 @@ do
   cp $jar $dest/$tool.jar
   echo '#!/bin/sh
 
-  java -jar '$dest'/'$tool'.jar $@' > $dest/$tool
+  java -jar '$dest'/'$tool'.jar "$@"' > $dest/$tool
   chmod +x $dest/$tool
 done

--- a/compiler/install
+++ b/compiler/install
@@ -42,7 +42,7 @@ fpp-to-cpp
 fpp-to-xml
 "
 
-commit=`git describe --tags --always`
+commit=`git log | awk 'NR == 1 { print $2 }'`
 util=lib/src/main/scala/util
 echo "Updating commit to $commit"
 sed -i.bak -e "s/val commit = .*/val commit = \"$commit\"/" \

--- a/compiler/release
+++ b/compiler/release
@@ -1,0 +1,55 @@
+#!/bin/sh -e
+
+# ----------------------------------------------------------------------
+# FPP release builder
+# ----------------------------------------------------------------------
+# To pass flags to sbt, set the environment variable
+# FPP_SBT_FLAGS
+# ----------------------------------------------------------------------
+
+DIRECTORY=`dirname $0`
+FAST_BIN="${DIRECTORY}/fast-fpp-`uname`-`uname -m`"
+NATIVE_IMAGE=`which native-image || exit 0`
+JAVA_PATH=`which java || exit 0`
+
+# Looking for native-image
+if [ ! -x "${NATIVE_IMAGE}" ]
+then
+    echo "[ERROR] native-image not found, install Graal JVM, native-image, and ensure it runs on your system" 1>&2
+    exit 1
+fi
+JAVA_DIR=`dirname "${JAVA_PATH}"`
+NATIVE_DIR=`dirname "${NATIVE_IMAGE}"`
+
+if [ "${JAVA_DIR}" != "${NATIVE_DIR}" ]
+then
+    echo "[ERROR] Java and native-image found in different paths. This will result in a failed build." 1>&2
+    echo "[ERROR] Make sure Graal JVM is on the path and native-image was installed with 'gu install native-image'" 1>&2
+    echo "[ERROR] Java Path: ${JAVA_DIR}" 1>&2
+    echo "[ERROR] Native Path: ${NATIVE_IMAGE}" 1>&2
+    exit 2
+fi
+mkdir -p "${FAST_BIN}"
+
+
+
+
+# Install locally
+${DIRECTORY}/install
+
+for item in ${DIRECTORY}/bin/*.jar
+do
+    IMAGE_NAME=`basename $item`
+    IMAGE_NAME=`echo $IMAGE_NAME | cut -f 1 -d '.'`
+    OUTPUT="${FAST_BIN}/${IMAGE_NAME}"
+    echo "Building Fast Version of ${IMAGE_NAME}"
+    native-image --no-fallback --install-exit-handlers -jar "${item}" "${OUTPUT}"
+    if [ $? -ne 0 ]
+    then
+        echo "[ERROR] Failed to build ${IMAGE_NAME}"
+        exit 1
+    fi
+done
+rm "${FAST_BIN}"/*.txt
+tar -czf "${FAST_BIN}.tar.gz" "${FAST_BIN}"
+echo "[INFO] Release archive built, prepare for Hyper Drive"

--- a/compiler/release
+++ b/compiler/release
@@ -8,7 +8,7 @@
 # ----------------------------------------------------------------------
 
 DIRECTORY=`dirname $0`
-FAST_BIN="${DIRECTORY}/fast-fpp-`uname`-`uname -m`"
+NATIVE_BIN="${DIRECTORY}/native-fpp-`uname`-`uname -m`"
 NATIVE_IMAGE=`which native-image || exit 0`
 JAVA_PATH=`which java || exit 0`
 
@@ -29,7 +29,7 @@ then
     echo "[ERROR] Native Path: ${NATIVE_IMAGE}" 1>&2
     exit 2
 fi
-mkdir -p "${FAST_BIN}"
+mkdir -p "${NATIVE_BIN}"
 
 
 
@@ -41,7 +41,7 @@ for item in ${DIRECTORY}/bin/*.jar
 do
     IMAGE_NAME=`basename $item`
     IMAGE_NAME=`echo $IMAGE_NAME | cut -f 1 -d '.'`
-    OUTPUT="${FAST_BIN}/${IMAGE_NAME}"
+    OUTPUT="${NATIVE_BIN}/${IMAGE_NAME}"
     echo "Building Fast Version of ${IMAGE_NAME}"
     native-image --no-fallback --install-exit-handlers -jar "${item}" "${OUTPUT}"
     if [ $? -ne 0 ]
@@ -50,6 +50,6 @@ do
         exit 1
     fi
 done
-rm "${FAST_BIN}"/*.txt
-tar -czf "${FAST_BIN}.tar.gz" "${FAST_BIN}"
+rm "${NATIVE_BIN}"/*.txt
+tar -czf "${NATIVE_BIN}.tar.gz" "${NATIVE_BIN}"
 echo "[INFO] Release archive built, prepare for Hyper Drive"


### PR DESCRIPTION
This adds 3 fixes:

1. It changes the version information to be use `git describe --tags --always`
2. It escapes shell arguments in the shell wrappers (#104)
3. It adds a `release` script that can build Graal JVM based native-images that increase fpp speed substantially.

Note: the above version change has the above desirable properties over the raw commit hash:

1. Collapses to <tag> when versioning an exact tag
2. Human readable (<last tag>-<commits past tag>-g<commit short has>)
2. Used elsewhere in F´ to capture version
3. Comparable to other versions with string greater and lesser operations

It retains the following properties:
1. Git hash is present
2. `git checkout <version>` works as expected
