### PR TITLE
Revise release script

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -6,7 +6,7 @@ jobs:
   Build-Native-Images:
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-11.0"]
+        os: ["ubuntu-18.04", "macos-10.15"]
     runs-on: ${{ matrix.os }}
     steps:
     - name: "Checkout FPP Repository"

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -6,7 +6,7 @@ jobs:
   Build-Native-Images:
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-10.15"]
+        os: ["ubuntu-latest", "macos-11.0"]
     runs-on: ${{ matrix.os }}
     steps:
     - name: "Checkout FPP Repository"

--- a/.github/workflows/env-setup
+++ b/.github/workflows/env-setup
@@ -1,5 +1,5 @@
 #!/bin/bash
-graal_ver="22.1.0"
+graal_ver="22.2.0"
 graal_os="$( uname -s | tr "[:upper:]" "[:lower:]")"
 graal_ar="graalvm-ce-java11-${graal_os}-amd64-${graal_ver}.tar.gz"
 graal_dir="$(pwd)/graalvm-ce-java11-${graal_ver}"

--- a/.github/workflows/env-setup
+++ b/.github/workflows/env-setup
@@ -1,5 +1,5 @@
 #!/bin/bash
-graal_ver="22.2.0"
+graal_ver="22.3.0"
 graal_os="$( uname -s | tr "[:upper:]" "[:lower:]")"
 graal_ar="graalvm-ce-java11-${graal_os}-amd64-${graal_ver}.tar.gz"
 graal_dir="$(pwd)/graalvm-ce-java11-${graal_ver}"

--- a/compiler/README.adoc
+++ b/compiler/README.adoc
@@ -127,14 +127,18 @@ The script will build the native binary tools and install them at
 directory.
 To install the standard version of the FPP tools, run `./install`.
 
-*Trace files:*
-Before generating native binary tools, the `release` script runs
-the FPP unit tests with a tracing agent enabled and records the results.
-The directory `lib/src/main/resources/META-INF` stores the results of
-running the FPP unit tests with the tracing agent enabled.
+*Running the tracing agent:*
+Occasionally when developing FPP, you may need to re-run the tracing
+agent to capture new runtime behavior.
+To do that, use the following procedure:
 
-A version of the trace files is checked in to this repository.
-Running the release installation will merge the new trace results
-into these files.
-Occasionally, due to issues with GraalVM, these files have to be
-edited by hand, to add trace information missed by the tracing agent.
+. Run `./install-trace` to install JVM versions of the FPP tools with
+tracing enabled in the `bin` directory.
+
+. Run `./test` to use the installed tools to run the unit tests.
+This will run the tracing agent and update the trace files.
+
+. Commit the updated trace files to the repository.
+
+Remember to run `./install` to install the standard version
+of the tools if you no longer want to run the tracing agent.

--- a/compiler/README.adoc
+++ b/compiler/README.adoc
@@ -127,6 +127,18 @@ The script will build the native binary tools and install them at
 directory.
 To install the standard version of the FPP tools, run `./install`.
 
+*Custom native-image flags:*
+For some installations, you may need to pass special flags
+to `native-image`.
+To do this, set the environment variable `FPP_NATIVE_IMAGE_FLAGS`.
+For example, to set the temporary directory used by `native-image`, you can run
+
+[source,bash]
+----
+% export FPP_NATIVE_IMAGE_FLAGS='-H:TempDirectory=/path/to/tmp/directory'
+% ./release
+----
+
 *Running the tracing agent:*
 Occasionally when developing FPP, you may need to re-run the tracing
 agent to capture new runtime behavior.

--- a/compiler/lib/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/compiler/lib/src/main/resources/META-INF/native-image/reflect-config.json
@@ -41,10 +41,6 @@
   "fields":[{"name":"0bitmap$1"}]
 },
 {
-  "name":"fpp.compiler.codegen.TypeCppWriter$",
-  "fields":[{"name":"0bitmap$1"}]
-},
-{
   "name":"fpp.compiler.syntax.Lexer$",
   "fields":[{"name":"0bitmap$2"}]
 },

--- a/compiler/lib/src/main/resources/META-INF/native-image/serialization-config.json
+++ b/compiler/lib/src/main/resources/META-INF/native-image/serialization-config.json
@@ -2,5 +2,7 @@
   "types":[
   ],
   "lambdaCapturingTypes":[
+  ],
+  "proxies":[
   ]
 }

--- a/compiler/lib/src/main/scala/util/Version.scala
+++ b/compiler/lib/src/main/scala/util/Version.scala
@@ -3,6 +3,6 @@ package fpp.compiler.util
 /** The compiler version */
 object Version {
 
-  val v = "[unknown version]"
+  val v = "v1.1.0a4-2-gb0da09a4"
 
 }

--- a/compiler/lib/src/main/scala/util/Version.scala
+++ b/compiler/lib/src/main/scala/util/Version.scala
@@ -3,6 +3,6 @@ package fpp.compiler.util
 /** The compiler version */
 object Version {
 
-  val v = "v1.1.0a4-2-gb0da09a4"
+  val v = "[unknown version]"
 
 }

--- a/compiler/release
+++ b/compiler/release
@@ -52,6 +52,13 @@ native_bin="native-fpp-`uname`-`uname -m`"
 native_image="$GRAALVM_JAVA_HOME/bin/native-image"
 meta_inf_dir="lib/src/main/resources/META-INF/native-image"
 release_tgz="$native_bin.tar.gz"
+# Use gtar if it's available
+# The default tar has issues on Mac OS on GitHub
+tar=`which gtar`
+if test -z "$tar"
+then
+  tar=tar
+fi
 
 # Make directories
 mkdir -p "$meta_inf_dir"
@@ -118,12 +125,12 @@ fi
 print_phase "Constructing the release archive $release_tgz"
 
 # Create the tar ball
-evalp tar -czf "$release_tgz" "$native_bin"
+evalp $tar -czf "$release_tgz" "$native_bin"
 sync; sync; sync;
 
 # Verify the tar ball
 evalp mkdir -p check-tar
-(cd check-tar; evalp tar -xvf "../$release_tgz")
+(cd check-tar; evalp $tar -xvf "../$release_tgz")
 sync; sync; sync;
 for file in `ls "$native_bin"`
 do

--- a/compiler/release
+++ b/compiler/release
@@ -81,8 +81,8 @@ do
     jar_file="bin/$tool_name.jar"
     out_file="$native_bin/$tool_name"
     echo "Building $out_file"
-    evalp "$native_image" --configure-reflection-metadata --no-fallback \
-      --install-exit-handlers -jar "$jar_file" "$out_file"
+    evalp "$native_image" --no-fallback --install-exit-handlers \
+      -jar "$jar_file" "$out_file"
     if [ $? -ne 0 ]
     then
         echo "release: Failed to build $out_file"
@@ -137,3 +137,5 @@ evalp rm -r check-tar
 
 # Print status
 echo "Release archive written to $release_tgz with size `du -hs $release_tgz`"
+
+print_phase "Success"

--- a/compiler/release
+++ b/compiler/release
@@ -12,7 +12,7 @@
 # See README.adoc.
 # ----------------------------------------------------------------------
 
-# Print and evaluate
+# Print and evaluate a command
 evalp()
 {
   echo "$@"
@@ -43,7 +43,8 @@ cd `dirname $0`
 native_bin="native-fpp-`uname`-`uname -m`"
 java=$GRAALVM_JAVA_HOME/bin/java
 native_image="$GRAALVM_JAVA_HOME/bin/native-image"
-meta_inf_dir="lib/src/main/resources/META-INF/native-image/"
+meta_inf_dir="lib/src/main/resources/META-INF/native-image"
+release_tgz="$native_bin.tar.gz"
 
 # Make directories
 mkdir -p "$meta_inf_dir"
@@ -58,12 +59,13 @@ echo "Native Image Version"
 $native_image --version
 
 # Install jar files in bin
+# Install scripts that run jar files with tracing
 ./install-trace
 
 # Get the tool names from bin
 tool_names=`get_tool_names bin`
 
-# Run unit tests and capture the GraalVM trace
+# Run the FPP unit tests and capture the GraalVM trace
 ./test
 if [ $? -ne 0 ]
 then
@@ -73,10 +75,11 @@ then
 fi
 sync; sync; sync;
 
-# Use GraalVM to convert jar files to binaries
-for jar_file in bin/*.jar
+# Use GraalVM to convert the jar files to native binaries
+for tool_name in $tool_names
 do
-    out_file=$native_bin/`basename $jar_file .jar`
+    jar_file="bin/$tool_name.jar"
+    out_file="$native_bin/$tool_name"
     echo "Building $out_file"
     evalp "$native_image" --configure-reflection-metadata --no-fallback \
       --install-exit-handlers -jar "$jar_file" "$out_file"
@@ -94,13 +97,16 @@ do
 done
 sync; sync; sync;
 
-# Clean up native directory
-rm -f "$native_bin"/*.txt "$native_bin"/*.o
+# Install the native binaries
+evalp rm -r bin
+evalp mkdir bin
+for tool_name in $tool_names
+do
+    evalp cp $native_bin/$tool_name bin/$tool_name
+done
 sync; sync; sync;
 
 # Test the native binaries
-evalp rm -r "bin"
-evalp cp -r "$native_bin" "bin"
 ./test
 if [ $? -ne 0 ]
 then
@@ -109,12 +115,11 @@ then
 fi
 
 # Create the tar ball
-release_tgz="$native_bin.tar.gz"
 evalp tar -czf "$release_tgz" "$native_bin"
 sync; sync; sync;
 
 # Verify the tar ball
-mkdir -p check-tar
+evalp mkdir -p check-tar
 (cd check-tar; evalp tar -xvf "../$release_tgz")
 sync; sync; sync;
 for file in `ls "$native_bin"`
@@ -125,6 +130,7 @@ do
     exit 1
   fi
 done
+evalp rm -r check-tar
 
 # Print status
 echo "Release archive written to $release_tgz with size `du -hs $release_tgz`"

--- a/compiler/release
+++ b/compiler/release
@@ -29,6 +29,14 @@ get_tool_names()
   done
 }
 
+# Print a phase of the process
+print_phase()
+{
+  echo "----------------------------------------------------------------------"
+  echo $1
+  echo "----------------------------------------------------------------------"
+}
+
 # Check that GRAALVM_JAVA_HOME is set
 if test -z "$GRAALVM_JAVA_HOME"
 then
@@ -49,14 +57,20 @@ release_tgz="$native_bin.tar.gz"
 mkdir -p "$meta_inf_dir"
 mkdir -p "$native_bin"
 
+print_phase "Version information"
+
 # Print version information
 echo "C compiler version"
 cc --version
 echo "Native Image Version"
 $native_image --version
 
+print_phase "Installing JVM tools in bin"
+
 # Install jar files in bin
 ./install
+
+print_phase "Constructing binary tools in $native_bin"
 
 # Get the tool names from bin
 tool_names=`get_tool_names bin`
@@ -91,6 +105,8 @@ evalp rm -r "bin"
 evalp cp -r "$native_bin" "bin"
 sync; sync; sync;
 
+print_phase "Testing the binary tools"
+
 # Test the native binaries
 ./test
 if [ $? -ne 0 ]
@@ -98,6 +114,8 @@ then
     echo "[ERROR] Native unit tests failed"
     exit 1
 fi
+
+print_phase "Constructing the release archive $release_tgz"
 
 # Create the tar ball
 evalp tar -czf "$release_tgz" "$native_bin"

--- a/compiler/release
+++ b/compiler/release
@@ -54,9 +54,10 @@ meta_inf_dir="lib/src/main/resources/META-INF/native-image"
 release_tgz="$native_bin.tar.gz"
 # Use gtar if it's available
 # The default tar has issues on Mac OS on GitHub
-tar=`which gtar`
-if test -z "$tar"
+if which gtar
 then
+  tar=`which gtar`
+else
   tar=tar
 fi
 

--- a/compiler/release
+++ b/compiler/release
@@ -40,7 +40,7 @@ print_phase()
 # Check that GRAALVM_JAVA_HOME is set
 if test -z "$GRAALVM_JAVA_HOME"
 then
-  echo "release: environment variable GRAALVM_JAVA_HOME is not set" 1>&2
+  echo "[ERROR] Environment variable GRAALVM_JAVA_HOME is not set" 1>&2
   exit 1
 fi
 
@@ -85,13 +85,13 @@ do
       -jar "$jar_file" "$out_file"
     if [ $? -ne 0 ]
     then
-        echo "release: Failed to build $out_file"
+        echo "[ERROR] Failed to build $out_file"
         exit 1
     fi
     sync; sync; sync;
     if ! $out_file --help 1>/dev/null
     then
-        echo "release: Failed, $out_file not executable"
+        echo "[ERROR] $out_file not executable"
         exit 1
     fi
 done

--- a/compiler/release
+++ b/compiler/release
@@ -9,6 +9,9 @@
 #
 # 2. Set the environment variable GRAALVM_JAVA_HOME.
 #
+# 3. To pass flags to native-image, set the environment variable
+#    FPP_NATIVE_IMAGE_FLAGS.
+#
 # See README.adoc.
 # ----------------------------------------------------------------------
 
@@ -89,7 +92,8 @@ do
     jar_file="bin/$tool_name.jar"
     out_file="$native_bin/$tool_name"
     echo "Building $out_file"
-    evalp "$native_image" --no-fallback --install-exit-handlers \
+    evalp "$native_image" $FPP_NATIVE_IMAGE_FLAGS \
+      --no-fallback --install-exit-handlers \
       -jar "$jar_file" "$out_file"
     if [ $? -ne 0 ]
     then

--- a/compiler/release
+++ b/compiler/release
@@ -41,7 +41,6 @@ cd `dirname $0`
 
 # Set local variables
 native_bin="native-fpp-`uname`-`uname -m`"
-java=$GRAALVM_JAVA_HOME/bin/java
 native_image="$GRAALVM_JAVA_HOME/bin/native-image"
 meta_inf_dir="lib/src/main/resources/META-INF/native-image"
 release_tgz="$native_bin.tar.gz"
@@ -50,30 +49,17 @@ release_tgz="$native_bin.tar.gz"
 mkdir -p "$meta_inf_dir"
 mkdir -p "$native_bin"
 
-# Versioning information
+# Print version information
 echo "C compiler version"
 cc --version
-echo "Java version"
-$java --version
 echo "Native Image Version"
 $native_image --version
 
 # Install jar files in bin
-# Install scripts that run jar files with tracing
-./install-trace
+./install
 
 # Get the tool names from bin
 tool_names=`get_tool_names bin`
-
-# Run the FPP unit tests and capture the GraalVM trace
-./test
-if [ $? -ne 0 ]
-then
-    # Check that unit tests passed
-    echo "[ERROR] JVM unit tests failed"
-    exit 1
-fi
-sync; sync; sync;
 
 # Use GraalVM to convert the jar files to native binaries
 for tool_name in $tool_names
@@ -97,13 +83,12 @@ do
 done
 sync; sync; sync;
 
+# Clean up the native directory
+rm -f "$native_bin"/*.txt
+
 # Install the native binaries
-evalp rm -r bin
-evalp mkdir bin
-for tool_name in $tool_names
-do
-    evalp cp $native_bin/$tool_name bin/$tool_name
-done
+evalp rm -r "bin"
+evalp cp -r "$native_bin" "bin"
 sync; sync; sync;
 
 # Test the native binaries

--- a/compiler/release
+++ b/compiler/release
@@ -12,15 +12,38 @@
 # See README.adoc.
 # ----------------------------------------------------------------------
 
+# Print and evaluate
+evalp()
+{
+  echo "$@"
+  $@
+}
+
+# Get tool names from a directory
+get_tool_names()
+{
+  dir=$1
+  for file in $dir/*.jar
+  do
+    basename $file .jar
+  done
+}
+
+# Check that GRAALVM_JAVA_HOME is set
 if test -z "$GRAALVM_JAVA_HOME"
 then
   echo "release: environment variable GRAALVM_JAVA_HOME is not set" 1>&2
   exit 1
 fi
-directory=`dirname $0`
-native_bin="$directory/native-fpp-`uname`-`uname -m`"
+
+# Run in the directory where this script is located
+cd `dirname $0`
+
+# Set local variables
+native_bin="native-fpp-`uname`-`uname -m`"
+java=$GRAALVM_JAVA_HOME/bin/java
 native_image="$GRAALVM_JAVA_HOME/bin/native-image"
-meta_inf_dir="$directory/lib/src/main/resources/META-INF/native-image/"
+meta_inf_dir="lib/src/main/resources/META-INF/native-image/"
 
 # Make directories
 mkdir -p "$meta_inf_dir"
@@ -30,34 +53,33 @@ mkdir -p "$native_bin"
 echo "C compiler version"
 cc --version
 echo "Java version"
-java --version
+$java --version
 echo "Native Image Version"
-native-image --version
+$native_image --version
 
+# Install jar files in bin
+./install-trace
 
-# Install jar files here
-$directory/install-trace
-# Test a run before running test
-$directory/bin/fpp-locate-defs tools/fpp-locate-defs/test/defs/defs-1.fpp tools/fpp-locate-defs/test/defs/defs-2.fpp 1>/dev/null
+# Get the tool names from bin
+tool_names=`get_tool_names bin`
+
+# Run unit tests and capture the GraalVM trace
+./test
 if [ $? -ne 0 ]
 then
-    echo "[ERROR] Failed to run JAR with tracing enabled"
+    # Check that unit tests passed
+    echo "[ERROR] JVM unit tests failed"
     exit 1
 fi
-
-# Trace through testing
-$directory/test
-if [ $? -ne 0 ]
-then
-    echo "[WARNING] Failed to run tests"
-fi
 sync; sync; sync;
-# Convert jar files to binaries
-for jar_file in $directory/bin/*.jar
+
+# Use GraalVM to convert jar files to binaries
+for jar_file in bin/*.jar
 do
     out_file=$native_bin/`basename $jar_file .jar`
     echo "Building $out_file"
-    "$native_image" --configure-reflection-metadata --no-fallback --install-exit-handlers -jar "$jar_file" "$out_file"
+    evalp "$native_image" --configure-reflection-metadata --no-fallback \
+      --install-exit-handlers -jar "$jar_file" "$out_file"
     if [ $? -ne 0 ]
     then
         echo "release: Failed to build $out_file"
@@ -73,26 +95,36 @@ done
 sync; sync; sync;
 
 # Clean up native directory
-rm "$native_bin"/*.txt
+rm -f "$native_bin"/*.txt "$native_bin"/*.o
 sync; sync; sync;
 
-# Testing of the native binaries
-rm -r "$directory/bin"
-cp -r "$native_bin" "$directory/bin"
-"$directory/test"
+# Test the native binaries
+evalp rm -r "bin"
+evalp cp -r "$native_bin" "bin"
+./test
 if [ $? -ne 0 ]
 then
-    echo "[WARNING] Failed to run tests"
+    echo "[ERROR] Native unit tests failed"
+    exit 1
 fi
 
-# Create tar ball
+# Create the tar ball
 release_tgz="$native_bin.tar.gz"
-tar -czf "$release_tgz" "$native_bin"
+evalp tar -czf "$release_tgz" "$native_bin"
 sync; sync; sync;
-# Check if file size too small
-if [ `stat -f %z $release_tgz` -lt 55846858 ]
-then
-    echo "Release archive $release_tgz too small with size `du -hs $release_tgz`"
-    exit 99
-fi
+
+# Verify the tar ball
+mkdir -p check-tar
+(cd check-tar; evalp tar -xvf "../$release_tgz")
+sync; sync; sync;
+for file in `ls "$native_bin"`
+do
+  if ! evalp diff -q "$native_bin/$file check-tar/$native_bin/$file"
+  then
+    echo "[ERROR] Archive creation failed"
+    exit 1
+  fi
+done
+
+# Print status
 echo "Release archive written to $release_tgz with size `du -hs $release_tgz`"


### PR DESCRIPTION
* Improve diagnostic messages.
* Improve validation of release archive. Use diff instead of size estimate to check correctness.
* Revise the directory structure in the release archive. On my Mac, I noticed that we were giving absolute paths starting with / to tar. But these paths are meaningless in a release tar ball. My Mac was warning about it.
* Bump the GraalVM version to 22.3.0. This also fixes the problem with the missing trace info.
* In GraalVM 22.3.0, the trace info that we added by hand caused a warning, so I deleted it.
* Delete the code that runs all the JVM unit tests and captures the trace. Since we are checking the trace into the repo, and it seems brittle to changes in FPP and/or GraalVM, the procedure will be to run the trace manually, verify that everything is working, and commit any changes to the trace before submitting a release to GitHub.
* Revert the GraalVM README to what we had in the previous release. Hopefully, with the latest GraalVM, we won't have to hand-edit trace files.
* Use gtar instead of tar on Mac OS -- tar does not work properly.
* Switch from ubuntu-latest to ubuntu-18.04 for compatibility.
* Add and document an FPP_NATIVE_IMAGE_FLAGS configuration variable.
