### PR TITLE
Revise generated C++ headers

### DIFF
--- a/compiler/lib/src/main/scala/codegen/CppWriter/ArrayCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ArrayCppWriter.scala
@@ -98,20 +98,19 @@ case class ArrayCppWriter (
   }
 
   private def getCppIncludes: CppDoc.Member = {
-    val systemStrings = List("cstring", "cstdio", "cinttypes")
-    val fwStrings = List(
+    val systemHeaders = List(
+      "cstdio",
+      "cstring",
+    ).map(CppWriter.systemHeaderString).map(line)
+    val userHeaders = List(
       "Fw/Types/Assert.hpp",
       "Fw/Types/StringUtils.hpp",
-    )
-    val headerString = s"${s.getRelativePath(fileName).toString}.hpp"
+      s"${s.getRelativePath(fileName).toString}.hpp"
+    ).sorted.map(CppWriter.headerString).map(line)
     CppWriter.linesMember(
       List(
-        List(Line.blank),
-        systemStrings.map(CppWriter.systemHeaderString).map(line),
-        List(Line.blank),
-        fwStrings.map(CppWriter.headerString).map(line),
-        List(Line.blank),
-        lines(CppWriter.headerString(headerString)),
+        Line.blank :: systemHeaders,
+        Line.blank :: userHeaders
       ).flatten,
       CppDoc.Lines.Cpp
     )

--- a/compiler/lib/src/main/scala/codegen/CppWriter/CppWriterState.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/CppWriterState.scala
@@ -129,7 +129,7 @@ case class CppWriterState(
   }
 
   /** Write include directives as lines */
-  def writeIncludeDirectives(usedSymbols: Iterable[Symbol]): List[Line] = {
+  def writeIncludeDirectives(usedSymbols: Iterable[Symbol]): List[String] = {
     def getHeaderStr(file: File.JavaPath) =
       CppWriter.headerString(s"${file.toString}.hpp")
     def getDirectiveforSymbol(sym: Symbol): Option[String] = sym match {
@@ -142,9 +142,6 @@ case class CppWriterState(
       )
       case Symbol.Component(node) => Some(
         getHeaderStr(getRelativePath(ComputeCppFiles.FileNames.getComponent(getName(Symbol.Component(node)))))
-      )
-      case Symbol.Constant(_) => Some(
-        getHeaderStr(getRelativePath(ComputeCppFiles.FileNames.getConstants))
       )
       case Symbol.Enum(node) => Some(
         getHeaderStr(getRelativePath(ComputeCppFiles.FileNames.getEnum(getName(Symbol.Enum(node)))))
@@ -161,10 +158,7 @@ case class CppWriterState(
       case _ => None
     }
 
-    usedSymbols.map(getDirectiveforSymbol).filter(_.isDefined).map(_.get).toList match {
-      case Nil => Nil
-      case strings => strings.map(Line(_))
-    }
+    usedSymbols.map(getDirectiveforSymbol).filter(_.isDefined).map(_.get).toList
   }
 
   /** Is this a built-in type? */

--- a/compiler/tools/fpp-to-cpp/test/array/AbsTypeArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/AbsTypeArrayAc.ref.cpp
@@ -4,14 +4,12 @@
 // \brief  cpp file for AbsType array
 // ======================================================================
 
-#include <cstring>
 #include <cstdio>
-#include <cinttypes>
-
-#include "Fw/Types/Assert.hpp"
-#include "Fw/Types/StringUtils.hpp"
+#include <cstring>
 
 #include "AbsTypeArrayAc.hpp"
+#include "Fw/Types/Assert.hpp"
+#include "Fw/Types/StringUtils.hpp"
 
 // ----------------------------------------------------------------------
 // Constructors

--- a/compiler/tools/fpp-to-cpp/test/array/AbsTypeArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/AbsTypeArrayAc.ref.hpp
@@ -10,7 +10,6 @@
 #include "Fw/Types/BasicTypes.hpp"
 #include "Fw/Types/Serializable.hpp"
 #include "Fw/Types/String.hpp"
-
 #include "T.hpp"
 
 //! An array of abstract type

--- a/compiler/tools/fpp-to-cpp/test/array/BuiltInTypeArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/BuiltInTypeArrayAc.ref.cpp
@@ -4,14 +4,12 @@
 // \brief  cpp file for BuiltInType array
 // ======================================================================
 
-#include <cstring>
 #include <cstdio>
-#include <cinttypes>
-
-#include "Fw/Types/Assert.hpp"
-#include "Fw/Types/StringUtils.hpp"
+#include <cstring>
 
 #include "BuiltInTypeArrayAc.hpp"
+#include "Fw/Types/Assert.hpp"
+#include "Fw/Types/StringUtils.hpp"
 
 // ----------------------------------------------------------------------
 // Constructors

--- a/compiler/tools/fpp-to-cpp/test/array/BuiltInTypeArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/BuiltInTypeArrayAc.ref.hpp
@@ -11,7 +11,6 @@
 #include "Fw/Types/Serializable.hpp"
 #include "Fw/Types/String.hpp"
 
-
 //! An array of a built-in type
 class BuiltInType :
   public Fw::Serializable

--- a/compiler/tools/fpp-to-cpp/test/array/Enum1ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/Enum1ArrayAc.ref.cpp
@@ -4,14 +4,12 @@
 // \brief  cpp file for Enum1 array
 // ======================================================================
 
-#include <cstring>
 #include <cstdio>
-#include <cinttypes>
-
-#include "Fw/Types/Assert.hpp"
-#include "Fw/Types/StringUtils.hpp"
+#include <cstring>
 
 #include "Enum1ArrayAc.hpp"
+#include "Fw/Types/Assert.hpp"
+#include "Fw/Types/StringUtils.hpp"
 
 // ----------------------------------------------------------------------
 // Constructors

--- a/compiler/tools/fpp-to-cpp/test/array/Enum1ArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/Enum1ArrayAc.ref.hpp
@@ -7,11 +7,10 @@
 #ifndef Enum1ArrayAc_HPP
 #define Enum1ArrayAc_HPP
 
+#include "E1EnumAc.hpp"
 #include "Fw/Types/BasicTypes.hpp"
 #include "Fw/Types/Serializable.hpp"
 #include "Fw/Types/String.hpp"
-
-#include "E1EnumAc.hpp"
 
 //! Array with enum argument
 class Enum1 :

--- a/compiler/tools/fpp-to-cpp/test/array/Enum2ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/Enum2ArrayAc.ref.cpp
@@ -4,14 +4,12 @@
 // \brief  cpp file for Enum2 array
 // ======================================================================
 
-#include <cstring>
 #include <cstdio>
-#include <cinttypes>
-
-#include "Fw/Types/Assert.hpp"
-#include "Fw/Types/StringUtils.hpp"
+#include <cstring>
 
 #include "Enum2ArrayAc.hpp"
+#include "Fw/Types/Assert.hpp"
+#include "Fw/Types/StringUtils.hpp"
 
 // ----------------------------------------------------------------------
 // Constructors

--- a/compiler/tools/fpp-to-cpp/test/array/Enum2ArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/Enum2ArrayAc.ref.hpp
@@ -7,11 +7,10 @@
 #ifndef Enum2ArrayAc_HPP
 #define Enum2ArrayAc_HPP
 
+#include "E2EnumAc.hpp"
 #include "Fw/Types/BasicTypes.hpp"
 #include "Fw/Types/Serializable.hpp"
 #include "Fw/Types/String.hpp"
-
-#include "E2EnumAc.hpp"
 
 class Enum2 :
   public Fw::Serializable

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveArrayArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveArrayArrayAc.ref.cpp
@@ -4,13 +4,11 @@
 // \brief  cpp file for PrimitiveArray array
 // ======================================================================
 
-#include <cstring>
 #include <cstdio>
-#include <cinttypes>
+#include <cstring>
 
 #include "Fw/Types/Assert.hpp"
 #include "Fw/Types/StringUtils.hpp"
-
 #include "PrimitiveArrayArrayAc.hpp"
 
 // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveArrayArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveArrayArrayAc.ref.hpp
@@ -10,7 +10,6 @@
 #include "Fw/Types/BasicTypes.hpp"
 #include "Fw/Types/Serializable.hpp"
 #include "Fw/Types/String.hpp"
-
 #include "PrimitiveF64ArrayAc.hpp"
 
 //! An array of arrays

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveBoolArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveBoolArrayAc.ref.cpp
@@ -4,13 +4,11 @@
 // \brief  cpp file for PrimitiveBool array
 // ======================================================================
 
-#include <cstring>
 #include <cstdio>
-#include <cinttypes>
+#include <cstring>
 
 #include "Fw/Types/Assert.hpp"
 #include "Fw/Types/StringUtils.hpp"
-
 #include "PrimitiveBoolArrayAc.hpp"
 
 namespace M {

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveBoolArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveBoolArrayAc.ref.hpp
@@ -11,8 +11,6 @@
 #include "Fw/Types/Serializable.hpp"
 #include "Fw/Types/String.hpp"
 
-#include "FppConstantsAc.hpp"
-
 namespace M {
 
   class PrimitiveBool :

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveF32eArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveF32eArrayAc.ref.cpp
@@ -4,13 +4,11 @@
 // \brief  cpp file for PrimitiveF32e array
 // ======================================================================
 
-#include <cstring>
 #include <cstdio>
-#include <cinttypes>
+#include <cstring>
 
 #include "Fw/Types/Assert.hpp"
 #include "Fw/Types/StringUtils.hpp"
-
 #include "PrimitiveF32eArrayAc.hpp"
 
 namespace M {

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveF32eArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveF32eArrayAc.ref.hpp
@@ -11,8 +11,6 @@
 #include "Fw/Types/Serializable.hpp"
 #include "Fw/Types/String.hpp"
 
-#include "FppConstantsAc.hpp"
-
 namespace M {
 
   //! An array of F32 with default value and format string

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveF32fArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveF32fArrayAc.ref.cpp
@@ -4,13 +4,11 @@
 // \brief  cpp file for PrimitiveF32f array
 // ======================================================================
 
-#include <cstring>
 #include <cstdio>
-#include <cinttypes>
+#include <cstring>
 
 #include "Fw/Types/Assert.hpp"
 #include "Fw/Types/StringUtils.hpp"
-
 #include "PrimitiveF32fArrayAc.hpp"
 
 namespace M {

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveF32fArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveF32fArrayAc.ref.hpp
@@ -11,8 +11,6 @@
 #include "Fw/Types/Serializable.hpp"
 #include "Fw/Types/String.hpp"
 
-#include "FppConstantsAc.hpp"
-
 namespace M {
 
   //! An array of F32 with format string

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveF64ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveF64ArrayAc.ref.cpp
@@ -4,13 +4,11 @@
 // \brief  cpp file for PrimitiveF64 array
 // ======================================================================
 
-#include <cstring>
 #include <cstdio>
-#include <cinttypes>
+#include <cstring>
 
 #include "Fw/Types/Assert.hpp"
 #include "Fw/Types/StringUtils.hpp"
-
 #include "PrimitiveF64ArrayAc.hpp"
 
 namespace M {

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveF64ArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveF64ArrayAc.ref.hpp
@@ -11,8 +11,6 @@
 #include "Fw/Types/Serializable.hpp"
 #include "Fw/Types/String.hpp"
 
-#include "FppConstantsAc.hpp"
-
 namespace M {
 
   //! An array of F64 with default value and format string

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveI32ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveI32ArrayAc.ref.cpp
@@ -4,13 +4,11 @@
 // \brief  cpp file for PrimitiveI32 array
 // ======================================================================
 
-#include <cstring>
 #include <cstdio>
-#include <cinttypes>
+#include <cstring>
 
 #include "Fw/Types/Assert.hpp"
 #include "Fw/Types/StringUtils.hpp"
-
 #include "PrimitiveI32ArrayAc.hpp"
 
 namespace M {

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveI32ArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveI32ArrayAc.ref.hpp
@@ -11,8 +11,6 @@
 #include "Fw/Types/Serializable.hpp"
 #include "Fw/Types/String.hpp"
 
-#include "FppConstantsAc.hpp"
-
 namespace M {
 
   //! An array of I32 with format string

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveI64ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveI64ArrayAc.ref.cpp
@@ -4,13 +4,11 @@
 // \brief  cpp file for PrimitiveI64 array
 // ======================================================================
 
-#include <cstring>
 #include <cstdio>
-#include <cinttypes>
+#include <cstring>
 
 #include "Fw/Types/Assert.hpp"
 #include "Fw/Types/StringUtils.hpp"
-
 #include "PrimitiveI64ArrayAc.hpp"
 
 namespace M {

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveI64ArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveI64ArrayAc.ref.hpp
@@ -11,8 +11,6 @@
 #include "Fw/Types/Serializable.hpp"
 #include "Fw/Types/String.hpp"
 
-#include "FppConstantsAc.hpp"
-
 namespace M {
 
   //! An array of I64 with format string

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveU16ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveU16ArrayAc.ref.cpp
@@ -4,13 +4,11 @@
 // \brief  cpp file for PrimitiveU16 array
 // ======================================================================
 
-#include <cstring>
 #include <cstdio>
-#include <cinttypes>
+#include <cstring>
 
 #include "Fw/Types/Assert.hpp"
 #include "Fw/Types/StringUtils.hpp"
-
 #include "PrimitiveU16ArrayAc.hpp"
 
 namespace M {

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveU16ArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveU16ArrayAc.ref.hpp
@@ -11,8 +11,6 @@
 #include "Fw/Types/Serializable.hpp"
 #include "Fw/Types/String.hpp"
 
-#include "FppConstantsAc.hpp"
-
 namespace M {
 
   class PrimitiveU16 :

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveU8ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveU8ArrayAc.ref.cpp
@@ -4,13 +4,11 @@
 // \brief  cpp file for PrimitiveU8 array
 // ======================================================================
 
-#include <cstring>
 #include <cstdio>
-#include <cinttypes>
+#include <cstring>
 
 #include "Fw/Types/Assert.hpp"
 #include "Fw/Types/StringUtils.hpp"
-
 #include "PrimitiveU8ArrayAc.hpp"
 
 namespace M {

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveU8ArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveU8ArrayAc.ref.hpp
@@ -11,8 +11,6 @@
 #include "Fw/Types/Serializable.hpp"
 #include "Fw/Types/String.hpp"
 
-#include "FppConstantsAc.hpp"
-
 namespace M {
 
   class PrimitiveU8 :

--- a/compiler/tools/fpp-to-cpp/test/array/String1ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/String1ArrayAc.ref.cpp
@@ -4,13 +4,11 @@
 // \brief  cpp file for String1 array
 // ======================================================================
 
-#include <cstring>
 #include <cstdio>
-#include <cinttypes>
+#include <cstring>
 
 #include "Fw/Types/Assert.hpp"
 #include "Fw/Types/StringUtils.hpp"
-
 #include "String1ArrayAc.hpp"
 
 // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/array/String1ArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/String1ArrayAc.ref.hpp
@@ -11,7 +11,6 @@
 #include "Fw/Types/Serializable.hpp"
 #include "Fw/Types/String.hpp"
 
-
 //! An array of strings
 class String1 :
   public Fw::Serializable

--- a/compiler/tools/fpp-to-cpp/test/array/String2ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/String2ArrayAc.ref.cpp
@@ -4,13 +4,11 @@
 // \brief  cpp file for String2 array
 // ======================================================================
 
-#include <cstring>
 #include <cstdio>
-#include <cinttypes>
+#include <cstring>
 
 #include "Fw/Types/Assert.hpp"
 #include "Fw/Types/StringUtils.hpp"
-
 #include "String2ArrayAc.hpp"
 
 // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/array/String2ArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/String2ArrayAc.ref.hpp
@@ -11,7 +11,6 @@
 #include "Fw/Types/Serializable.hpp"
 #include "Fw/Types/String.hpp"
 
-
 //! An array of strings with specified default value and format string
 class String2 :
   public Fw::Serializable

--- a/compiler/tools/fpp-to-cpp/test/array/StringArrayArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/StringArrayArrayAc.ref.cpp
@@ -4,13 +4,11 @@
 // \brief  cpp file for StringArray array
 // ======================================================================
 
-#include <cstring>
 #include <cstdio>
-#include <cinttypes>
+#include <cstring>
 
 #include "Fw/Types/Assert.hpp"
 #include "Fw/Types/StringUtils.hpp"
-
 #include "StringArrayArrayAc.hpp"
 
 // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/array/StringArrayArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/StringArrayArrayAc.ref.hpp
@@ -10,7 +10,6 @@
 #include "Fw/Types/BasicTypes.hpp"
 #include "Fw/Types/Serializable.hpp"
 #include "Fw/Types/String.hpp"
-
 #include "String2ArrayAc.hpp"
 
 //! An array of arrays of strings

--- a/compiler/tools/fpp-to-cpp/test/array/Struct1ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/Struct1ArrayAc.ref.cpp
@@ -4,13 +4,11 @@
 // \brief  cpp file for Struct1 array
 // ======================================================================
 
-#include <cstring>
 #include <cstdio>
-#include <cinttypes>
+#include <cstring>
 
 #include "Fw/Types/Assert.hpp"
 #include "Fw/Types/StringUtils.hpp"
-
 #include "Struct1ArrayAc.hpp"
 
 // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/array/Struct1ArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/Struct1ArrayAc.ref.hpp
@@ -10,7 +10,6 @@
 #include "Fw/Types/BasicTypes.hpp"
 #include "Fw/Types/Serializable.hpp"
 #include "Fw/Types/String.hpp"
-
 #include "S1SerializableAc.hpp"
 
 //! An array of structs

--- a/compiler/tools/fpp-to-cpp/test/array/Struct2ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/Struct2ArrayAc.ref.cpp
@@ -4,13 +4,11 @@
 // \brief  cpp file for Struct2 array
 // ======================================================================
 
-#include <cstring>
 #include <cstdio>
-#include <cinttypes>
+#include <cstring>
 
 #include "Fw/Types/Assert.hpp"
 #include "Fw/Types/StringUtils.hpp"
-
 #include "Struct2ArrayAc.hpp"
 
 // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/array/Struct2ArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/Struct2ArrayAc.ref.hpp
@@ -10,7 +10,6 @@
 #include "Fw/Types/BasicTypes.hpp"
 #include "Fw/Types/Serializable.hpp"
 #include "Fw/Types/String.hpp"
-
 #include "S2SerializableAc.hpp"
 
 //! Array of structs with struct member

--- a/compiler/tools/fpp-to-cpp/test/array/Struct3ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/Struct3ArrayAc.ref.cpp
@@ -4,13 +4,11 @@
 // \brief  cpp file for Struct3 array
 // ======================================================================
 
-#include <cstring>
 #include <cstdio>
-#include <cinttypes>
+#include <cstring>
 
 #include "Fw/Types/Assert.hpp"
 #include "Fw/Types/StringUtils.hpp"
-
 #include "Struct3ArrayAc.hpp"
 
 // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/array/Struct3ArrayAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/Struct3ArrayAc.ref.hpp
@@ -10,7 +10,6 @@
 #include "Fw/Types/BasicTypes.hpp"
 #include "Fw/Types/Serializable.hpp"
 #include "Fw/Types/String.hpp"
-
 #include "S3SerializableAc.hpp"
 
 //! An array of structs with array member


### PR DESCRIPTION
* Don't generate headers for constant symbols. The names of constant symbols are resolved away before code gen.
* Write out all user (non-system) headers as a single sorted list.