### PR TITLE
Fix indent in vim for fpp files

### DIFF
--- a/editors/vim/fpp.vim
+++ b/editors/vim/fpp.vim
@@ -6,6 +6,8 @@
 "
 setl cinwords=component,enum,module,struct,topology
 setl cindent
+setl shiftwidth=2
+setl expandtab
 
 " keywords
 syn keyword fppKeyword active


### PR DESCRIPTION
these lines are needed to avoid vim from indenting 8 spaces.
Instead, vim will indent by 2 spaces. Also, tabs will be treated as 2 spaces