### PR TITLE
Add line utilities for C++ writer

### DIFF
--- a/compiler/lib/src/main/scala/codegen/CppWriter/ArrayCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ArrayCppWriter.scala
@@ -260,189 +260,166 @@ case class ArrayCppWriter (
 
   private def getOperatorMembers: List[CppDoc.Class.Member] =
     List(
-      CppDoc.Class.Member.Lines(
-        CppDoc.Lines(CppDocHppWriter.writeAccessTag("public"))
-      ),
-      CppDoc.Class.Member.Lines(
-        CppDoc.Lines(
-          CppDocWriter.writeBannerComment("Operators"),
-          CppDoc.Lines.Both,
-        )
-      ),
-      CppDoc.Class.Member.Function(
-        CppDoc.Function(
-          Some("Subscript operator"),
-          "operator[]",
-          List(
-            CppDoc.Function.Param(
-              CppDoc.Type("const U32"),
-              "i",
-              Some("The subscript index"),
-            ),
-          ),
-          CppDoc.Type("ElementType&", Some(s"$name::ElementType&")),
-          List(
-            line("FW_ASSERT(i < SIZE);"),
-            line("return this->elements[i];"),
-          ),
-        )
-      ),
-      CppDoc.Class.Member.Function(
-        CppDoc.Function(
-          Some("Const subscript operator"),
-          "operator[]",
-          List(
-            CppDoc.Function.Param(
-              CppDoc.Type("const U32"),
-              "i",
-              Some("The subscript index"),
-            ),
-          ),
-          CppDoc.Type("const ElementType&", Some(s"const $name::ElementType&")),
-          List(
-            line("FW_ASSERT(i < SIZE);"),
-            line("return this->elements[i];"),
-          ),
-          CppDoc.Function.NonSV,
-          CppDoc.Function.Const,
-        )
-      ),
-      CppDoc.Class.Member.Function(
-        CppDoc.Function(
-          Some("Copy assignment operator (object)"),
-          "operator=",
-          List(
-            CppDoc.Function.Param(
-              CppDoc.Type(s"const $name&"),
-              "obj",
-              Some("The source object"),
-            ),
-          ),
-          CppDoc.Type(s"$name&"),
-          List(
-            wrapInIf("this == &obj", lines("return *this;")),
-            Line.blank ::
-            indexIterator(lines("this->elements[index] = obj.elements[index];")),
-            lines("return *this;"),
-          ).flatten,
-        )
-      ),
-      CppDoc.Class.Member.Function(
-        CppDoc.Function(
-          Some("Copy assignment operator (raw array)"),
-          "operator=",
-          List(
-            CppDoc.Function.Param(
-              CppDoc.Type(s"const ElementType"),
-              "(&a)[SIZE]",
-              Some("The source array"),
-            ),
-          ),
-          CppDoc.Type(s"$name&"),
-          List(
-            indexIterator(lines("this->elements[index] = a[index];")),
-            lines("return *this;"),
-          ).flatten
-        )
-      ),
-      CppDoc.Class.Member.Function(
-        CppDoc.Function(
-          Some("Copy assignment operator (single element)"),
-          "operator=",
-          List(
-            CppDoc.Function.Param(
-              CppDoc.Type(s"const ElementType&"),
-              "e",
-              Some("The element"),
-            ),
-          ),
-          CppDoc.Type(s"$name&"),
-          List(
-            indexIterator(lines("this->elements[index] = e;")),
-            lines("return *this;"),
-          ).flatten
-        )
-      ),
-      CppDoc.Class.Member.Function(
-        CppDoc.Function(
-          Some("Equality operator"),
-          "operator==",
-          List(
-            CppDoc.Function.Param(
-              CppDoc.Type(s"const $name&"),
-              "obj",
-              Some("The other object"),
-            ),
-          ),
-          CppDoc.Type("bool"),
-          List(
-            indexIterator(wrapInIf(
-              "!((*this)[index] == obj[index])",
-              lines("return false;"),
-            )),
-            lines("return true;"),
-          ).flatten,
-          CppDoc.Function.NonSV,
-          CppDoc.Function.Const,
-        )
-      ),
-      CppDoc.Class.Member.Function(
-        CppDoc.Function(
-          Some("Inequality operator"),
-          "operator!=",
-          List(
-            CppDoc.Function.Param(
-              CppDoc.Type(s"const $name&"),
-              "obj",
-              Some("The other object"),
-            ),
-          ),
-          CppDoc.Type("bool"),
-          lines("return !(*this == obj);"),
-          CppDoc.Function.NonSV,
-          CppDoc.Function.Const,
-        )
-      ),
-      CppDoc.Class.Member.Lines(
-        CppDoc.Lines(
-          lines("\n#ifdef BUILD_UT"),
-          CppDoc.Lines.Both
-        )
-      ),
-      CppDoc.Class.Member.Lines(
-        CppDoc.Lines(
-          lines(
-            s"""|
-                |//! Ostream operator
-                |friend std::ostream& operator<<(
-                |    std::ostream& os, //!< The ostream
-                |    const $name& obj //!< The object
-                |);"""
+      List(
+        CppDoc.Class.Member.Lines(
+          CppDoc.Lines(CppDocHppWriter.writeAccessTag("public"))
+        ),
+        CppDoc.Class.Member.Lines(
+          CppDoc.Lines(
+            CppDocWriter.writeBannerComment("Operators"),
+            CppDoc.Lines.Both,
           )
-        )
-      ),
-      CppDoc.Class.Member.Lines(
-        CppDoc.Lines(
-          wrapInScope(
-            s"\nstd::ostream& operator<<(std::ostream& os, const $name& obj) {",
-            lines(
-              """|Fw::String s;
-                 |obj.toString(s);
-                 |os << s;
-                 |return os;"""
+        ),
+        CppDoc.Class.Member.Function(
+          CppDoc.Function(
+            Some("Subscript operator"),
+            "operator[]",
+            List(
+              CppDoc.Function.Param(
+                CppDoc.Type("const U32"),
+                "i",
+                Some("The subscript index"),
+              ),
             ),
-            "}"
-          ),
-          CppDoc.Lines.Cpp
-        )
+            CppDoc.Type("ElementType&", Some(s"$name::ElementType&")),
+            List(
+              line("FW_ASSERT(i < SIZE);"),
+              line("return this->elements[i];"),
+            ),
+          )
+        ),
+        CppDoc.Class.Member.Function(
+          CppDoc.Function(
+            Some("Const subscript operator"),
+            "operator[]",
+            List(
+              CppDoc.Function.Param(
+                CppDoc.Type("const U32"),
+                "i",
+                Some("The subscript index"),
+              ),
+            ),
+            CppDoc.Type("const ElementType&", Some(s"const $name::ElementType&")),
+            List(
+              line("FW_ASSERT(i < SIZE);"),
+              line("return this->elements[i];"),
+            ),
+            CppDoc.Function.NonSV,
+            CppDoc.Function.Const,
+          )
+        ),
+        CppDoc.Class.Member.Function(
+          CppDoc.Function(
+            Some("Copy assignment operator (object)"),
+            "operator=",
+            List(
+              CppDoc.Function.Param(
+                CppDoc.Type(s"const $name&"),
+                "obj",
+                Some("The source object"),
+              ),
+            ),
+            CppDoc.Type(s"$name&"),
+            List(
+              wrapInIf("this == &obj", lines("return *this;")),
+              Line.blank ::
+              indexIterator(lines("this->elements[index] = obj.elements[index];")),
+              lines("return *this;"),
+            ).flatten,
+          )
+        ),
+        CppDoc.Class.Member.Function(
+          CppDoc.Function(
+            Some("Copy assignment operator (raw array)"),
+            "operator=",
+            List(
+              CppDoc.Function.Param(
+                CppDoc.Type(s"const ElementType"),
+                "(&a)[SIZE]",
+                Some("The source array"),
+              ),
+            ),
+            CppDoc.Type(s"$name&"),
+            List(
+              indexIterator(lines("this->elements[index] = a[index];")),
+              lines("return *this;"),
+            ).flatten
+          )
+        ),
+        CppDoc.Class.Member.Function(
+          CppDoc.Function(
+            Some("Copy assignment operator (single element)"),
+            "operator=",
+            List(
+              CppDoc.Function.Param(
+                CppDoc.Type(s"const ElementType&"),
+                "e",
+                Some("The element"),
+              ),
+            ),
+            CppDoc.Type(s"$name&"),
+            List(
+              indexIterator(lines("this->elements[index] = e;")),
+              lines("return *this;"),
+            ).flatten
+          )
+        ),
+        CppDoc.Class.Member.Function(
+          CppDoc.Function(
+            Some("Equality operator"),
+            "operator==",
+            List(
+              CppDoc.Function.Param(
+                CppDoc.Type(s"const $name&"),
+                "obj",
+                Some("The other object"),
+              ),
+            ),
+            CppDoc.Type("bool"),
+            List(
+              indexIterator(wrapInIf(
+                "!((*this)[index] == obj[index])",
+                lines("return false;"),
+              )),
+              lines("return true;"),
+            ).flatten,
+            CppDoc.Function.NonSV,
+            CppDoc.Function.Const,
+          )
+        ),
+        CppDoc.Class.Member.Function(
+          CppDoc.Function(
+            Some("Inequality operator"),
+            "operator!=",
+            List(
+              CppDoc.Function.Param(
+                CppDoc.Type(s"const $name&"),
+                "obj",
+                Some("The other object"),
+              ),
+            ),
+            CppDoc.Type("bool"),
+            lines("return !(*this == obj);"),
+            CppDoc.Function.NonSV,
+            CppDoc.Function.Const,
+          )
+        ),
       ),
       CppDoc.Class.Member.Lines(
         CppDoc.Lines(
-          lines("\n#endif"),
+          List(Line.blank),
           CppDoc.Lines.Both
         )
+      ) :: writeOstreamOperator(
+        name,
+        lines(
+          """|Fw::String s;
+             |obj.toString(s);
+             |os << s;
+             |return os;"""
+        )
       ),
-    )
+    ).flatten
 
   private def getMemberFunctionMembers: List[CppDoc.Class.Member] = {
     val hasPrimitiveEltType = s.isPrimitive(eltType, eltTypeName)
@@ -471,116 +448,111 @@ case class ArrayCppWriter (
           lines(List.range(0, arraySize).map(i => s"str$i.toChar()").mkString(",\n"))
 
     List(
-      CppDoc.Class.Member.Lines(
-        CppDoc.Lines(CppDocHppWriter.writeAccessTag("public"))
-      ),
-      CppDoc.Class.Member.Lines(
-        CppDoc.Lines(
-          CppDocWriter.writeBannerComment("Member functions"),
-          CppDoc.Lines.Both
-        )
-      ),
-      CppDoc.Class.Member.Function(
-        CppDoc.Function(
-          Some("Serialization"),
-          "serialize",
-          List(
-            CppDoc.Function.Param(
-              CppDoc.Type("Fw::SerializeBufferBase&"),
-              "buffer",
-              Some("The serial buffer"),
-            )
-          ),
-          CppDoc.Type("Fw::SerializeStatus"),
-          List(
-            lines("Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;"),
-            indexIterator(
-              line("status = buffer.serialize((*this)[index]);") ::
-                wrapInIf("status != Fw::FW_SERIALIZE_OK", lines("return status;")),
-            ),
-            lines("return status;"),
-          ).flatten,
-          CppDoc.Function.NonSV,
-          CppDoc.Function.Const
-        )
-      ),
-      CppDoc.Class.Member.Function(
-        CppDoc.Function(
-          Some("Deserialization"),
-          "deserialize",
-          List(
-            CppDoc.Function.Param(
-              CppDoc.Type("Fw::SerializeBufferBase&"),
-              "buffer",
-              Some("The serial buffer"),
-            )
-          ),
-          CppDoc.Type("Fw::SerializeStatus"),
-          List(
-            lines("Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;"),
-            indexIterator(
-              line("status = buffer.deserialize((*this)[index]);") ::
-                wrapInIf("status != Fw::FW_SERIALIZE_OK", lines("return status;")),
-            ),
-            lines("return status;"),
-          ).flatten,
-        )
-      ),
-      CppDoc.Class.Member.Lines(
-        CppDoc.Lines(
-          lines("\n#if FW_ARRAY_TO_STRING || BUILD_UT"),
-          CppDoc.Lines.Both
-        )
-      ),
-      CppDoc.Class.Member.Function(
-        CppDoc.Function(
-          Some("Convert array to string"),
-          "toString",
-          List(
-            CppDoc.Function.Param(
-              CppDoc.Type("Fw::StringBase&"),
-              "sb",
-              Some("The StringBase object to hold the result")
-            )
-          ),
-          CppDoc.Type("void"),
-          List(
-            wrapInScope(
-              "static const char *formatString = \"[ \"",
-              lines(List.fill(arraySize)(s"\"$formatStr ").mkString("\"\n") + "]\";"),
-              ""
-            ),
-            initStrings,
-            lines("char outputString[FW_ARRAY_TO_STRING_BUFFER_SIZE];"),
-            wrapInScope(
-              "(void) snprintf(",
-              List(
-                List(
-                  line("outputString,"),
-                  line("FW_ARRAY_TO_STRING_BUFFER_SIZE,"),
-                  line("formatString,"),
-                ),
-                formatArgs,
-              ).flatten,
-              ");"
-            ),
+      List(
+        CppDoc.Class.Member.Lines(
+          CppDoc.Lines(CppDocHppWriter.writeAccessTag("public"))
+        ),
+        CppDoc.Class.Member.Lines(
+          CppDoc.Lines(
+            CppDocWriter.writeBannerComment("Member functions"),
+            CppDoc.Lines.Both
+          )
+        ),
+        CppDoc.Class.Member.Function(
+          CppDoc.Function(
+            Some("Serialization"),
+            "serialize",
             List(
-              Line.blank,
-              line("outputString[FW_ARRAY_TO_STRING_BUFFER_SIZE-1] = 0; // NULL terminate"),
-              line("sb = outputString;"),
+              CppDoc.Function.Param(
+                CppDoc.Type("Fw::SerializeBufferBase&"),
+                "buffer",
+                Some("The serial buffer"),
+              )
             ),
-          ).flatten,
-          CppDoc.Function.NonSV,
-          CppDoc.Function.Const,
+            CppDoc.Type("Fw::SerializeStatus"),
+            List(
+              lines("Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;"),
+              indexIterator(
+                line("status = buffer.serialize((*this)[index]);") ::
+                  wrapInIf("status != Fw::FW_SERIALIZE_OK", lines("return status;")),
+              ),
+              lines("return status;"),
+            ).flatten,
+            CppDoc.Function.NonSV,
+            CppDoc.Function.Const
+          )
+        ),
+        CppDoc.Class.Member.Function(
+          CppDoc.Function(
+            Some("Deserialization"),
+            "deserialize",
+            List(
+              CppDoc.Function.Param(
+                CppDoc.Type("Fw::SerializeBufferBase&"),
+                "buffer",
+                Some("The serial buffer"),
+              )
+            ),
+            CppDoc.Type("Fw::SerializeStatus"),
+            List(
+              lines("Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;"),
+              indexIterator(
+                line("status = buffer.deserialize((*this)[index]);") ::
+                  wrapInIf("status != Fw::FW_SERIALIZE_OK", lines("return status;")),
+              ),
+              lines("return status;"),
+            ).flatten,
+          )
+        ),
+      ),
+      wrapClassMembersInIfDirective(
+        "\n#if FW_ARRAY_TO_STRING || BUILD_UT",
+        List(
+          CppDoc.Class.Member.Function(
+            CppDoc.Function(
+              Some("Convert array to string"),
+              "toString",
+              List(
+                CppDoc.Function.Param(
+                  CppDoc.Type("Fw::StringBase&"),
+                  "sb",
+                  Some("The StringBase object to hold the result")
+                )
+              ),
+              CppDoc.Type("void"),
+              List(
+                wrapInScope(
+                  "static const char *formatString = \"[ \"",
+                  lines(List.fill(arraySize)(s"\"$formatStr ").mkString("\"\n") + "]\";"),
+                  ""
+                ),
+                initStrings,
+                lines("char outputString[FW_ARRAY_TO_STRING_BUFFER_SIZE];"),
+                wrapInScope(
+                  "(void) snprintf(",
+                  List(
+                    List(
+                      line("outputString,"),
+                      line("FW_ARRAY_TO_STRING_BUFFER_SIZE,"),
+                      line("formatString,"),
+                    ),
+                    formatArgs,
+                  ).flatten,
+                  ");"
+                ),
+                List(
+                  Line.blank,
+                  line("outputString[FW_ARRAY_TO_STRING_BUFFER_SIZE-1] = 0; // NULL terminate"),
+                  line("sb = outputString;"),
+                ),
+              ).flatten,
+              CppDoc.Function.NonSV,
+              CppDoc.Function.Const,
+            )
+          )
         )
       ),
-      CppDoc.Class.Member.Lines(
-        CppDoc.Lines(
-          lines("\n#endif"),
-          CppDoc.Lines.Both
-        )
-      ),
-    )
+    ).flatten
   }
 
   private def getMemberVariableMembers: List[CppDoc.Class.Member] =

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ArrayCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ArrayCppWriter.scala
@@ -260,151 +260,150 @@ case class ArrayCppWriter (
 
   private def getOperatorMembers: List[CppDoc.Class.Member] =
     List(
-      List(
-        CppDoc.Class.Member.Lines(
-          CppDoc.Lines(CppDocHppWriter.writeAccessTag("public"))
-        ),
-        CppDoc.Class.Member.Lines(
-          CppDoc.Lines(
-            CppDocWriter.writeBannerComment("Operators"),
-            CppDoc.Lines.Both,
-          )
-        ),
-        CppDoc.Class.Member.Function(
-          CppDoc.Function(
-            Some("Subscript operator"),
-            "operator[]",
-            List(
-              CppDoc.Function.Param(
-                CppDoc.Type("const U32"),
-                "i",
-                Some("The subscript index"),
-              ),
-            ),
-            CppDoc.Type("ElementType&", Some(s"$name::ElementType&")),
-            List(
-              line("FW_ASSERT(i < SIZE);"),
-              line("return this->elements[i];"),
-            ),
-          )
-        ),
-        CppDoc.Class.Member.Function(
-          CppDoc.Function(
-            Some("Const subscript operator"),
-            "operator[]",
-            List(
-              CppDoc.Function.Param(
-                CppDoc.Type("const U32"),
-                "i",
-                Some("The subscript index"),
-              ),
-            ),
-            CppDoc.Type("const ElementType&", Some(s"const $name::ElementType&")),
-            List(
-              line("FW_ASSERT(i < SIZE);"),
-              line("return this->elements[i];"),
-            ),
-            CppDoc.Function.NonSV,
-            CppDoc.Function.Const,
-          )
-        ),
-        CppDoc.Class.Member.Function(
-          CppDoc.Function(
-            Some("Copy assignment operator (object)"),
-            "operator=",
-            List(
-              CppDoc.Function.Param(
-                CppDoc.Type(s"const $name&"),
-                "obj",
-                Some("The source object"),
-              ),
-            ),
-            CppDoc.Type(s"$name&"),
-            List(
-              wrapInIf("this == &obj", lines("return *this;")),
-              Line.blank ::
-              indexIterator(lines("this->elements[index] = obj.elements[index];")),
-              lines("return *this;"),
-            ).flatten,
-          )
-        ),
-        CppDoc.Class.Member.Function(
-          CppDoc.Function(
-            Some("Copy assignment operator (raw array)"),
-            "operator=",
-            List(
-              CppDoc.Function.Param(
-                CppDoc.Type(s"const ElementType"),
-                "(&a)[SIZE]",
-                Some("The source array"),
-              ),
-            ),
-            CppDoc.Type(s"$name&"),
-            List(
-              indexIterator(lines("this->elements[index] = a[index];")),
-              lines("return *this;"),
-            ).flatten
-          )
-        ),
-        CppDoc.Class.Member.Function(
-          CppDoc.Function(
-            Some("Copy assignment operator (single element)"),
-            "operator=",
-            List(
-              CppDoc.Function.Param(
-                CppDoc.Type(s"const ElementType&"),
-                "e",
-                Some("The element"),
-              ),
-            ),
-            CppDoc.Type(s"$name&"),
-            List(
-              indexIterator(lines("this->elements[index] = e;")),
-              lines("return *this;"),
-            ).flatten
-          )
-        ),
-        CppDoc.Class.Member.Function(
-          CppDoc.Function(
-            Some("Equality operator"),
-            "operator==",
-            List(
-              CppDoc.Function.Param(
-                CppDoc.Type(s"const $name&"),
-                "obj",
-                Some("The other object"),
-              ),
-            ),
-            CppDoc.Type("bool"),
-            List(
-              indexIterator(wrapInIf(
-                "!((*this)[index] == obj[index])",
-                lines("return false;"),
-              )),
-              lines("return true;"),
-            ).flatten,
-            CppDoc.Function.NonSV,
-            CppDoc.Function.Const,
-          )
-        ),
-        CppDoc.Class.Member.Function(
-          CppDoc.Function(
-            Some("Inequality operator"),
-            "operator!=",
-            List(
-              CppDoc.Function.Param(
-                CppDoc.Type(s"const $name&"),
-                "obj",
-                Some("The other object"),
-              ),
-            ),
-            CppDoc.Type("bool"),
-            lines("return !(*this == obj);"),
-            CppDoc.Function.NonSV,
-            CppDoc.Function.Const,
-          )
-        ),
+      CppDoc.Class.Member.Lines(
+        CppDoc.Lines(CppDocHppWriter.writeAccessTag("public"))
       ),
+      CppDoc.Class.Member.Lines(
+        CppDoc.Lines(
+          CppDocWriter.writeBannerComment("Operators"),
+          CppDoc.Lines.Both,
+        )
+      ),
+      CppDoc.Class.Member.Function(
+        CppDoc.Function(
+          Some("Subscript operator"),
+          "operator[]",
+          List(
+            CppDoc.Function.Param(
+              CppDoc.Type("const U32"),
+              "i",
+              Some("The subscript index"),
+            ),
+          ),
+          CppDoc.Type("ElementType&", Some(s"$name::ElementType&")),
+          List(
+            line("FW_ASSERT(i < SIZE);"),
+            line("return this->elements[i];"),
+          ),
+        )
+      ),
+      CppDoc.Class.Member.Function(
+        CppDoc.Function(
+          Some("Const subscript operator"),
+          "operator[]",
+          List(
+            CppDoc.Function.Param(
+              CppDoc.Type("const U32"),
+              "i",
+              Some("The subscript index"),
+            ),
+          ),
+          CppDoc.Type("const ElementType&", Some(s"const $name::ElementType&")),
+          List(
+            line("FW_ASSERT(i < SIZE);"),
+            line("return this->elements[i];"),
+          ),
+          CppDoc.Function.NonSV,
+          CppDoc.Function.Const,
+        )
+      ),
+      CppDoc.Class.Member.Function(
+        CppDoc.Function(
+          Some("Copy assignment operator (object)"),
+          "operator=",
+          List(
+            CppDoc.Function.Param(
+              CppDoc.Type(s"const $name&"),
+              "obj",
+              Some("The source object"),
+            ),
+          ),
+          CppDoc.Type(s"$name&"),
+          List(
+            wrapInIf("this == &obj", lines("return *this;")),
+            Line.blank ::
+            indexIterator(lines("this->elements[index] = obj.elements[index];")),
+            lines("return *this;"),
+          ).flatten,
+        )
+      ),
+      CppDoc.Class.Member.Function(
+        CppDoc.Function(
+          Some("Copy assignment operator (raw array)"),
+          "operator=",
+          List(
+            CppDoc.Function.Param(
+              CppDoc.Type(s"const ElementType"),
+              "(&a)[SIZE]",
+              Some("The source array"),
+            ),
+          ),
+          CppDoc.Type(s"$name&"),
+          List(
+            indexIterator(lines("this->elements[index] = a[index];")),
+            lines("return *this;"),
+          ).flatten
+        )
+      ),
+      CppDoc.Class.Member.Function(
+        CppDoc.Function(
+          Some("Copy assignment operator (single element)"),
+          "operator=",
+          List(
+            CppDoc.Function.Param(
+              CppDoc.Type(s"const ElementType&"),
+              "e",
+              Some("The element"),
+            ),
+          ),
+          CppDoc.Type(s"$name&"),
+          List(
+            indexIterator(lines("this->elements[index] = e;")),
+            lines("return *this;"),
+          ).flatten
+        )
+      ),
+      CppDoc.Class.Member.Function(
+        CppDoc.Function(
+          Some("Equality operator"),
+          "operator==",
+          List(
+            CppDoc.Function.Param(
+              CppDoc.Type(s"const $name&"),
+              "obj",
+              Some("The other object"),
+            ),
+          ),
+          CppDoc.Type("bool"),
+          List(
+            indexIterator(wrapInIf(
+              "!((*this)[index] == obj[index])",
+              lines("return false;"),
+            )),
+            lines("return true;"),
+          ).flatten,
+          CppDoc.Function.NonSV,
+          CppDoc.Function.Const,
+        )
+      ),
+      CppDoc.Class.Member.Function(
+        CppDoc.Function(
+          Some("Inequality operator"),
+          "operator!=",
+          List(
+            CppDoc.Function.Param(
+              CppDoc.Type(s"const $name&"),
+              "obj",
+              Some("The other object"),
+            ),
+          ),
+          CppDoc.Type("bool"),
+          lines("return !(*this == obj);"),
+          CppDoc.Function.NonSV,
+          CppDoc.Function.Const,
+        )
+      )
+    ) ++ (
       CppDoc.Class.Member.Lines(
         CppDoc.Lines(
           List(Line.blank),
@@ -418,8 +417,8 @@ case class ArrayCppWriter (
              |os << s;
              |return os;"""
         )
-      ),
-    ).flatten
+      )
+    )
 
   private def getMemberFunctionMembers: List[CppDoc.Class.Member] = {
     val hasPrimitiveEltType = s.isPrimitive(eltType, eltTypeName)
@@ -448,63 +447,62 @@ case class ArrayCppWriter (
           lines(List.range(0, arraySize).map(i => s"str$i.toChar()").mkString(",\n"))
 
     List(
-      List(
-        CppDoc.Class.Member.Lines(
-          CppDoc.Lines(CppDocHppWriter.writeAccessTag("public"))
-        ),
-        CppDoc.Class.Member.Lines(
-          CppDoc.Lines(
-            CppDocWriter.writeBannerComment("Member functions"),
-            CppDoc.Lines.Both
-          )
-        ),
-        CppDoc.Class.Member.Function(
-          CppDoc.Function(
-            Some("Serialization"),
-            "serialize",
-            List(
-              CppDoc.Function.Param(
-                CppDoc.Type("Fw::SerializeBufferBase&"),
-                "buffer",
-                Some("The serial buffer"),
-              )
-            ),
-            CppDoc.Type("Fw::SerializeStatus"),
-            List(
-              lines("Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;"),
-              indexIterator(
-                line("status = buffer.serialize((*this)[index]);") ::
-                  wrapInIf("status != Fw::FW_SERIALIZE_OK", lines("return status;")),
-              ),
-              lines("return status;"),
-            ).flatten,
-            CppDoc.Function.NonSV,
-            CppDoc.Function.Const
-          )
-        ),
-        CppDoc.Class.Member.Function(
-          CppDoc.Function(
-            Some("Deserialization"),
-            "deserialize",
-            List(
-              CppDoc.Function.Param(
-                CppDoc.Type("Fw::SerializeBufferBase&"),
-                "buffer",
-                Some("The serial buffer"),
-              )
-            ),
-            CppDoc.Type("Fw::SerializeStatus"),
-            List(
-              lines("Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;"),
-              indexIterator(
-                line("status = buffer.deserialize((*this)[index]);") ::
-                  wrapInIf("status != Fw::FW_SERIALIZE_OK", lines("return status;")),
-              ),
-              lines("return status;"),
-            ).flatten,
-          )
-        ),
+      CppDoc.Class.Member.Lines(
+        CppDoc.Lines(CppDocHppWriter.writeAccessTag("public"))
       ),
+      CppDoc.Class.Member.Lines(
+        CppDoc.Lines(
+          CppDocWriter.writeBannerComment("Member functions"),
+          CppDoc.Lines.Both
+        )
+      ),
+      CppDoc.Class.Member.Function(
+        CppDoc.Function(
+          Some("Serialization"),
+          "serialize",
+          List(
+            CppDoc.Function.Param(
+              CppDoc.Type("Fw::SerializeBufferBase&"),
+              "buffer",
+              Some("The serial buffer"),
+            )
+          ),
+          CppDoc.Type("Fw::SerializeStatus"),
+          List(
+            lines("Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;"),
+            indexIterator(
+              line("status = buffer.serialize((*this)[index]);") ::
+                wrapInIf("status != Fw::FW_SERIALIZE_OK", lines("return status;")),
+            ),
+            lines("return status;"),
+          ).flatten,
+          CppDoc.Function.NonSV,
+          CppDoc.Function.Const
+        )
+      ),
+      CppDoc.Class.Member.Function(
+        CppDoc.Function(
+          Some("Deserialization"),
+          "deserialize",
+          List(
+            CppDoc.Function.Param(
+              CppDoc.Type("Fw::SerializeBufferBase&"),
+              "buffer",
+              Some("The serial buffer"),
+            )
+          ),
+          CppDoc.Type("Fw::SerializeStatus"),
+          List(
+            lines("Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;"),
+            indexIterator(
+              line("status = buffer.deserialize((*this)[index]);") ::
+                wrapInIf("status != Fw::FW_SERIALIZE_OK", lines("return status;")),
+            ),
+            lines("return status;"),
+          ).flatten,
+        )
+      )
+    ) ++
       wrapClassMembersInIfDirective(
         "\n#if FW_ARRAY_TO_STRING || BUILD_UT",
         List(
@@ -551,8 +549,7 @@ case class ArrayCppWriter (
             )
           )
         )
-      ),
-    ).flatten
+      )
   }
 
   private def getMemberVariableMembers: List[CppDoc.Class.Member] =

--- a/compiler/lib/src/main/scala/codegen/CppWriter/CppWriterLineUtils.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/CppWriterLineUtils.scala
@@ -27,4 +27,73 @@ trait CppWriterLineUtils extends LineUtils {
   def wrapInIf(condition: String, body: List[Line]): List[Line] =
     wrapInScope(s"if ($condition) {", body, "}")
 
+  def wrapMembersInIfDirective(
+    directive: String,
+    body: List[CppDoc.Member]
+  ): List[CppDoc.Member] =
+    wrapInIfDirective(directive, body, CppDoc.Member.Lines.apply)
+
+  def wrapClassMembersInIfDirective(
+    directive: String,
+    body: List[CppDoc.Class.Member]
+  ): List[CppDoc.Class.Member] =
+    wrapInIfDirective(directive, body, CppDoc.Class.Member.Lines.apply)
+
+  def wrapInIfDirective[T](
+    directive: String,
+    body: List[T],
+    constructMemberLines: CppDoc.Lines => T
+  ): List[T] =
+    List(
+      List(
+        constructMemberLines(
+          CppDoc.Lines(
+            lines(directive),
+            CppDoc.Lines.Both
+          )
+        )
+      ),
+      body,
+      List(
+        constructMemberLines(
+          CppDoc.Lines(
+            Line.blank :: lines("#endif"),
+            CppDoc.Lines.Both
+          )
+        )
+      ),
+    ).flatten
+
+  def writeOstreamOperator(
+    name: String,
+    body: List[Line]
+  ): List[CppDoc.Class.Member] =
+    wrapClassMembersInIfDirective(
+      "#ifdef BUILD_UT",
+      List(
+        CppDoc.Class.Member.Lines(
+          CppDoc.Lines(
+            lines(
+              s"""|
+                  |//! Ostream operator
+                  |friend std::ostream& operator<<(
+                  |    std::ostream& os, //!< The ostream
+                  |    const $name& obj //!< The object
+                  |);"""
+            )
+          )
+        ),
+        CppDoc.Class.Member.Lines(
+          CppDoc.Lines(
+            wrapInScope(
+              s"\nstd::ostream& operator<<(std::ostream& os, const $name& obj) {",
+              body,
+              "}"
+            ),
+            CppDoc.Lines.Cpp
+          )
+        ),
+      )
+    )
+
 }

--- a/compiler/lib/src/main/scala/codegen/CppWriter/CppWriterLineUtils.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/CppWriterLineUtils.scala
@@ -29,27 +29,40 @@ trait CppWriterLineUtils extends LineUtils {
 
   def wrapMembersInIfDirective(
     directive: String,
-    body: List[CppDoc.Member]
+    body: List[CppDoc.Member],
+    linesOutput: CppDoc.Lines.Output = CppDoc.Lines.Both
   ): List[CppDoc.Member] =
-    wrapInIfDirective(directive, body, CppDoc.Member.Lines.apply)
+    wrapInIfDirective(
+      directive,
+      body,
+      CppDoc.Member.Lines.apply,
+      linesOutput
+    )
 
   def wrapClassMembersInIfDirective(
     directive: String,
-    body: List[CppDoc.Class.Member]
+    body: List[CppDoc.Class.Member],
+    linesOutput: CppDoc.Lines.Output = CppDoc.Lines.Both
   ): List[CppDoc.Class.Member] =
-    wrapInIfDirective(directive, body, CppDoc.Class.Member.Lines.apply)
+    wrapInIfDirective(
+      directive,
+      body,
+      CppDoc.Class.Member.Lines.apply,
+      linesOutput
+    )
 
   def wrapInIfDirective[T](
     directive: String,
     body: List[T],
-    constructMemberLines: CppDoc.Lines => T
+    constructMemberLines: CppDoc.Lines => T,
+    linesOutput: CppDoc.Lines.Output = CppDoc.Lines.Both
   ): List[T] =
     List(
       List(
         constructMemberLines(
           CppDoc.Lines(
             lines(directive),
-            CppDoc.Lines.Both
+            linesOutput
           )
         )
       ),
@@ -58,7 +71,7 @@ trait CppWriterLineUtils extends LineUtils {
         constructMemberLines(
           CppDoc.Lines(
             Line.blank :: lines("#endif"),
-            CppDoc.Lines.Both
+            linesOutput
           )
         )
       ),

--- a/compiler/lib/src/main/scala/codegen/CppWriter/EnumCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/EnumCppWriter.scala
@@ -232,104 +232,103 @@ case class EnumCppWriter(
 
   private def getOperatorMembers: List[CppDoc.Class.Member] =
     List(
-      List(
-        CppDoc.Class.Member.Lines(
-          CppDoc.Lines(CppDocHppWriter.writeAccessTag("public"))
-        ),
-        CppDoc.Class.Member.Lines(
-          CppDoc.Lines(
-            CppDocWriter.writeBannerComment("Operators"),
-            CppDoc.Lines.Both
-          )
-        ),
-        CppDoc.Class.Member.Function(
-          CppDoc.Function(
-            Some(s"Copy assignment operator (object)"),
-            "operator=",
-            List(
-              CppDoc.Function.Param(
-                CppDoc.Type(s"const $name&"),
-                "obj",
-                Some("The source object"),
-              ),
-            ),
-            CppDoc.Type(s"$name&"),
-            List(
-              line("this->e = obj.e;"),
-              line("return *this;"),
-            )
-          )
-        ),
-        CppDoc.Class.Member.Function(
-          CppDoc.Function(
-            Some(s"Copy assignment operator (raw enum)"),
-            "operator=",
-            List(
-              CppDoc.Function.Param(
-                CppDoc.Type("T"),
-                "e",
-                Some("The enum value"),
-              ),
-            ),
-            CppDoc.Type(s"$name&"),
-            List(
-              line("this->e = e;"),
-              line("return *this;"),
-            )
-          )
-        ),
-        CppDoc.Class.Member.Function(
-          CppDoc.Function(
-            Some(s"Conversion operator"),
-            s"operator t",
-            Nil,
-            CppDoc.Type(""),
-            List(
-              line("return this->e;"),
-            ),
-            CppDoc.Function.NonSV,
-            CppDoc.Function.Const
-          )
-        ),
-        CppDoc.Class.Member.Function(
-          CppDoc.Function(
-            Some(s"Equality operator"),
-            "operator==",
-            List(
-              CppDoc.Function.Param(
-                CppDoc.Type(s"const $name&"),
-                "obj",
-                Some("The other object"),
-              ),
-            ),
-            CppDoc.Type("bool"),
-            List(
-              line("return this->e == obj.e;"),
-            ),
-            CppDoc.Function.NonSV,
-            CppDoc.Function.Const
-          )
-        ),
-        CppDoc.Class.Member.Function(
-          CppDoc.Function(
-            Some(s"Inequality operator"),
-            "operator!=",
-            List(
-              CppDoc.Function.Param(
-                CppDoc.Type(s"const $name&"),
-                "obj",
-                Some("The other object"),
-              ),
-            ),
-            CppDoc.Type("bool"),
-            List(
-              line("return !(*this == obj);"),
-            ),
-            CppDoc.Function.NonSV,
-            CppDoc.Function.Const
-          )
-        ),
+      CppDoc.Class.Member.Lines(
+        CppDoc.Lines(CppDocHppWriter.writeAccessTag("public"))
       ),
+      CppDoc.Class.Member.Lines(
+        CppDoc.Lines(
+          CppDocWriter.writeBannerComment("Operators"),
+          CppDoc.Lines.Both
+        )
+      ),
+      CppDoc.Class.Member.Function(
+        CppDoc.Function(
+          Some(s"Copy assignment operator (object)"),
+          "operator=",
+          List(
+            CppDoc.Function.Param(
+              CppDoc.Type(s"const $name&"),
+              "obj",
+              Some("The source object"),
+            ),
+          ),
+          CppDoc.Type(s"$name&"),
+          List(
+            line("this->e = obj.e;"),
+            line("return *this;"),
+          )
+        )
+      ),
+      CppDoc.Class.Member.Function(
+        CppDoc.Function(
+          Some(s"Copy assignment operator (raw enum)"),
+          "operator=",
+          List(
+            CppDoc.Function.Param(
+              CppDoc.Type("T"),
+              "e",
+              Some("The enum value"),
+            ),
+          ),
+          CppDoc.Type(s"$name&"),
+          List(
+            line("this->e = e;"),
+            line("return *this;"),
+          )
+        )
+      ),
+      CppDoc.Class.Member.Function(
+        CppDoc.Function(
+          Some(s"Conversion operator"),
+          s"operator t",
+          Nil,
+          CppDoc.Type(""),
+          List(
+            line("return this->e;"),
+          ),
+          CppDoc.Function.NonSV,
+          CppDoc.Function.Const
+        )
+      ),
+      CppDoc.Class.Member.Function(
+        CppDoc.Function(
+          Some(s"Equality operator"),
+          "operator==",
+          List(
+            CppDoc.Function.Param(
+              CppDoc.Type(s"const $name&"),
+              "obj",
+              Some("The other object"),
+            ),
+          ),
+          CppDoc.Type("bool"),
+          List(
+            line("return this->e == obj.e;"),
+          ),
+          CppDoc.Function.NonSV,
+          CppDoc.Function.Const
+        )
+      ),
+      CppDoc.Class.Member.Function(
+        CppDoc.Function(
+          Some(s"Inequality operator"),
+          "operator!=",
+          List(
+            CppDoc.Function.Param(
+              CppDoc.Type(s"const $name&"),
+              "obj",
+              Some("The other object"),
+            ),
+          ),
+          CppDoc.Type("bool"),
+          List(
+            line("return !(*this == obj);"),
+          ),
+          CppDoc.Function.NonSV,
+          CppDoc.Function.Const
+        )
+      )
+    ) ++ (
       CppDoc.Class.Member.Lines(
         CppDoc.Lines(
           List(Line.blank),
@@ -343,84 +342,83 @@ case class EnumCppWriter(
              |os << s;
              |return os;"""
         )
-      ),
-    ).flatten
+      )
+    )
 
   private def getMemberFunctionMembers: List[CppDoc.Class.Member] =
     List(
-      List(
-        CppDoc.Class.Member.Lines(
-          CppDoc.Lines(CppDocHppWriter.writeAccessTag("public"))
-        ),
-        CppDoc.Class.Member.Lines(
-          CppDoc.Lines(
-            CppDocWriter.writeBannerComment("Member functions"),
-            CppDoc.Lines.Both
-          )
-        ),
-        CppDoc.Class.Member.Function(
-          CppDoc.Function(
-            Some(s"Check raw enum value for validity"),
-            "isValid",
-            Nil,
-            CppDoc.Type("bool"),
-            Line.addPrefixAndSuffix(
-              "return ",
-              writeIntervals(intervals),
-              ";"
-            ),
-            CppDoc.Function.NonSV,
-            CppDoc.Function.Const
-          )
-        ),
-        CppDoc.Class.Member.Function(
-          CppDoc.Function(
-            Some(s"Serialize raw enum value to SerialType"),
-            "serialize",
-            List(
-              CppDoc.Function.Param(
-                CppDoc.Type("Fw::SerializeBufferBase&"),
-                "buffer",
-                Some("The serial buffer")
-              )
-            ),
-            CppDoc.Type("Fw::SerializeStatus"),
-            lines(
-              s"""|const Fw::SerializeStatus status = buffer.serialize(
-                  |    static_cast<SerialType>(this->e)
-                  |);
-                  |return status;"""
-            ),
-            CppDoc.Function.NonSV,
-            CppDoc.Function.Const
-          )
-        ),
-        CppDoc.Class.Member.Function(
-          CppDoc.Function(
-            Some(s"Deserialize raw enum value from SerialType"),
-            "deserialize",
-            List(
-              CppDoc.Function.Param(
-                CppDoc.Type("Fw::SerializeBufferBase&"),
-                "buffer",
-                Some("The serial buffer")
-              )
-            ),
-            CppDoc.Type("Fw::SerializeStatus"),
-            lines(
-              s"""|SerialType es;
-                  |Fw::SerializeStatus status = buffer.deserialize(es);
-                  |if (status == Fw::FW_SERIALIZE_OK) {
-                  |  this->e = static_cast<T>(es);
-                  |  if (!this->isValid()) {
-                  |    status = Fw::FW_DESERIALIZE_FORMAT_ERROR;
-                  |  }
-                  |}
-                  |return status;"""
-            )
-          )
-        ),
+      CppDoc.Class.Member.Lines(
+        CppDoc.Lines(CppDocHppWriter.writeAccessTag("public"))
       ),
+      CppDoc.Class.Member.Lines(
+        CppDoc.Lines(
+          CppDocWriter.writeBannerComment("Member functions"),
+          CppDoc.Lines.Both
+        )
+      ),
+      CppDoc.Class.Member.Function(
+        CppDoc.Function(
+          Some(s"Check raw enum value for validity"),
+          "isValid",
+          Nil,
+          CppDoc.Type("bool"),
+          Line.addPrefixAndSuffix(
+            "return ",
+            writeIntervals(intervals),
+            ";"
+          ),
+          CppDoc.Function.NonSV,
+          CppDoc.Function.Const
+        )
+      ),
+      CppDoc.Class.Member.Function(
+        CppDoc.Function(
+          Some(s"Serialize raw enum value to SerialType"),
+          "serialize",
+          List(
+            CppDoc.Function.Param(
+              CppDoc.Type("Fw::SerializeBufferBase&"),
+              "buffer",
+              Some("The serial buffer")
+            )
+          ),
+          CppDoc.Type("Fw::SerializeStatus"),
+          lines(
+            s"""|const Fw::SerializeStatus status = buffer.serialize(
+                |    static_cast<SerialType>(this->e)
+                |);
+                |return status;"""
+          ),
+          CppDoc.Function.NonSV,
+          CppDoc.Function.Const
+        )
+      ),
+      CppDoc.Class.Member.Function(
+        CppDoc.Function(
+          Some(s"Deserialize raw enum value from SerialType"),
+          "deserialize",
+          List(
+            CppDoc.Function.Param(
+              CppDoc.Type("Fw::SerializeBufferBase&"),
+              "buffer",
+              Some("The serial buffer")
+            )
+          ),
+          CppDoc.Type("Fw::SerializeStatus"),
+          lines(
+            s"""|SerialType es;
+                |Fw::SerializeStatus status = buffer.deserialize(es);
+                |if (status == Fw::FW_SERIALIZE_OK) {
+                |  this->e = static_cast<T>(es);
+                |  if (!this->isValid()) {
+                |    status = Fw::FW_DESERIALIZE_FORMAT_ERROR;
+                |  }
+                |}
+                |return status;"""
+          )
+        )
+      )
+    ) ++
       wrapClassMembersInIfDirective(
         "\n#if FW_SERIALIZABLE_TO_STRING || BUILD_UT",
         List(
@@ -466,8 +464,7 @@ case class EnumCppWriter(
             )
           )
         )
-      ),
-    ).flatten
+      )
 
   private def getMemberVariableMembers: List[CppDoc.Class.Member] =
     List(

--- a/compiler/lib/src/main/scala/codegen/CppWriter/EnumCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/EnumCppWriter.scala
@@ -232,270 +232,242 @@ case class EnumCppWriter(
 
   private def getOperatorMembers: List[CppDoc.Class.Member] =
     List(
-      CppDoc.Class.Member.Lines(
-        CppDoc.Lines(CppDocHppWriter.writeAccessTag("public"))
-      ),
-      CppDoc.Class.Member.Lines(
-        CppDoc.Lines(
-          CppDocWriter.writeBannerComment("Operators"),
-          CppDoc.Lines.Both
-        )
-      ),
-      CppDoc.Class.Member.Function(
-        CppDoc.Function(
-          Some(s"Copy assignment operator (object)"),
-          "operator=",
-          List(
-            CppDoc.Function.Param(
-              CppDoc.Type(s"const $name&"),
-              "obj",
-              Some("The source object"),
-            ),
-          ),
-          CppDoc.Type(s"$name&"),
-          List(
-            line("this->e = obj.e;"),
-            line("return *this;"),
+      List(
+        CppDoc.Class.Member.Lines(
+          CppDoc.Lines(CppDocHppWriter.writeAccessTag("public"))
+        ),
+        CppDoc.Class.Member.Lines(
+          CppDoc.Lines(
+            CppDocWriter.writeBannerComment("Operators"),
+            CppDoc.Lines.Both
           )
-        )
-      ),
-      CppDoc.Class.Member.Function(
-        CppDoc.Function(
-          Some(s"Copy assignment operator (raw enum)"),
-          "operator=",
-          List(
-            CppDoc.Function.Param(
-              CppDoc.Type("T"),
-              "e",
-              Some("The enum value"),
+        ),
+        CppDoc.Class.Member.Function(
+          CppDoc.Function(
+            Some(s"Copy assignment operator (object)"),
+            "operator=",
+            List(
+              CppDoc.Function.Param(
+                CppDoc.Type(s"const $name&"),
+                "obj",
+                Some("The source object"),
+              ),
             ),
-          ),
-          CppDoc.Type(s"$name&"),
-          List(
-            line("this->e = e;"),
-            line("return *this;"),
-          )
-        )
-      ),
-      CppDoc.Class.Member.Function(
-        CppDoc.Function(
-          Some(s"Conversion operator"),
-          s"operator t",
-          Nil,
-          CppDoc.Type(""),
-          List(
-            line("return this->e;"),
-          ),
-          CppDoc.Function.NonSV,
-          CppDoc.Function.Const
-        )
-      ),
-      CppDoc.Class.Member.Function(
-        CppDoc.Function(
-          Some(s"Equality operator"),
-          "operator==",
-          List(
-            CppDoc.Function.Param(
-              CppDoc.Type(s"const $name&"),
-              "obj",
-              Some("The other object"),
-            ),
-          ),
-          CppDoc.Type("bool"),
-          List(
-            line("return this->e == obj.e;"),
-          ),
-          CppDoc.Function.NonSV,
-          CppDoc.Function.Const
-        )
-      ),
-      CppDoc.Class.Member.Function(
-        CppDoc.Function(
-          Some(s"Inequality operator"),
-          "operator!=",
-          List(
-            CppDoc.Function.Param(
-              CppDoc.Type(s"const $name&"),
-              "obj",
-              Some("The other object"),
-            ),
-          ),
-          CppDoc.Type("bool"),
-          List(
-            line("return !(*this == obj);"),
-          ),
-          CppDoc.Function.NonSV,
-          CppDoc.Function.Const
-        )
-      ),
-      CppDoc.Class.Member.Lines(
-        CppDoc.Lines(
-          lines("\n#ifdef BUILD_UT"),
-          CppDoc.Lines.Both
-        )
-      ),
-      CppDoc.Class.Member.Lines(
-        CppDoc.Lines(
-          lines(
-            s"""|
-                |//! Ostream operator
-                |friend std::ostream& operator<<(
-                |    std::ostream& os, //!< The ostream
-                |    const $name& obj //!< The object
-                |);"""
+            CppDoc.Type(s"$name&"),
+            List(
+              line("this->e = obj.e;"),
+              line("return *this;"),
             )
-        )
-      ),
-      CppDoc.Class.Member.Lines(
-        CppDoc.Lines(
-          wrapInScope(
-            s"\nstd::ostream& operator<<(std::ostream& os, const $name& obj) {",
-            lines(
-              """|Fw::String s;
-                 |obj.toString(s);
-                 |os << s;
-                 |return os;"""
+          )
+        ),
+        CppDoc.Class.Member.Function(
+          CppDoc.Function(
+            Some(s"Copy assignment operator (raw enum)"),
+            "operator=",
+            List(
+              CppDoc.Function.Param(
+                CppDoc.Type("T"),
+                "e",
+                Some("The enum value"),
+              ),
             ),
-            "}"
-          ),
-          CppDoc.Lines.Cpp
-        )
+            CppDoc.Type(s"$name&"),
+            List(
+              line("this->e = e;"),
+              line("return *this;"),
+            )
+          )
+        ),
+        CppDoc.Class.Member.Function(
+          CppDoc.Function(
+            Some(s"Conversion operator"),
+            s"operator t",
+            Nil,
+            CppDoc.Type(""),
+            List(
+              line("return this->e;"),
+            ),
+            CppDoc.Function.NonSV,
+            CppDoc.Function.Const
+          )
+        ),
+        CppDoc.Class.Member.Function(
+          CppDoc.Function(
+            Some(s"Equality operator"),
+            "operator==",
+            List(
+              CppDoc.Function.Param(
+                CppDoc.Type(s"const $name&"),
+                "obj",
+                Some("The other object"),
+              ),
+            ),
+            CppDoc.Type("bool"),
+            List(
+              line("return this->e == obj.e;"),
+            ),
+            CppDoc.Function.NonSV,
+            CppDoc.Function.Const
+          )
+        ),
+        CppDoc.Class.Member.Function(
+          CppDoc.Function(
+            Some(s"Inequality operator"),
+            "operator!=",
+            List(
+              CppDoc.Function.Param(
+                CppDoc.Type(s"const $name&"),
+                "obj",
+                Some("The other object"),
+              ),
+            ),
+            CppDoc.Type("bool"),
+            List(
+              line("return !(*this == obj);"),
+            ),
+            CppDoc.Function.NonSV,
+            CppDoc.Function.Const
+          )
+        ),
       ),
       CppDoc.Class.Member.Lines(
         CppDoc.Lines(
-          lines("\n#endif"),
+          List(Line.blank),
           CppDoc.Lines.Both
         )
+      ) :: writeOstreamOperator(
+        name,
+        lines(
+          """|Fw::String s;
+             |obj.toString(s);
+             |os << s;
+             |return os;"""
+        )
       ),
-    )
+    ).flatten
 
   private def getMemberFunctionMembers: List[CppDoc.Class.Member] =
     List(
-      CppDoc.Class.Member.Lines(
-        CppDoc.Lines(CppDocHppWriter.writeAccessTag("public"))
-      ),
-      CppDoc.Class.Member.Lines(
-        CppDoc.Lines(
-          CppDocWriter.writeBannerComment("Member functions"),
-          CppDoc.Lines.Both
-        )
-      ),
-      CppDoc.Class.Member.Function(
-        CppDoc.Function(
-          Some(s"Check raw enum value for validity"),
-          "isValid",
-          Nil,
-          CppDoc.Type("bool"),
-          Line.addPrefixAndSuffix(
-            "return ",
-            writeIntervals(intervals),
-            ";"
-          ),
-          CppDoc.Function.NonSV,
-          CppDoc.Function.Const
-        )
-      ),
-      CppDoc.Class.Member.Function(
-        CppDoc.Function(
-          Some(s"Serialize raw enum value to SerialType"),
-          "serialize",
-          List(
-            CppDoc.Function.Param(
-              CppDoc.Type("Fw::SerializeBufferBase&"),
-              "buffer",
-              Some("The serial buffer")
+      List(
+        CppDoc.Class.Member.Lines(
+          CppDoc.Lines(CppDocHppWriter.writeAccessTag("public"))
+        ),
+        CppDoc.Class.Member.Lines(
+          CppDoc.Lines(
+            CppDocWriter.writeBannerComment("Member functions"),
+            CppDoc.Lines.Both
+          )
+        ),
+        CppDoc.Class.Member.Function(
+          CppDoc.Function(
+            Some(s"Check raw enum value for validity"),
+            "isValid",
+            Nil,
+            CppDoc.Type("bool"),
+            Line.addPrefixAndSuffix(
+              "return ",
+              writeIntervals(intervals),
+              ";"
+            ),
+            CppDoc.Function.NonSV,
+            CppDoc.Function.Const
+          )
+        ),
+        CppDoc.Class.Member.Function(
+          CppDoc.Function(
+            Some(s"Serialize raw enum value to SerialType"),
+            "serialize",
+            List(
+              CppDoc.Function.Param(
+                CppDoc.Type("Fw::SerializeBufferBase&"),
+                "buffer",
+                Some("The serial buffer")
+              )
+            ),
+            CppDoc.Type("Fw::SerializeStatus"),
+            lines(
+              s"""|const Fw::SerializeStatus status = buffer.serialize(
+                  |    static_cast<SerialType>(this->e)
+                  |);
+                  |return status;"""
+            ),
+            CppDoc.Function.NonSV,
+            CppDoc.Function.Const
+          )
+        ),
+        CppDoc.Class.Member.Function(
+          CppDoc.Function(
+            Some(s"Deserialize raw enum value from SerialType"),
+            "deserialize",
+            List(
+              CppDoc.Function.Param(
+                CppDoc.Type("Fw::SerializeBufferBase&"),
+                "buffer",
+                Some("The serial buffer")
+              )
+            ),
+            CppDoc.Type("Fw::SerializeStatus"),
+            lines(
+              s"""|SerialType es;
+                  |Fw::SerializeStatus status = buffer.deserialize(es);
+                  |if (status == Fw::FW_SERIALIZE_OK) {
+                  |  this->e = static_cast<T>(es);
+                  |  if (!this->isValid()) {
+                  |    status = Fw::FW_DESERIALIZE_FORMAT_ERROR;
+                  |  }
+                  |}
+                  |return status;"""
             )
-          ),
-          CppDoc.Type("Fw::SerializeStatus"),
-          lines(
-            s"""|const Fw::SerializeStatus status = buffer.serialize(
-                |    static_cast<SerialType>(this->e)
-                |);
-                |return status;"""
-          ),
-          CppDoc.Function.NonSV,
-          CppDoc.Function.Const
-        )
+          )
+        ),
       ),
-      CppDoc.Class.Member.Function(
-        CppDoc.Function(
-          Some(s"Deserialize raw enum value from SerialType"),
-          "deserialize",
-          List(
-            CppDoc.Function.Param(
-              CppDoc.Type("Fw::SerializeBufferBase&"),
-              "buffer",
-              Some("The serial buffer")
+      wrapClassMembersInIfDirective(
+        "\n#if FW_SERIALIZABLE_TO_STRING || BUILD_UT",
+        List(
+          CppDoc.Class.Member.Function(
+            CppDoc.Function(
+              Some(s"Convert enum to string"),
+              "toString",
+              List(
+                CppDoc.Function.Param(
+                  CppDoc.Type("Fw::StringBase&"),
+                  "sb",
+                  Some("The StringBase object to hold the result")
+                )
+              ),
+              CppDoc.Type("void"),
+              List(
+                lines(
+                  s"""|Fw::String s;"""
+                ),
+                wrapInScope(
+                  "switch (e) {",
+                  data.constants.flatMap(aNode => {
+                    val enumName = aNode._2.data.name
+                    lines(
+                      s"""|case $enumName:
+                          |  s = "$enumName";
+                          |  break;"""
+                    )
+                  }) ++
+                    lines(
+                      """|default:
+                         |  s = "[invalid]";
+                         |  break;"""
+                    ),
+                  "}"
+                ),
+                lines(
+                  """|sb.format("%s (%d)", s.toChar(), e);"""
+                )
+              ).flatten,
+              CppDoc.Function.NonSV,
+              CppDoc.Function.Const
             )
-          ),
-          CppDoc.Type("Fw::SerializeStatus"),
-          lines(
-            s"""|SerialType es;
-                |Fw::SerializeStatus status = buffer.deserialize(es);
-                |if (status == Fw::FW_SERIALIZE_OK) {
-                |  this->e = static_cast<T>(es);
-                |  if (!this->isValid()) {
-                |    status = Fw::FW_DESERIALIZE_FORMAT_ERROR;
-                |  }
-                |}
-                |return status;"""
           )
         )
       ),
-      CppDoc.Class.Member.Lines(
-        CppDoc.Lines(
-          lines("\n#if FW_SERIALIZABLE_TO_STRING || BUILD_UT"),
-          CppDoc.Lines.Both
-        )
-      ),
-      CppDoc.Class.Member.Function(
-        CppDoc.Function(
-          Some(s"Convert enum to string"),
-          "toString",
-          List(
-            CppDoc.Function.Param(
-              CppDoc.Type("Fw::StringBase&"),
-              "sb",
-              Some("The StringBase object to hold the result")
-            )
-          ),
-          CppDoc.Type("void"),
-          List(
-            lines(
-              s"""|Fw::String s;"""
-            ),
-            wrapInScope(
-              "switch (e) {",
-              data.constants.flatMap(aNode => {
-                val enumName = aNode._2.data.name
-                lines(
-                  s"""|case $enumName:
-                      |  s = "$enumName";
-                      |  break;"""
-                )
-              }) ++
-              lines(
-                """|default:
-                   |  s = "[invalid]";
-                   |  break;"""
-              ),
-              "}"
-            ),
-            lines(
-              """|sb.format("%s (%d)", s.toChar(), e);"""
-            )
-          ).flatten,
-          CppDoc.Function.NonSV,
-          CppDoc.Function.Const
-        )
-      ),
-      CppDoc.Class.Member.Lines(
-        CppDoc.Lines(
-          lines("\n#endif"),
-          CppDoc.Lines.Both
-        )
-      ),
-    )
+    ).flatten
 
   private def getMemberVariableMembers: List[CppDoc.Class.Member] =
     List(

--- a/compiler/lib/src/main/scala/codegen/CppWriter/StructCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/StructCppWriter.scala
@@ -312,74 +312,73 @@ case class StructCppWriter(
       ).flatten
 
     List(
-      List(
-        CppDoc.Class.Member.Lines(
-          CppDoc.Lines(
-            CppDocHppWriter.writeAccessTag("public")
-          )
-        ),
-        CppDoc.Class.Member.Lines(
-          CppDoc.Lines(
-            CppDocWriter.writeBannerComment("Operators"),
-            CppDoc.Lines.Both
-          )
-        ),
-        CppDoc.Class.Member.Function(
-          CppDoc.Function(
-            Some("Copy assignment operator"),
-            "operator=",
-            List(
-              CppDoc.Function.Param(
-                CppDoc.Type(s"const $name&"),
-                "obj",
-                Some("The source object")
-              ),
+      CppDoc.Class.Member.Lines(
+        CppDoc.Lines(
+          CppDocHppWriter.writeAccessTag("public")
+        )
+      ),
+      CppDoc.Class.Member.Lines(
+        CppDoc.Lines(
+          CppDocWriter.writeBannerComment("Operators"),
+          CppDoc.Lines.Both
+        )
+      ),
+      CppDoc.Class.Member.Function(
+        CppDoc.Function(
+          Some("Copy assignment operator"),
+          "operator=",
+          List(
+            CppDoc.Function.Param(
+              CppDoc.Type(s"const $name&"),
+              "obj",
+              Some("The source object")
             ),
-            CppDoc.Type(s"$name&"),
-            List(
-              wrapInIf("this == &obj", lines("return *this;")),
-              Line.blank :: lines(
-                s"set(${memberNames.map(n => s"obj.$n").mkString(", ")});"
-              ),
-              lines("return *this;"),
-            ).flatten
-          )
-        ),
-        CppDoc.Class.Member.Function(
-          CppDoc.Function(
-            Some("Equality operator"),
-            "operator==",
-            List(
-              CppDoc.Function.Param(
-                CppDoc.Type(s"const $name&"),
-                "obj",
-                Some("The other object")
-              )
-            ),
-            CppDoc.Type("bool"),
-            equalityOpBody,
-            CppDoc.Function.NonSV,
-            CppDoc.Function.Const
           ),
-        ),
-        CppDoc.Class.Member.Function(
-          CppDoc.Function(
-            Some("Inequality operator"),
-            "operator!=",
-            List(
-              CppDoc.Function.Param(
-                CppDoc.Type(s"const $name&"),
-                "obj",
-                Some("The other object")
-              )
+          CppDoc.Type(s"$name&"),
+          List(
+            wrapInIf("this == &obj", lines("return *this;")),
+            Line.blank :: lines(
+              s"set(${memberNames.map(n => s"obj.$n").mkString(", ")});"
             ),
-            CppDoc.Type("bool"),
-            lines("return !(*this == obj);"),
-            CppDoc.Function.NonSV,
-            CppDoc.Function.Const
+            lines("return *this;"),
+          ).flatten
+        )
+      ),
+      CppDoc.Class.Member.Function(
+        CppDoc.Function(
+          Some("Equality operator"),
+          "operator==",
+          List(
+            CppDoc.Function.Param(
+              CppDoc.Type(s"const $name&"),
+              "obj",
+              Some("The other object")
+            )
           ),
+          CppDoc.Type("bool"),
+          equalityOpBody,
+          CppDoc.Function.NonSV,
+          CppDoc.Function.Const
         ),
       ),
+      CppDoc.Class.Member.Function(
+        CppDoc.Function(
+          Some("Inequality operator"),
+          "operator!=",
+          List(
+            CppDoc.Function.Param(
+              CppDoc.Type(s"const $name&"),
+              "obj",
+              Some("The other object")
+            )
+          ),
+          CppDoc.Type("bool"),
+          lines("return !(*this == obj);"),
+          CppDoc.Function.NonSV,
+          CppDoc.Function.Const
+        ),
+      ),
+    ) ++ (
       CppDoc.Class.Member.Lines(
         CppDoc.Lines(
           List(Line.blank),
@@ -393,8 +392,8 @@ case class StructCppWriter(
              |os << s.toChar();
              |return os;"""
         )
-      ),
-    ).flatten
+      )
+    )
   }
 
   private def getMemberFunctionMembers: List[CppDoc.Class.Member] = {

--- a/compiler/lib/src/main/scala/codegen/CppWriter/StructCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/StructCppWriter.scala
@@ -312,62 +312,89 @@ case class StructCppWriter(
       ).flatten
 
     List(
-      CppDoc.Class.Member.Function(
-        CppDoc.Function(
-          Some("Copy assignment operator"),
-          "operator=",
-          List(
-            CppDoc.Function.Param(
-              CppDoc.Type(s"const $name&"),
-              "obj",
-              Some("The source object")
+      List(
+        CppDoc.Class.Member.Lines(
+          CppDoc.Lines(
+            CppDocHppWriter.writeAccessTag("public")
+          )
+        ),
+        CppDoc.Class.Member.Lines(
+          CppDoc.Lines(
+            CppDocWriter.writeBannerComment("Operators"),
+            CppDoc.Lines.Both
+          )
+        ),
+        CppDoc.Class.Member.Function(
+          CppDoc.Function(
+            Some("Copy assignment operator"),
+            "operator=",
+            List(
+              CppDoc.Function.Param(
+                CppDoc.Type(s"const $name&"),
+                "obj",
+                Some("The source object")
+              ),
             ),
+            CppDoc.Type(s"$name&"),
+            List(
+              wrapInIf("this == &obj", lines("return *this;")),
+              Line.blank :: lines(
+                s"set(${memberNames.map(n => s"obj.$n").mkString(", ")});"
+              ),
+              lines("return *this;"),
+            ).flatten
+          )
+        ),
+        CppDoc.Class.Member.Function(
+          CppDoc.Function(
+            Some("Equality operator"),
+            "operator==",
+            List(
+              CppDoc.Function.Param(
+                CppDoc.Type(s"const $name&"),
+                "obj",
+                Some("The other object")
+              )
+            ),
+            CppDoc.Type("bool"),
+            equalityOpBody,
+            CppDoc.Function.NonSV,
+            CppDoc.Function.Const
           ),
-          CppDoc.Type(s"$name&"),
-          List(
-            wrapInIf("this == &obj", lines("return *this;")),
-            Line.blank :: lines(
-              s"set(${memberNames.map(n => s"obj.$n").mkString(", ")});"
+        ),
+        CppDoc.Class.Member.Function(
+          CppDoc.Function(
+            Some("Inequality operator"),
+            "operator!=",
+            List(
+              CppDoc.Function.Param(
+                CppDoc.Type(s"const $name&"),
+                "obj",
+                Some("The other object")
+              )
             ),
-            lines("return *this;"),
-          ).flatten
+            CppDoc.Type("bool"),
+            lines("return !(*this == obj);"),
+            CppDoc.Function.NonSV,
+            CppDoc.Function.Const
+          ),
+        ),
+      ),
+      CppDoc.Class.Member.Lines(
+        CppDoc.Lines(
+          List(Line.blank),
+          CppDoc.Lines.Both
+        )
+      ) :: writeOstreamOperator(
+        name,
+        lines(
+          """|Fw::String s;
+             |obj.toString(s);
+             |os << s.toChar();
+             |return os;"""
         )
       ),
-      CppDoc.Class.Member.Function(
-        CppDoc.Function(
-          Some("Equality operator"),
-          "operator==",
-          List(
-            CppDoc.Function.Param(
-              CppDoc.Type(s"const $name&"),
-              "obj",
-              Some("The other object")
-            )
-          ),
-          CppDoc.Type("bool"),
-          equalityOpBody,
-          CppDoc.Function.NonSV,
-          CppDoc.Function.Const
-        ),
-      ),
-      CppDoc.Class.Member.Function(
-        CppDoc.Function(
-          Some("Inequality operator"),
-          "operator!=",
-          List(
-            CppDoc.Function.Param(
-              CppDoc.Type(s"const $name&"),
-              "obj",
-              Some("The other object")
-            )
-          ),
-          CppDoc.Type("bool"),
-          lines("return !(*this == obj);"),
-          CppDoc.Function.NonSV,
-          CppDoc.Function.Const
-        ),
-      ),
-    )
+    ).flatten
   }
 
   private def getMemberFunctionMembers: List[CppDoc.Class.Member] = {
@@ -473,127 +500,81 @@ case class StructCppWriter(
             ).flatten
           )
         ),
-        CppDoc.Class.Member.Lines(
-          CppDoc.Lines(
-            lines("\n#if FW_SERIALIZABLE_TO_STRING || BUILD_UT"),
-            CppDoc.Lines.Both
-          )
-        ),
-        CppDoc.Class.Member.Function(
-          CppDoc.Function(
-            Some("Convert struct to string"),
-            "toString",
-            List(
-              CppDoc.Function.Param(
-                CppDoc.Type("Fw::StringBase&"),
-                "sb",
-                Some("The StringBase object to hold the result")
-              )
-            ),
-            CppDoc.Type("void"),
-            List(
-              lines("static const char* formatString ="),
-              lines(typeMembers.flatMap((_, node, _) => {
-                val n = node.data.name
-                val formatStr = FormatCppWriter.write(
-                  getFormatStr(n),
-                  node.data.typeName
-                )
-                if sizes.contains(n) then {
-                  if sizes(n) == 1 then
-                    List(s"$n = [ $formatStr ]")
-                  else
-                    s"$n = [ $formatStr" ::
-                      List.fill(sizes(n) - 2)(formatStr) ++
-                        List(s"$formatStr ]")
-                } else
-                  List(s"$n = $formatStr")
-              }).mkString("\"( \"\n\"", ", \"\n\"", "\"\n\" )\";")).map(indentIn),
-              initStrings,
-              Line.blank ::
-                lines("char outputString[FW_SERIALIZABLE_TO_STRING_BUFFER_SIZE];"),
-              wrapInScope(
-                "(void) snprintf(",
-                List(
-                  List(
-                    line("outputString,"),
-                    line("FW_SERIALIZABLE_TO_STRING_BUFFER_SIZE,"),
-                    line("formatString,"),
-                  ),
-                  // Write format arguments
-                  lines(memberList.flatMap((n, tn) =>
-                    (sizes.contains(n), members(n)) match {
-                      case (false, _: Type.String) =>
-                        List(s"this->$n.toChar()")
-                      case (false, t) if s.isPrimitive(t, tn) =>
-                        List(s"this->$n")
-                      case (false, _) =>
-                        List(s"${n}Str.toChar()")
-                      case (true, _: Type.String) =>
-                        List.range(0, sizes(n)).map(i => s"this->$n[$i].toChar()")
-                      case (true, t) if s.isPrimitive(t, tn) =>
-                        List.range(0, sizes(n)).map(i => s"this->$n[$i]")
-                      case _ =>
-                        List.range(0, sizes(n)).map(i => s"${n}Str[$i].toChar()")
-                    }).mkString(",\n")),
-                ).flatten,
-                ");"
-              ),
+      ),
+      wrapClassMembersInIfDirective(
+        "\n#if FW_SERIALIZABLE_TO_STRING || BUILD_UT",
+        List(
+          CppDoc.Class.Member.Function(
+            CppDoc.Function(
+              Some("Convert struct to string"),
+              "toString",
               List(
-                Line.blank,
-                line("outputString[FW_SERIALIZABLE_TO_STRING_BUFFER_SIZE-1] = 0; // NULL terminate"),
-                line("sb = outputString;"),
+                CppDoc.Function.Param(
+                  CppDoc.Type("Fw::StringBase&"),
+                  "sb",
+                  Some("The StringBase object to hold the result")
+                )
               ),
-            ).flatten,
-            CppDoc.Function.NonSV,
-            CppDoc.Function.Const
-          )
-        ),
-        CppDoc.Class.Member.Lines(
-          CppDoc.Lines(
-            lines("\n#endif"),
-            CppDoc.Lines.Both
-          )
-        ),
-        CppDoc.Class.Member.Lines(
-          CppDoc.Lines(
-            lines("\n#ifdef BUILD_UT"),
-            CppDoc.Lines.Both
-          )
-        ),
-        CppDoc.Class.Member.Lines(
-          CppDoc.Lines(
-            lines(
-              s"""|
-                  |//! Ostream operator
-                  |friend std::ostream& operator<<(
-                  |    std::ostream& os, //!< The ostream
-                  |    const $name& obj //!< The object
-                  |);"""
+              CppDoc.Type("void"),
+              List(
+                lines("static const char* formatString ="),
+                lines(typeMembers.flatMap((_, node, _) => {
+                  val n = node.data.name
+                  val formatStr = FormatCppWriter.write(
+                    getFormatStr(n),
+                    node.data.typeName
+                  )
+                  if sizes.contains(n) then {
+                    if sizes(n) == 1 then
+                      List(s"$n = [ $formatStr ]")
+                    else
+                      s"$n = [ $formatStr" ::
+                        List.fill(sizes(n) - 2)(formatStr) ++
+                          List(s"$formatStr ]")
+                  } else
+                    List(s"$n = $formatStr")
+                }).mkString("\"( \"\n\"", ", \"\n\"", "\"\n\" )\";")).map(indentIn),
+                initStrings,
+                Line.blank ::
+                  lines("char outputString[FW_SERIALIZABLE_TO_STRING_BUFFER_SIZE];"),
+                wrapInScope(
+                  "(void) snprintf(",
+                  List(
+                    List(
+                      line("outputString,"),
+                      line("FW_SERIALIZABLE_TO_STRING_BUFFER_SIZE,"),
+                      line("formatString,"),
+                    ),
+                    // Write format arguments
+                    lines(memberList.flatMap((n, tn) =>
+                      (sizes.contains(n), members(n)) match {
+                        case (false, _: Type.String) =>
+                          List(s"this->$n.toChar()")
+                        case (false, t) if s.isPrimitive(t, tn) =>
+                          List(s"this->$n")
+                        case (false, _) =>
+                          List(s"${n}Str.toChar()")
+                        case (true, _: Type.String) =>
+                          List.range(0, sizes(n)).map(i => s"this->$n[$i].toChar()")
+                        case (true, t) if s.isPrimitive(t, tn) =>
+                          List.range(0, sizes(n)).map(i => s"this->$n[$i]")
+                        case _ =>
+                          List.range(0, sizes(n)).map(i => s"${n}Str[$i].toChar()")
+                      }).mkString(",\n")),
+                  ).flatten,
+                  ");"
+                ),
+                List(
+                  Line.blank,
+                  line("outputString[FW_SERIALIZABLE_TO_STRING_BUFFER_SIZE-1] = 0; // NULL terminate"),
+                  line("sb = outputString;"),
+                ),
+              ).flatten,
+              CppDoc.Function.NonSV,
+              CppDoc.Function.Const
             )
           )
-        ),
-        CppDoc.Class.Member.Lines(
-          CppDoc.Lines(
-            wrapInScope(
-              s"\nstd::ostream& operator<<(std::ostream& os, const $name& obj) {",
-              lines(
-                """|Fw::String s;
-                   |obj.toString(s);
-                   |os << s.toChar();
-                   |return os;"""
-              ),
-              "}"
-            ),
-            CppDoc.Lines.Cpp
-          )
-        ),
-        CppDoc.Class.Member.Lines(
-          CppDoc.Lines(
-            lines("\n#endif"),
-            CppDoc.Lines.Both
-          )
-        ),
+        )
       ),
       CppDoc.Class.Member.Lines(
         CppDoc.Lines(

--- a/compiler/tools/fpp-to-cpp/test/struct/AbsTypeSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/AbsTypeSerializableAc.ref.cpp
@@ -39,6 +39,10 @@ AbsType ::
 
 }
 
+// ----------------------------------------------------------------------
+// Operators
+// ----------------------------------------------------------------------
+
 AbsType& AbsType ::
   operator=(const AbsType& obj)
 {
@@ -61,6 +65,17 @@ bool AbsType ::
 {
   return !(*this == obj);
 }
+
+#ifdef BUILD_UT
+
+std::ostream& operator<<(std::ostream& os, const AbsType& obj) {
+  Fw::String s;
+  obj.toString(s);
+  os << s.toChar();
+  return os;
+}
+
+#endif
 
 // ----------------------------------------------------------------------
 // Member functions
@@ -118,17 +133,6 @@ void AbsType ::
 
   outputString[FW_SERIALIZABLE_TO_STRING_BUFFER_SIZE-1] = 0; // NULL terminate
   sb = outputString;
-}
-
-#endif
-
-#ifdef BUILD_UT
-
-std::ostream& operator<<(std::ostream& os, const AbsType& obj) {
-  Fw::String s;
-  obj.toString(s);
-  os << s.toChar();
-  return os;
 }
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/struct/AbsTypeSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/AbsTypeSerializableAc.ref.hpp
@@ -45,6 +45,12 @@ class AbsType :
         const AbsType& obj //!< The source object
     );
 
+  public:
+
+    // ----------------------------------------------------------------------
+    // Operators
+    // ----------------------------------------------------------------------
+
     //! Copy assignment operator
     AbsType& operator=(
         const AbsType& obj //!< The source object
@@ -59,6 +65,16 @@ class AbsType :
     bool operator!=(
         const AbsType& obj //!< The other object
     ) const;
+
+#ifdef BUILD_UT
+
+    //! Ostream operator
+    friend std::ostream& operator<<(
+        std::ostream& os, //!< The ostream
+        const AbsType& obj //!< The object
+    );
+
+#endif
 
   public:
 
@@ -82,16 +98,6 @@ class AbsType :
     void toString(
         Fw::StringBase& sb //!< The StringBase object to hold the result
     ) const;
-
-#endif
-
-#ifdef BUILD_UT
-
-    //! Ostream operator
-    friend std::ostream& operator<<(
-        std::ostream& os, //!< The ostream
-        const AbsType& obj //!< The object
-    );
 
 #endif
 

--- a/compiler/tools/fpp-to-cpp/test/struct/DefaultSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/DefaultSerializableAc.ref.cpp
@@ -128,6 +128,10 @@ Default ::
 
 }
 
+// ----------------------------------------------------------------------
+// Operators
+// ----------------------------------------------------------------------
+
 Default& Default ::
   operator=(const Default& obj)
 {
@@ -154,6 +158,17 @@ bool Default ::
 {
   return !(*this == obj);
 }
+
+#ifdef BUILD_UT
+
+std::ostream& operator<<(std::ostream& os, const Default& obj) {
+  Fw::String s;
+  obj.toString(s);
+  os << s.toChar();
+  return os;
+}
+
+#endif
 
 // ----------------------------------------------------------------------
 // Member functions
@@ -225,17 +240,6 @@ void Default ::
 
   outputString[FW_SERIALIZABLE_TO_STRING_BUFFER_SIZE-1] = 0; // NULL terminate
   sb = outputString;
-}
-
-#endif
-
-#ifdef BUILD_UT
-
-std::ostream& operator<<(std::ostream& os, const Default& obj) {
-  Fw::String s;
-  obj.toString(s);
-  os << s.toChar();
-  return os;
 }
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/struct/DefaultSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/DefaultSerializableAc.ref.hpp
@@ -101,6 +101,12 @@ class Default :
         const Default& obj //!< The source object
     );
 
+  public:
+
+    // ----------------------------------------------------------------------
+    // Operators
+    // ----------------------------------------------------------------------
+
     //! Copy assignment operator
     Default& operator=(
         const Default& obj //!< The source object
@@ -115,6 +121,16 @@ class Default :
     bool operator!=(
         const Default& obj //!< The other object
     ) const;
+
+#ifdef BUILD_UT
+
+    //! Ostream operator
+    friend std::ostream& operator<<(
+        std::ostream& os, //!< The ostream
+        const Default& obj //!< The object
+    );
+
+#endif
 
   public:
 
@@ -138,16 +154,6 @@ class Default :
     void toString(
         Fw::StringBase& sb //!< The StringBase object to hold the result
     ) const;
-
-#endif
-
-#ifdef BUILD_UT
-
-    //! Ostream operator
-    friend std::ostream& operator<<(
-        std::ostream& os, //!< The ostream
-        const Default& obj //!< The object
-    );
 
 #endif
 

--- a/compiler/tools/fpp-to-cpp/test/struct/EnumSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/EnumSerializableAc.ref.cpp
@@ -61,6 +61,10 @@ Enum ::
   }
 }
 
+// ----------------------------------------------------------------------
+// Operators
+// ----------------------------------------------------------------------
+
 Enum& Enum ::
   operator=(const Enum& obj)
 {
@@ -97,6 +101,17 @@ bool Enum ::
 {
   return !(*this == obj);
 }
+
+#ifdef BUILD_UT
+
+std::ostream& operator<<(std::ostream& os, const Enum& obj) {
+  Fw::String s;
+  obj.toString(s);
+  os << s.toChar();
+  return os;
+}
+
+#endif
 
 // ----------------------------------------------------------------------
 // Member functions
@@ -176,17 +191,6 @@ void Enum ::
 
   outputString[FW_SERIALIZABLE_TO_STRING_BUFFER_SIZE-1] = 0; // NULL terminate
   sb = outputString;
-}
-
-#endif
-
-#ifdef BUILD_UT
-
-std::ostream& operator<<(std::ostream& os, const Enum& obj) {
-  Fw::String s;
-  obj.toString(s);
-  os << s.toChar();
-  return os;
 }
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/struct/EnumSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/EnumSerializableAc.ref.hpp
@@ -64,6 +64,12 @@ class Enum :
         M::E::T eArr
     );
 
+  public:
+
+    // ----------------------------------------------------------------------
+    // Operators
+    // ----------------------------------------------------------------------
+
     //! Copy assignment operator
     Enum& operator=(
         const Enum& obj //!< The source object
@@ -78,6 +84,16 @@ class Enum :
     bool operator!=(
         const Enum& obj //!< The other object
     ) const;
+
+#ifdef BUILD_UT
+
+    //! Ostream operator
+    friend std::ostream& operator<<(
+        std::ostream& os, //!< The ostream
+        const Enum& obj //!< The object
+    );
+
+#endif
 
   public:
 
@@ -101,16 +117,6 @@ class Enum :
     void toString(
         Fw::StringBase& sb //!< The StringBase object to hold the result
     ) const;
-
-#endif
-
-#ifdef BUILD_UT
-
-    //! Ostream operator
-    friend std::ostream& operator<<(
-        std::ostream& os, //!< The ostream
-        const Enum& obj //!< The object
-    );
 
 #endif
 

--- a/compiler/tools/fpp-to-cpp/test/struct/FormatSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/FormatSerializableAc.ref.cpp
@@ -105,6 +105,10 @@ Format ::
 
 }
 
+// ----------------------------------------------------------------------
+// Operators
+// ----------------------------------------------------------------------
+
 Format& Format ::
   operator=(const Format& obj)
 {
@@ -145,6 +149,17 @@ bool Format ::
 {
   return !(*this == obj);
 }
+
+#ifdef BUILD_UT
+
+std::ostream& operator<<(std::ostream& os, const Format& obj) {
+  Fw::String s;
+  obj.toString(s);
+  os << s.toChar();
+  return os;
+}
+
+#endif
 
 // ----------------------------------------------------------------------
 // Member functions
@@ -356,17 +371,6 @@ void Format ::
 
   outputString[FW_SERIALIZABLE_TO_STRING_BUFFER_SIZE-1] = 0; // NULL terminate
   sb = outputString;
-}
-
-#endif
-
-#ifdef BUILD_UT
-
-std::ostream& operator<<(std::ostream& os, const Format& obj) {
-  Fw::String s;
-  obj.toString(s);
-  os << s.toChar();
-  return os;
 }
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/struct/FormatSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/FormatSerializableAc.ref.hpp
@@ -78,6 +78,12 @@ class Format :
         const Format& obj //!< The source object
     );
 
+  public:
+
+    // ----------------------------------------------------------------------
+    // Operators
+    // ----------------------------------------------------------------------
+
     //! Copy assignment operator
     Format& operator=(
         const Format& obj //!< The source object
@@ -92,6 +98,16 @@ class Format :
     bool operator!=(
         const Format& obj //!< The other object
     ) const;
+
+#ifdef BUILD_UT
+
+    //! Ostream operator
+    friend std::ostream& operator<<(
+        std::ostream& os, //!< The ostream
+        const Format& obj //!< The object
+    );
+
+#endif
 
   public:
 
@@ -115,16 +131,6 @@ class Format :
     void toString(
         Fw::StringBase& sb //!< The StringBase object to hold the result
     ) const;
-
-#endif
-
-#ifdef BUILD_UT
-
-    //! Ostream operator
-    friend std::ostream& operator<<(
-        std::ostream& os, //!< The ostream
-        const Format& obj //!< The object
-    );
 
 #endif
 

--- a/compiler/tools/fpp-to-cpp/test/struct/Modules1SerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/Modules1SerializableAc.ref.cpp
@@ -47,6 +47,10 @@ namespace M {
 
   }
 
+  // ----------------------------------------------------------------------
+  // Operators
+  // ----------------------------------------------------------------------
+
   Modules1& Modules1 ::
     operator=(const Modules1& obj)
   {
@@ -72,6 +76,17 @@ namespace M {
   {
     return !(*this == obj);
   }
+
+#ifdef BUILD_UT
+
+  std::ostream& operator<<(std::ostream& os, const Modules1& obj) {
+    Fw::String s;
+    obj.toString(s);
+    os << s.toChar();
+    return os;
+  }
+
+#endif
 
   // ----------------------------------------------------------------------
   // Member functions
@@ -133,17 +148,6 @@ namespace M {
 
     outputString[FW_SERIALIZABLE_TO_STRING_BUFFER_SIZE-1] = 0; // NULL terminate
     sb = outputString;
-  }
-
-#endif
-
-#ifdef BUILD_UT
-
-  std::ostream& operator<<(std::ostream& os, const Modules1& obj) {
-    Fw::String s;
-    obj.toString(s);
-    os << s.toChar();
-    return os;
   }
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/struct/Modules1SerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/Modules1SerializableAc.ref.hpp
@@ -50,6 +50,12 @@ namespace M {
           const Modules1& obj //!< The source object
       );
 
+    public:
+
+      // ----------------------------------------------------------------------
+      // Operators
+      // ----------------------------------------------------------------------
+
       //! Copy assignment operator
       Modules1& operator=(
           const Modules1& obj //!< The source object
@@ -64,6 +70,16 @@ namespace M {
       bool operator!=(
           const Modules1& obj //!< The other object
       ) const;
+
+#ifdef BUILD_UT
+
+      //! Ostream operator
+      friend std::ostream& operator<<(
+          std::ostream& os, //!< The ostream
+          const Modules1& obj //!< The object
+      );
+
+#endif
 
     public:
 
@@ -87,16 +103,6 @@ namespace M {
       void toString(
           Fw::StringBase& sb //!< The StringBase object to hold the result
       ) const;
-
-#endif
-
-#ifdef BUILD_UT
-
-      //! Ostream operator
-      friend std::ostream& operator<<(
-          std::ostream& os, //!< The ostream
-          const Modules1& obj //!< The object
-      );
 
 #endif
 

--- a/compiler/tools/fpp-to-cpp/test/struct/Modules2SerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/Modules2SerializableAc.ref.cpp
@@ -41,6 +41,10 @@ namespace M {
 
   }
 
+  // ----------------------------------------------------------------------
+  // Operators
+  // ----------------------------------------------------------------------
+
   Modules2& Modules2 ::
     operator=(const Modules2& obj)
   {
@@ -63,6 +67,17 @@ namespace M {
   {
     return !(*this == obj);
   }
+
+#ifdef BUILD_UT
+
+  std::ostream& operator<<(std::ostream& os, const Modules2& obj) {
+    Fw::String s;
+    obj.toString(s);
+    os << s.toChar();
+    return os;
+  }
+
+#endif
 
   // ----------------------------------------------------------------------
   // Member functions
@@ -120,17 +135,6 @@ namespace M {
 
     outputString[FW_SERIALIZABLE_TO_STRING_BUFFER_SIZE-1] = 0; // NULL terminate
     sb = outputString;
-  }
-
-#endif
-
-#ifdef BUILD_UT
-
-  std::ostream& operator<<(std::ostream& os, const Modules2& obj) {
-    Fw::String s;
-    obj.toString(s);
-    os << s.toChar();
-    return os;
   }
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/struct/Modules2SerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/Modules2SerializableAc.ref.hpp
@@ -47,6 +47,12 @@ namespace M {
           const Modules2& obj //!< The source object
       );
 
+    public:
+
+      // ----------------------------------------------------------------------
+      // Operators
+      // ----------------------------------------------------------------------
+
       //! Copy assignment operator
       Modules2& operator=(
           const Modules2& obj //!< The source object
@@ -61,6 +67,16 @@ namespace M {
       bool operator!=(
           const Modules2& obj //!< The other object
       ) const;
+
+#ifdef BUILD_UT
+
+      //! Ostream operator
+      friend std::ostream& operator<<(
+          std::ostream& os, //!< The ostream
+          const Modules2& obj //!< The object
+      );
+
+#endif
 
     public:
 
@@ -84,16 +100,6 @@ namespace M {
       void toString(
           Fw::StringBase& sb //!< The StringBase object to hold the result
       ) const;
-
-#endif
-
-#ifdef BUILD_UT
-
-      //! Ostream operator
-      friend std::ostream& operator<<(
-          std::ostream& os, //!< The ostream
-          const Modules2& obj //!< The object
-      );
 
 #endif
 

--- a/compiler/tools/fpp-to-cpp/test/struct/Modules3SerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/Modules3SerializableAc.ref.cpp
@@ -61,6 +61,10 @@ Modules3 ::
   }
 }
 
+// ----------------------------------------------------------------------
+// Operators
+// ----------------------------------------------------------------------
+
 Modules3& Modules3 ::
   operator=(const Modules3& obj)
 {
@@ -97,6 +101,17 @@ bool Modules3 ::
 {
   return !(*this == obj);
 }
+
+#ifdef BUILD_UT
+
+std::ostream& operator<<(std::ostream& os, const Modules3& obj) {
+  Fw::String s;
+  obj.toString(s);
+  os << s.toChar();
+  return os;
+}
+
+#endif
 
 // ----------------------------------------------------------------------
 // Member functions
@@ -176,17 +191,6 @@ void Modules3 ::
 
   outputString[FW_SERIALIZABLE_TO_STRING_BUFFER_SIZE-1] = 0; // NULL terminate
   sb = outputString;
-}
-
-#endif
-
-#ifdef BUILD_UT
-
-std::ostream& operator<<(std::ostream& os, const Modules3& obj) {
-  Fw::String s;
-  obj.toString(s);
-  os << s.toChar();
-  return os;
 }
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/struct/Modules3SerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/Modules3SerializableAc.ref.hpp
@@ -64,6 +64,12 @@ class Modules3 :
         const M::Modules2& arr
     );
 
+  public:
+
+    // ----------------------------------------------------------------------
+    // Operators
+    // ----------------------------------------------------------------------
+
     //! Copy assignment operator
     Modules3& operator=(
         const Modules3& obj //!< The source object
@@ -78,6 +84,16 @@ class Modules3 :
     bool operator!=(
         const Modules3& obj //!< The other object
     ) const;
+
+#ifdef BUILD_UT
+
+    //! Ostream operator
+    friend std::ostream& operator<<(
+        std::ostream& os, //!< The ostream
+        const Modules3& obj //!< The object
+    );
+
+#endif
 
   public:
 
@@ -101,16 +117,6 @@ class Modules3 :
     void toString(
         Fw::StringBase& sb //!< The StringBase object to hold the result
     ) const;
-
-#endif
-
-#ifdef BUILD_UT
-
-    //! Ostream operator
-    friend std::ostream& operator<<(
-        std::ostream& os, //!< The ostream
-        const Modules3& obj //!< The object
-    );
 
 #endif
 

--- a/compiler/tools/fpp-to-cpp/test/struct/PrimitiveSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/PrimitiveSerializableAc.ref.cpp
@@ -200,6 +200,10 @@ Primitive ::
   }
 }
 
+// ----------------------------------------------------------------------
+// Operators
+// ----------------------------------------------------------------------
+
 Primitive& Primitive ::
   operator=(const Primitive& obj)
 {
@@ -248,6 +252,17 @@ bool Primitive ::
 {
   return !(*this == obj);
 }
+
+#ifdef BUILD_UT
+
+std::ostream& operator<<(std::ostream& os, const Primitive& obj) {
+  Fw::String s;
+  obj.toString(s);
+  os << s.toChar();
+  return os;
+}
+
+#endif
 
 // ----------------------------------------------------------------------
 // Member functions
@@ -417,17 +432,6 @@ void Primitive ::
 
   outputString[FW_SERIALIZABLE_TO_STRING_BUFFER_SIZE-1] = 0; // NULL terminate
   sb = outputString;
-}
-
-#endif
-
-#ifdef BUILD_UT
-
-std::ostream& operator<<(std::ostream& os, const Primitive& obj) {
-  Fw::String s;
-  obj.toString(s);
-  os << s.toChar();
-  return os;
 }
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/struct/PrimitiveSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/PrimitiveSerializableAc.ref.hpp
@@ -146,6 +146,12 @@ class Primitive :
         const StringSize80& m_string
     );
 
+  public:
+
+    // ----------------------------------------------------------------------
+    // Operators
+    // ----------------------------------------------------------------------
+
     //! Copy assignment operator
     Primitive& operator=(
         const Primitive& obj //!< The source object
@@ -160,6 +166,16 @@ class Primitive :
     bool operator!=(
         const Primitive& obj //!< The other object
     ) const;
+
+#ifdef BUILD_UT
+
+    //! Ostream operator
+    friend std::ostream& operator<<(
+        std::ostream& os, //!< The ostream
+        const Primitive& obj //!< The object
+    );
+
+#endif
 
   public:
 
@@ -183,16 +199,6 @@ class Primitive :
     void toString(
         Fw::StringBase& sb //!< The StringBase object to hold the result
     ) const;
-
-#endif
-
-#ifdef BUILD_UT
-
-    //! Ostream operator
-    friend std::ostream& operator<<(
-        std::ostream& os, //!< The ostream
-        const Primitive& obj //!< The object
-    );
 
 #endif
 

--- a/compiler/tools/fpp-to-cpp/test/struct/PrimitiveStructSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/PrimitiveStructSerializableAc.ref.cpp
@@ -39,6 +39,10 @@ PrimitiveStruct ::
 
 }
 
+// ----------------------------------------------------------------------
+// Operators
+// ----------------------------------------------------------------------
+
 PrimitiveStruct& PrimitiveStruct ::
   operator=(const PrimitiveStruct& obj)
 {
@@ -61,6 +65,17 @@ bool PrimitiveStruct ::
 {
   return !(*this == obj);
 }
+
+#ifdef BUILD_UT
+
+std::ostream& operator<<(std::ostream& os, const PrimitiveStruct& obj) {
+  Fw::String s;
+  obj.toString(s);
+  os << s.toChar();
+  return os;
+}
+
+#endif
 
 // ----------------------------------------------------------------------
 // Member functions
@@ -118,17 +133,6 @@ void PrimitiveStruct ::
 
   outputString[FW_SERIALIZABLE_TO_STRING_BUFFER_SIZE-1] = 0; // NULL terminate
   sb = outputString;
-}
-
-#endif
-
-#ifdef BUILD_UT
-
-std::ostream& operator<<(std::ostream& os, const PrimitiveStruct& obj) {
-  Fw::String s;
-  obj.toString(s);
-  os << s.toChar();
-  return os;
 }
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/struct/PrimitiveStructSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/PrimitiveStructSerializableAc.ref.hpp
@@ -45,6 +45,12 @@ class PrimitiveStruct :
         const PrimitiveStruct& obj //!< The source object
     );
 
+  public:
+
+    // ----------------------------------------------------------------------
+    // Operators
+    // ----------------------------------------------------------------------
+
     //! Copy assignment operator
     PrimitiveStruct& operator=(
         const PrimitiveStruct& obj //!< The source object
@@ -59,6 +65,16 @@ class PrimitiveStruct :
     bool operator!=(
         const PrimitiveStruct& obj //!< The other object
     ) const;
+
+#ifdef BUILD_UT
+
+    //! Ostream operator
+    friend std::ostream& operator<<(
+        std::ostream& os, //!< The ostream
+        const PrimitiveStruct& obj //!< The object
+    );
+
+#endif
 
   public:
 
@@ -82,16 +98,6 @@ class PrimitiveStruct :
     void toString(
         Fw::StringBase& sb //!< The StringBase object to hold the result
     ) const;
-
-#endif
-
-#ifdef BUILD_UT
-
-    //! Ostream operator
-    friend std::ostream& operator<<(
-        std::ostream& os, //!< The ostream
-        const PrimitiveStruct& obj //!< The object
-    );
 
 #endif
 

--- a/compiler/tools/fpp-to-cpp/test/struct/StringArraySerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/StringArraySerializableAc.ref.cpp
@@ -219,6 +219,10 @@ StringArray ::
   }
 }
 
+// ----------------------------------------------------------------------
+// Operators
+// ----------------------------------------------------------------------
+
 StringArray& StringArray ::
   operator=(const StringArray& obj)
 {
@@ -255,6 +259,17 @@ bool StringArray ::
 {
   return !(*this == obj);
 }
+
+#ifdef BUILD_UT
+
+std::ostream& operator<<(std::ostream& os, const StringArray& obj) {
+  Fw::String s;
+  obj.toString(s);
+  os << s.toChar();
+  return os;
+}
+
+#endif
 
 // ----------------------------------------------------------------------
 // Member functions
@@ -350,17 +365,6 @@ void StringArray ::
 
   outputString[FW_SERIALIZABLE_TO_STRING_BUFFER_SIZE-1] = 0; // NULL terminate
   sb = outputString;
-}
-
-#endif
-
-#ifdef BUILD_UT
-
-std::ostream& operator<<(std::ostream& os, const StringArray& obj) {
-  Fw::String s;
-  obj.toString(s);
-  os << s.toChar();
-  return os;
 }
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/struct/StringArraySerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/StringArraySerializableAc.ref.hpp
@@ -163,6 +163,12 @@ class StringArray :
         const StringSize40& s2
     );
 
+  public:
+
+    // ----------------------------------------------------------------------
+    // Operators
+    // ----------------------------------------------------------------------
+
     //! Copy assignment operator
     StringArray& operator=(
         const StringArray& obj //!< The source object
@@ -177,6 +183,16 @@ class StringArray :
     bool operator!=(
         const StringArray& obj //!< The other object
     ) const;
+
+#ifdef BUILD_UT
+
+    //! Ostream operator
+    friend std::ostream& operator<<(
+        std::ostream& os, //!< The ostream
+        const StringArray& obj //!< The object
+    );
+
+#endif
 
   public:
 
@@ -200,16 +216,6 @@ class StringArray :
     void toString(
         Fw::StringBase& sb //!< The StringBase object to hold the result
     ) const;
-
-#endif
-
-#ifdef BUILD_UT
-
-    //! Ostream operator
-    friend std::ostream& operator<<(
-        std::ostream& os, //!< The ostream
-        const StringArray& obj //!< The object
-    );
 
 #endif
 

--- a/compiler/tools/fpp-to-cpp/test/struct/StringSerializableAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/StringSerializableAc.ref.cpp
@@ -203,6 +203,10 @@ String ::
 
 }
 
+// ----------------------------------------------------------------------
+// Operators
+// ----------------------------------------------------------------------
+
 String& String ::
   operator=(const String& obj)
 {
@@ -228,6 +232,17 @@ bool String ::
 {
   return !(*this == obj);
 }
+
+#ifdef BUILD_UT
+
+std::ostream& operator<<(std::ostream& os, const String& obj) {
+  Fw::String s;
+  obj.toString(s);
+  os << s.toChar();
+  return os;
+}
+
+#endif
 
 // ----------------------------------------------------------------------
 // Member functions
@@ -289,17 +304,6 @@ void String ::
 
   outputString[FW_SERIALIZABLE_TO_STRING_BUFFER_SIZE-1] = 0; // NULL terminate
   sb = outputString;
-}
-
-#endif
-
-#ifdef BUILD_UT
-
-std::ostream& operator<<(std::ostream& os, const String& obj) {
-  Fw::String s;
-  obj.toString(s);
-  os << s.toChar();
-  return os;
 }
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/struct/StringSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/StringSerializableAc.ref.hpp
@@ -148,6 +148,12 @@ class String :
         const String& obj //!< The source object
     );
 
+  public:
+
+    // ----------------------------------------------------------------------
+    // Operators
+    // ----------------------------------------------------------------------
+
     //! Copy assignment operator
     String& operator=(
         const String& obj //!< The source object
@@ -162,6 +168,16 @@ class String :
     bool operator!=(
         const String& obj //!< The other object
     ) const;
+
+#ifdef BUILD_UT
+
+    //! Ostream operator
+    friend std::ostream& operator<<(
+        std::ostream& os, //!< The ostream
+        const String& obj //!< The object
+    );
+
+#endif
 
   public:
 
@@ -185,16 +201,6 @@ class String :
     void toString(
         Fw::StringBase& sb //!< The StringBase object to hold the result
     ) const;
-
-#endif
-
-#ifdef BUILD_UT
-
-    //! Ostream operator
-    friend std::ostream& operator<<(
-        std::ostream& os, //!< The ostream
-        const String& obj //!< The object
-    );
 
 #endif
 


### PR DESCRIPTION
- Add `CppWriterLineUtils.wrapInIfDirective()`: generic utility for wrapping members in an if directive
- Add `CppWriterLineUtils.writeOstreamOperator()`: utility for writing operator<< function
- Refactor enum, array, and struct writers to use those utilities
- Add operator member section with banner comment to struct classes