### PR TITLE
Fix C++ array toString() member function

### DIFF
--- a/compiler/tools/fpp-to-cpp/test/array/AbsTypeArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/AbsTypeArrayAc.ref.cpp
@@ -184,16 +184,16 @@ void AbsType ::
     "%s "
     "%s ]";
 
-  // Call toString for arrays and serializable types
+  // Declare strings to hold any serializable toString() arguments
   Fw::String str0;
   Fw::String str1;
   Fw::String str2;
 
+  // Call toString for arrays and serializable types
   this->elements[0].toString(str0);
   this->elements[1].toString(str1);
   this->elements[2].toString(str2);
 
-  // Declare strings to hold any serializable toString() arguments
   char outputString[FW_ARRAY_TO_STRING_BUFFER_SIZE];
   (void) snprintf(
     outputString,

--- a/compiler/tools/fpp-to-cpp/test/array/BuiltInTypeArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/BuiltInTypeArrayAc.ref.cpp
@@ -184,7 +184,6 @@ void BuiltInType ::
     "%s "
     "%s ]";
 
-  // Declare strings to hold any serializable toString() arguments
   char outputString[FW_ARRAY_TO_STRING_BUFFER_SIZE];
   (void) snprintf(
     outputString,

--- a/compiler/tools/fpp-to-cpp/test/array/Enum1ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/Enum1ArrayAc.ref.cpp
@@ -180,14 +180,14 @@ void Enum1 ::
     "%s "
     "%s ]";
 
-  // Call toString for arrays and serializable types
+  // Declare strings to hold any serializable toString() arguments
   Fw::String str0;
   Fw::String str1;
 
+  // Call toString for arrays and serializable types
   this->elements[0].toString(str0);
   this->elements[1].toString(str1);
 
-  // Declare strings to hold any serializable toString() arguments
   char outputString[FW_ARRAY_TO_STRING_BUFFER_SIZE];
   (void) snprintf(
     outputString,

--- a/compiler/tools/fpp-to-cpp/test/array/Enum2ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/Enum2ArrayAc.ref.cpp
@@ -192,20 +192,20 @@ void Enum2 ::
     "%s "
     "%s ]";
 
-  // Call toString for arrays and serializable types
+  // Declare strings to hold any serializable toString() arguments
   Fw::String str0;
   Fw::String str1;
   Fw::String str2;
   Fw::String str3;
   Fw::String str4;
 
+  // Call toString for arrays and serializable types
   this->elements[0].toString(str0);
   this->elements[1].toString(str1);
   this->elements[2].toString(str2);
   this->elements[3].toString(str3);
   this->elements[4].toString(str4);
 
-  // Declare strings to hold any serializable toString() arguments
   char outputString[FW_ARRAY_TO_STRING_BUFFER_SIZE];
   (void) snprintf(
     outputString,

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveArrayArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveArrayArrayAc.ref.cpp
@@ -192,20 +192,20 @@ void PrimitiveArray ::
     "%s "
     "%s ]";
 
-  // Call toString for arrays and serializable types
+  // Declare strings to hold any serializable toString() arguments
   Fw::String str0;
   Fw::String str1;
   Fw::String str2;
   Fw::String str3;
   Fw::String str4;
 
+  // Call toString for arrays and serializable types
   this->elements[0].toString(str0);
   this->elements[1].toString(str1);
   this->elements[2].toString(str2);
   this->elements[3].toString(str3);
   this->elements[4].toString(str4);
 
-  // Declare strings to hold any serializable toString() arguments
   char outputString[FW_ARRAY_TO_STRING_BUFFER_SIZE];
   (void) snprintf(
     outputString,

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveBoolArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveBoolArrayAc.ref.cpp
@@ -186,7 +186,6 @@ namespace M {
       "%d "
       "%d ]";
 
-    // Declare strings to hold any serializable toString() arguments
     char outputString[FW_ARRAY_TO_STRING_BUFFER_SIZE];
     (void) snprintf(
       outputString,

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveF32eArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveF32eArrayAc.ref.cpp
@@ -186,7 +186,6 @@ namespace M {
       "%.3e "
       "%.3e ]";
 
-    // Declare strings to hold any serializable toString() arguments
     char outputString[FW_ARRAY_TO_STRING_BUFFER_SIZE];
     (void) snprintf(
       outputString,

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveF32fArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveF32fArrayAc.ref.cpp
@@ -186,7 +186,6 @@ namespace M {
       "%.1f "
       "%.1f ]";
 
-    // Declare strings to hold any serializable toString() arguments
     char outputString[FW_ARRAY_TO_STRING_BUFFER_SIZE];
     (void) snprintf(
       outputString,

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveF64ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveF64ArrayAc.ref.cpp
@@ -194,7 +194,6 @@ namespace M {
       "%.5g "
       "%.5g ]";
 
-    // Declare strings to hold any serializable toString() arguments
     char outputString[FW_ARRAY_TO_STRING_BUFFER_SIZE];
     (void) snprintf(
       outputString,

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveI32ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveI32ArrayAc.ref.cpp
@@ -186,7 +186,6 @@ namespace M {
       "%" PRIo32 " "
       "%" PRIo32 " ]";
 
-    // Declare strings to hold any serializable toString() arguments
     char outputString[FW_ARRAY_TO_STRING_BUFFER_SIZE];
     (void) snprintf(
       outputString,

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveI64ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveI64ArrayAc.ref.cpp
@@ -186,7 +186,6 @@ namespace M {
       "%" PRIx64 " "
       "%" PRIx64 " ]";
 
-    // Declare strings to hold any serializable toString() arguments
     char outputString[FW_ARRAY_TO_STRING_BUFFER_SIZE];
     (void) snprintf(
       outputString,

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveU16ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveU16ArrayAc.ref.cpp
@@ -186,7 +186,6 @@ namespace M {
       "%" PRIu16 " "
       "%" PRIu16 " ]";
 
-    // Declare strings to hold any serializable toString() arguments
     char outputString[FW_ARRAY_TO_STRING_BUFFER_SIZE];
     (void) snprintf(
       outputString,

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveU8ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveU8ArrayAc.ref.cpp
@@ -186,7 +186,6 @@ namespace M {
       "%" PRIu8 " "
       "%" PRIu8 " ]";
 
-    // Declare strings to hold any serializable toString() arguments
     char outputString[FW_ARRAY_TO_STRING_BUFFER_SIZE];
     (void) snprintf(
       outputString,

--- a/compiler/tools/fpp-to-cpp/test/array/String1ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/String1ArrayAc.ref.cpp
@@ -263,24 +263,14 @@ void String1 ::
     "%s "
     "%s ]";
 
-  // Call toString for arrays and serializable types
-  Fw::String str0;
-  Fw::String str1;
-  Fw::String str2;
-
-  this->elements[0].toString(str0);
-  this->elements[1].toString(str1);
-  this->elements[2].toString(str2);
-
-  // Declare strings to hold any serializable toString() arguments
   char outputString[FW_ARRAY_TO_STRING_BUFFER_SIZE];
   (void) snprintf(
     outputString,
     FW_ARRAY_TO_STRING_BUFFER_SIZE,
     formatString,
-    str0.toChar(),
-    str1.toChar(),
-    str2.toChar()
+    this->elements[0].toChar(),
+    this->elements[1].toChar(),
+    this->elements[2].toChar()
   );
 
   outputString[FW_ARRAY_TO_STRING_BUFFER_SIZE-1] = 0; // NULL terminate

--- a/compiler/tools/fpp-to-cpp/test/array/String2ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/String2ArrayAc.ref.cpp
@@ -259,21 +259,13 @@ void String2 ::
     "a %s b "
     "a %s b ]";
 
-  // Call toString for arrays and serializable types
-  Fw::String str0;
-  Fw::String str1;
-
-  this->elements[0].toString(str0);
-  this->elements[1].toString(str1);
-
-  // Declare strings to hold any serializable toString() arguments
   char outputString[FW_ARRAY_TO_STRING_BUFFER_SIZE];
   (void) snprintf(
     outputString,
     FW_ARRAY_TO_STRING_BUFFER_SIZE,
     formatString,
-    str0.toChar(),
-    str1.toChar()
+    this->elements[0].toChar(),
+    this->elements[1].toChar()
   );
 
   outputString[FW_ARRAY_TO_STRING_BUFFER_SIZE-1] = 0; // NULL terminate

--- a/compiler/tools/fpp-to-cpp/test/array/StringArrayArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/StringArrayArrayAc.ref.cpp
@@ -192,20 +192,20 @@ void StringArray ::
     "%s "
     "%s ]";
 
-  // Call toString for arrays and serializable types
+  // Declare strings to hold any serializable toString() arguments
   Fw::String str0;
   Fw::String str1;
   Fw::String str2;
   Fw::String str3;
   Fw::String str4;
 
+  // Call toString for arrays and serializable types
   this->elements[0].toString(str0);
   this->elements[1].toString(str1);
   this->elements[2].toString(str2);
   this->elements[3].toString(str3);
   this->elements[4].toString(str4);
 
-  // Declare strings to hold any serializable toString() arguments
   char outputString[FW_ARRAY_TO_STRING_BUFFER_SIZE];
   (void) snprintf(
     outputString,

--- a/compiler/tools/fpp-to-cpp/test/array/Struct1ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/Struct1ArrayAc.ref.cpp
@@ -192,20 +192,20 @@ void Struct1 ::
     "%s "
     "%s ]";
 
-  // Call toString for arrays and serializable types
+  // Declare strings to hold any serializable toString() arguments
   Fw::String str0;
   Fw::String str1;
   Fw::String str2;
   Fw::String str3;
   Fw::String str4;
 
+  // Call toString for arrays and serializable types
   this->elements[0].toString(str0);
   this->elements[1].toString(str1);
   this->elements[2].toString(str2);
   this->elements[3].toString(str3);
   this->elements[4].toString(str4);
 
-  // Declare strings to hold any serializable toString() arguments
   char outputString[FW_ARRAY_TO_STRING_BUFFER_SIZE];
   (void) snprintf(
     outputString,

--- a/compiler/tools/fpp-to-cpp/test/array/Struct2ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/Struct2ArrayAc.ref.cpp
@@ -184,16 +184,16 @@ void Struct2 ::
     "%s "
     "%s ]";
 
-  // Call toString for arrays and serializable types
+  // Declare strings to hold any serializable toString() arguments
   Fw::String str0;
   Fw::String str1;
   Fw::String str2;
 
+  // Call toString for arrays and serializable types
   this->elements[0].toString(str0);
   this->elements[1].toString(str1);
   this->elements[2].toString(str2);
 
-  // Declare strings to hold any serializable toString() arguments
   char outputString[FW_ARRAY_TO_STRING_BUFFER_SIZE];
   (void) snprintf(
     outputString,

--- a/compiler/tools/fpp-to-cpp/test/array/Struct3ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/Struct3ArrayAc.ref.cpp
@@ -184,16 +184,16 @@ void Struct3 ::
     "%s "
     "%s ]";
 
-  // Call toString for arrays and serializable types
+  // Declare strings to hold any serializable toString() arguments
   Fw::String str0;
   Fw::String str1;
   Fw::String str2;
 
+  // Call toString for arrays and serializable types
   this->elements[0].toString(str0);
   this->elements[1].toString(str1);
   this->elements[2].toString(str2);
 
-  // Declare strings to hold any serializable toString() arguments
   char outputString[FW_ARRAY_TO_STRING_BUFFER_SIZE];
   (void) snprintf(
     outputString,


### PR DESCRIPTION
- Directly call toChar() instead of toString() on string type members in generated toString() member function
- Fix C++ comments