### PR TITLE
Make struct member variables protected instead of private in C++ writer

### DIFF
--- a/compiler/lib/src/main/scala/codegen/CppWriter/StructCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/StructCppWriter.scala
@@ -679,7 +679,7 @@ case class StructCppWriter(
   private def getMemberVariableMembers: List[CppDoc.Class.Member] =
     List(
       CppDoc.Class.Member.Lines(
-        CppDoc.Lines(CppDocHppWriter.writeAccessTag("private"))
+        CppDoc.Lines(CppDocHppWriter.writeAccessTag("protected"))
       ),
       CppDoc.Class.Member.Lines(
         CppDoc.Lines(

--- a/compiler/tools/fpp-to-cpp/test/array/S1SerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/S1SerializableAc.ref.hpp
@@ -277,7 +277,7 @@ namespace M {
       //! Set member mString
       void setmString(const StringSize80& mString);
 
-    private:
+    protected:
 
       // ----------------------------------------------------------------------
       // Member variables

--- a/compiler/tools/fpp-to-cpp/test/array/S2SerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/S2SerializableAc.ref.hpp
@@ -121,7 +121,7 @@ class S2 :
     //! Set member s1
     void sets1(const M::S1& s1);
 
-  private:
+  protected:
 
     // ----------------------------------------------------------------------
     // Member variables

--- a/compiler/tools/fpp-to-cpp/test/array/S3SerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/S3SerializableAc.ref.hpp
@@ -151,7 +151,7 @@ namespace S {
       //! Set member mF64
       void setmF64(F64 mF64);
 
-    private:
+    protected:
 
       // ----------------------------------------------------------------------
       // Member variables

--- a/compiler/tools/fpp-to-cpp/test/struct/AbsTypeSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/AbsTypeSerializableAc.ref.hpp
@@ -121,7 +121,7 @@ class AbsType :
     //! Set member t
     void sett(const T& t);
 
-  private:
+  protected:
 
     // ----------------------------------------------------------------------
     // Member variables

--- a/compiler/tools/fpp-to-cpp/test/struct/C_SSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/C_SSerializableAc.ref.hpp
@@ -117,7 +117,7 @@ class C_S :
     //! Set member x
     void setx(U32 x);
 
-  private:
+  protected:
 
     // ----------------------------------------------------------------------
     // Member variables

--- a/compiler/tools/fpp-to-cpp/test/struct/DefaultSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/DefaultSerializableAc.ref.hpp
@@ -194,7 +194,7 @@ class Default :
     //! Set member mF64
     void setmF64(F64 mF64);
 
-  private:
+  protected:
 
     // ----------------------------------------------------------------------
     // Member variables

--- a/compiler/tools/fpp-to-cpp/test/struct/EnumSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/EnumSerializableAc.ref.hpp
@@ -149,7 +149,7 @@ class Enum :
     //! Set member eArr
     void seteArr(const Type_of_eArr& eArr);
 
-  private:
+  protected:
 
     // ----------------------------------------------------------------------
     // Member variables

--- a/compiler/tools/fpp-to-cpp/test/struct/FormatSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/FormatSerializableAc.ref.hpp
@@ -265,7 +265,7 @@ class Format :
     //! Set member m17
     void setm17(F32 m17);
 
-  private:
+  protected:
 
     // ----------------------------------------------------------------------
     // Member variables

--- a/compiler/tools/fpp-to-cpp/test/struct/Modules1SerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/Modules1SerializableAc.ref.hpp
@@ -132,7 +132,7 @@ namespace M {
       //! Set member y
       void sety(F32 y);
 
-    private:
+    protected:
 
       // ----------------------------------------------------------------------
       // Member variables

--- a/compiler/tools/fpp-to-cpp/test/struct/Modules2SerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/Modules2SerializableAc.ref.hpp
@@ -123,7 +123,7 @@ namespace M {
       //! Set member x
       void setx(const M::Modules1& x);
 
-    private:
+    protected:
 
       // ----------------------------------------------------------------------
       // Member variables

--- a/compiler/tools/fpp-to-cpp/test/struct/Modules3SerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/Modules3SerializableAc.ref.hpp
@@ -152,7 +152,7 @@ class Modules3 :
     //! Set member arr
     void setarr(const Type_of_arr& arr);
 
-  private:
+  protected:
 
     // ----------------------------------------------------------------------
     // Member variables

--- a/compiler/tools/fpp-to-cpp/test/struct/PrimitiveSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/PrimitiveSerializableAc.ref.hpp
@@ -305,7 +305,7 @@ class Primitive :
     //! Set member m_string
     void setm_string(const StringSize80& m_string);
 
-  private:
+  protected:
 
     // ----------------------------------------------------------------------
     // Member variables

--- a/compiler/tools/fpp-to-cpp/test/struct/PrimitiveStructSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/PrimitiveStructSerializableAc.ref.hpp
@@ -121,7 +121,7 @@ class PrimitiveStruct :
     //! Set member s1
     void sets1(const Primitive& s1);
 
-  private:
+  protected:
 
     // ----------------------------------------------------------------------
     // Member variables

--- a/compiler/tools/fpp-to-cpp/test/struct/SSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/SSerializableAc.ref.hpp
@@ -118,7 +118,7 @@ class S :
     //! Set member x
     void setx(U32 x);
 
-  private:
+  protected:
 
     // ----------------------------------------------------------------------
     // Member variables

--- a/compiler/tools/fpp-to-cpp/test/struct/StringArraySerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/StringArraySerializableAc.ref.hpp
@@ -253,7 +253,7 @@ class StringArray :
     //! Set member s2
     void sets2(const Type_of_s2& s2);
 
-  private:
+  protected:
 
     // ----------------------------------------------------------------------
     // Member variables

--- a/compiler/tools/fpp-to-cpp/test/struct/StringSerializableAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/StringSerializableAc.ref.hpp
@@ -238,7 +238,7 @@ class String :
     //! Set member s2
     void sets2(const StringSize40& s2);
 
-  private:
+  protected:
 
     // ----------------------------------------------------------------------
     // Member variables


### PR DESCRIPTION
Closes #159 