### PR TITLE
Fix ambiguous use of overloaded operator== error for C++ enums

### DIFF
--- a/compiler/lib/src/main/scala/codegen/CppWriter/EnumCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/EnumCppWriter.scala
@@ -280,7 +280,7 @@ case class EnumCppWriter(
       CppDoc.Class.Member.Function(
         CppDoc.Function(
           Some(s"Conversion operator"),
-          s"operator t",
+          s"operator T",
           Nil,
           CppDoc.Type(""),
           List(
@@ -296,14 +296,14 @@ case class EnumCppWriter(
           "operator==",
           List(
             CppDoc.Function.Param(
-              CppDoc.Type(s"const $name&"),
-              "obj",
-              Some("The other object"),
+              CppDoc.Type(s"T"),
+              "e",
+              Some("The other enum value"),
             ),
           ),
           CppDoc.Type("bool"),
           List(
-            line("return this->e == obj.e;"),
+            line("return this->e == e;"),
           ),
           CppDoc.Function.NonSV,
           CppDoc.Function.Const
@@ -315,14 +315,14 @@ case class EnumCppWriter(
           "operator!=",
           List(
             CppDoc.Function.Param(
-              CppDoc.Type(s"const $name&"),
-              "obj",
-              Some("The other object"),
+              CppDoc.Type(s"T"),
+              "e",
+              Some("The other enum value"),
             ),
           ),
           CppDoc.Type("bool"),
           List(
-            line("return !(*this == obj);"),
+            line("return !(*this == e);"),
           ),
           CppDoc.Function.NonSV,
           CppDoc.Function.Const

--- a/compiler/tools/fpp-to-cpp/test/array/E1EnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/E1EnumAc.ref.cpp
@@ -53,21 +53,21 @@ namespace M {
   }
 
   E1 ::
-    operator t() const
+    operator T() const
   {
     return this->e;
   }
 
   bool E1 ::
-    operator==(const E1& obj) const
+    operator==(T e) const
   {
-    return this->e == obj.e;
+    return this->e == e;
   }
 
   bool E1 ::
-    operator!=(const E1& obj) const
+    operator!=(T e) const
   {
-    return !(*this == obj);
+    return !(*this == e);
   }
 
 #ifdef BUILD_UT

--- a/compiler/tools/fpp-to-cpp/test/array/E1EnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/E1EnumAc.ref.hpp
@@ -86,16 +86,16 @@ namespace M {
       );
 
       //! Conversion operator
-      operator t() const;
+      operator T() const;
 
       //! Equality operator
       bool operator==(
-          const E1& obj //!< The other object
+          T e //!< The other enum value
       ) const;
 
       //! Inequality operator
       bool operator!=(
-          const E1& obj //!< The other object
+          T e //!< The other enum value
       ) const;
 
 #ifdef BUILD_UT

--- a/compiler/tools/fpp-to-cpp/test/array/E2EnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/E2EnumAc.ref.cpp
@@ -51,21 +51,21 @@ E2& E2 ::
 }
 
 E2 ::
-  operator t() const
+  operator T() const
 {
   return this->e;
 }
 
 bool E2 ::
-  operator==(const E2& obj) const
+  operator==(T e) const
 {
-  return this->e == obj.e;
+  return this->e == e;
 }
 
 bool E2 ::
-  operator!=(const E2& obj) const
+  operator!=(T e) const
 {
-  return !(*this == obj);
+  return !(*this == e);
 }
 
 #ifdef BUILD_UT

--- a/compiler/tools/fpp-to-cpp/test/array/E2EnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/E2EnumAc.ref.hpp
@@ -85,16 +85,16 @@ class E2 :
     );
 
     //! Conversion operator
-    operator t() const;
+    operator T() const;
 
     //! Equality operator
     bool operator==(
-        const E2& obj //!< The other object
+        T e //!< The other enum value
     ) const;
 
     //! Inequality operator
     bool operator!=(
-        const E2& obj //!< The other object
+        T e //!< The other enum value
     ) const;
 
 #ifdef BUILD_UT

--- a/compiler/tools/fpp-to-cpp/test/enum/C_EEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/C_EEnumAc.ref.cpp
@@ -51,21 +51,21 @@ C_E& C_E ::
 }
 
 C_E ::
-  operator t() const
+  operator T() const
 {
   return this->e;
 }
 
 bool C_E ::
-  operator==(const C_E& obj) const
+  operator==(T e) const
 {
-  return this->e == obj.e;
+  return this->e == e;
 }
 
 bool C_E ::
-  operator!=(const C_E& obj) const
+  operator!=(T e) const
 {
-  return !(*this == obj);
+  return !(*this == e);
 }
 
 #ifdef BUILD_UT

--- a/compiler/tools/fpp-to-cpp/test/enum/C_EEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/C_EEnumAc.ref.hpp
@@ -82,16 +82,16 @@ class C_E :
     );
 
     //! Conversion operator
-    operator t() const;
+    operator T() const;
 
     //! Equality operator
     bool operator==(
-        const C_E& obj //!< The other object
+        T e //!< The other enum value
     ) const;
 
     //! Inequality operator
     bool operator!=(
-        const C_E& obj //!< The other object
+        T e //!< The other enum value
     ) const;
 
 #ifdef BUILD_UT

--- a/compiler/tools/fpp-to-cpp/test/enum/DefaultEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/DefaultEnumAc.ref.cpp
@@ -53,21 +53,21 @@ namespace M {
   }
 
   Default ::
-    operator t() const
+    operator T() const
   {
     return this->e;
   }
 
   bool Default ::
-    operator==(const Default& obj) const
+    operator==(T e) const
   {
-    return this->e == obj.e;
+    return this->e == e;
   }
 
   bool Default ::
-    operator!=(const Default& obj) const
+    operator!=(T e) const
   {
-    return !(*this == obj);
+    return !(*this == e);
   }
 
 #ifdef BUILD_UT

--- a/compiler/tools/fpp-to-cpp/test/enum/DefaultEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/DefaultEnumAc.ref.hpp
@@ -86,16 +86,16 @@ namespace M {
       );
 
       //! Conversion operator
-      operator t() const;
+      operator T() const;
 
       //! Equality operator
       bool operator==(
-          const Default& obj //!< The other object
+          T e //!< The other enum value
       ) const;
 
       //! Inequality operator
       bool operator!=(
-          const Default& obj //!< The other object
+          T e //!< The other enum value
       ) const;
 
 #ifdef BUILD_UT

--- a/compiler/tools/fpp-to-cpp/test/enum/ExplicitEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/ExplicitEnumAc.ref.cpp
@@ -53,21 +53,21 @@ namespace M {
   }
 
   Explicit ::
-    operator t() const
+    operator T() const
   {
     return this->e;
   }
 
   bool Explicit ::
-    operator==(const Explicit& obj) const
+    operator==(T e) const
   {
-    return this->e == obj.e;
+    return this->e == e;
   }
 
   bool Explicit ::
-    operator!=(const Explicit& obj) const
+    operator!=(T e) const
   {
-    return !(*this == obj);
+    return !(*this == e);
   }
 
 #ifdef BUILD_UT

--- a/compiler/tools/fpp-to-cpp/test/enum/ExplicitEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/ExplicitEnumAc.ref.hpp
@@ -86,16 +86,16 @@ namespace M {
       );
 
       //! Conversion operator
-      operator t() const;
+      operator T() const;
 
       //! Equality operator
       bool operator==(
-          const Explicit& obj //!< The other object
+          T e //!< The other enum value
       ) const;
 
       //! Inequality operator
       bool operator!=(
-          const Explicit& obj //!< The other object
+          T e //!< The other enum value
       ) const;
 
 #ifdef BUILD_UT

--- a/compiler/tools/fpp-to-cpp/test/enum/ImplicitEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/ImplicitEnumAc.ref.cpp
@@ -53,21 +53,21 @@ namespace M {
   }
 
   Implicit ::
-    operator t() const
+    operator T() const
   {
     return this->e;
   }
 
   bool Implicit ::
-    operator==(const Implicit& obj) const
+    operator==(T e) const
   {
-    return this->e == obj.e;
+    return this->e == e;
   }
 
   bool Implicit ::
-    operator!=(const Implicit& obj) const
+    operator!=(T e) const
   {
-    return !(*this == obj);
+    return !(*this == e);
   }
 
 #ifdef BUILD_UT

--- a/compiler/tools/fpp-to-cpp/test/enum/ImplicitEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/ImplicitEnumAc.ref.hpp
@@ -86,16 +86,16 @@ namespace M {
       );
 
       //! Conversion operator
-      operator t() const;
+      operator T() const;
 
       //! Equality operator
       bool operator==(
-          const Implicit& obj //!< The other object
+          T e //!< The other enum value
       ) const;
 
       //! Inequality operator
       bool operator!=(
-          const Implicit& obj //!< The other object
+          T e //!< The other enum value
       ) const;
 
 #ifdef BUILD_UT

--- a/compiler/tools/fpp-to-cpp/test/enum/SerializeTypeEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/SerializeTypeEnumAc.ref.cpp
@@ -53,21 +53,21 @@ namespace M {
   }
 
   SerializeType ::
-    operator t() const
+    operator T() const
   {
     return this->e;
   }
 
   bool SerializeType ::
-    operator==(const SerializeType& obj) const
+    operator==(T e) const
   {
-    return this->e == obj.e;
+    return this->e == e;
   }
 
   bool SerializeType ::
-    operator!=(const SerializeType& obj) const
+    operator!=(T e) const
   {
-    return !(*this == obj);
+    return !(*this == e);
   }
 
 #ifdef BUILD_UT

--- a/compiler/tools/fpp-to-cpp/test/enum/SerializeTypeEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/SerializeTypeEnumAc.ref.hpp
@@ -86,16 +86,16 @@ namespace M {
       );
 
       //! Conversion operator
-      operator t() const;
+      operator T() const;
 
       //! Equality operator
       bool operator==(
-          const SerializeType& obj //!< The other object
+          T e //!< The other enum value
       ) const;
 
       //! Inequality operator
       bool operator!=(
-          const SerializeType& obj //!< The other object
+          T e //!< The other enum value
       ) const;
 
 #ifdef BUILD_UT

--- a/compiler/tools/fpp-to-cpp/test/struct/EEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/EEnumAc.ref.cpp
@@ -53,21 +53,21 @@ namespace M {
   }
 
   E ::
-    operator t() const
+    operator T() const
   {
     return this->e;
   }
 
   bool E ::
-    operator==(const E& obj) const
+    operator==(T e) const
   {
-    return this->e == obj.e;
+    return this->e == e;
   }
 
   bool E ::
-    operator!=(const E& obj) const
+    operator!=(T e) const
   {
-    return !(*this == obj);
+    return !(*this == e);
   }
 
 #ifdef BUILD_UT

--- a/compiler/tools/fpp-to-cpp/test/struct/EEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/EEnumAc.ref.hpp
@@ -84,16 +84,16 @@ namespace M {
       );
 
       //! Conversion operator
-      operator t() const;
+      operator T() const;
 
       //! Equality operator
       bool operator==(
-          const E& obj //!< The other object
+          T e //!< The other enum value
       ) const;
 
       //! Inequality operator
       bool operator!=(
-          const E& obj //!< The other object
+          T e //!< The other enum value
       ) const;
 
 #ifdef BUILD_UT


### PR DESCRIPTION
Resolves #148 

- Change operator== and operator!= to take in raw enum type T instead of enum class type
- Change conversion operator type from t to T
- Update unit tests