### PR TITLE
Use U8 as the serialized size of bool

### DIFF
--- a/compiler/lib/src/main/scala/codegen/CppWriter/CppWriterState.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/CppWriterState.scala
@@ -174,10 +174,14 @@ case class CppWriterState(
   def isPrimitive(t: Type, typeName: String): Boolean  = t.isPrimitive || isBuiltInType(typeName)
 
   /** Get C++ expression for serialized size */
-  def getSerializedSizeExpr(t: Type, typeName: String): String = {
-    if isPrimitive(t, typeName) then s"sizeof($typeName)"
-    else s"$typeName::SERIALIZED_SIZE"
-  }
+  def getSerializedSizeExpr(t: Type, typeName: String): String =
+    (t, isPrimitive(t, typeName))  match {
+      // sizeof(bool) is not defined in C++
+      // F Prime serializes bool as U8
+      case (Type.Boolean, _ )=> "sizeof(U8)"
+      case (_, true) => s"sizeof($typeName)"
+      case _ => s"$typeName::SERIALIZED_SIZE"
+    }
 
 }
 

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveBoolArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveBoolArrayAc.ref.hpp
@@ -38,7 +38,7 @@ namespace M {
         //! The size of the array
         SIZE = 3,
         //! The size of the serial representation
-        SERIALIZED_SIZE = SIZE * sizeof(bool),
+        SERIALIZED_SIZE = SIZE * sizeof(U8),
       };
 
     public:


### PR DESCRIPTION
`sizeof(bool)` is not defined in C++.  See https://stackoverflow.com/questions/4897844/is-sizeofbool-defined-in-the-c-language-standard.

F Prime serializes `bool` as U8. See https://github.com/nasa/fprime/blob/776af784414b8df7c148845dfca8a1956e5ac4cb/Fw/Types/Serializable.cpp#L210-L225.