### PR TITLE
making fpp install location movable

### DIFF
--- a/compiler/install
+++ b/compiler/install
@@ -67,7 +67,6 @@ do
   echo "  $jar"
   cp $jar $dest/$tool.jar
   echo '#!/bin/sh
-  LOCAL_DIR="`dirname $0`"
-  java -jar "${LOCAL_DIR}/'$tool'.jar" "$@"' > $dest/$tool
+  java -jar "dirname $0`/'$tool'.jar" "$@"' > $dest/$tool
   chmod +x $dest/$tool
 done

--- a/compiler/install
+++ b/compiler/install
@@ -67,7 +67,7 @@ do
   echo "  $jar"
   cp $jar $dest/$tool.jar
   echo '#!/bin/sh
-
-  java -jar '$dest'/'$tool'.jar "$@"' > $dest/$tool
+  LOCAL_DIR="`dirname $0`"
+  java -jar "${LOCAL_DIR}/'$tool'.jar" "$@"' > $dest/$tool
   chmod +x $dest/$tool
 done


### PR DESCRIPTION
Allows the install FPP Scala tools directory to be portable.  This is needed to allow installing to one location and then moving the directory afterwards, which is part of the installation process when installing non-native tools.  