### PR TITLE
fixing topology includes

### DIFF
--- a/compiler/lib/src/main/scala/transform/ResolveSpecInclude.scala
+++ b/compiler/lib/src/main/scala/transform/ResolveSpecInclude.scala
@@ -27,6 +27,21 @@ object ResolveSpecInclude extends AstStateTransformer {
     }
   }
 
+  override def defTopologyAnnotatedNode(
+    a: Analysis,
+    node: Ast.Annotated[AstNode[Ast.DefTopology]]
+  ) = {
+    val (pre, node1, post) = node
+    val Ast.DefTopology(name, members) = node1.data
+    for { result <- transformList(a, members, topologyMember) }
+    yield {
+      val (a1, members1) = result
+      val defTopology = Ast.DefTopology(name, members1.flatten)
+      val node2 = AstNode.create(defTopology, node1.id)
+      (a1, (pre, node2, post))
+    }
+  }
+
   override def defModuleAnnotatedNode(
     a: Analysis,
     node: Ast.Annotated[AstNode[Ast.DefModule]]

--- a/compiler/tools/fpp-syntax/test/include-topology.fpp
+++ b/compiler/tools/fpp-syntax/test/include-topology.fpp
@@ -1,5 +1,5 @@
 topology T {
 
-  include "constant.fppi"
+  include "instance.fppi"
 
 }

--- a/compiler/tools/fpp-syntax/test/include-topology.ref.txt
+++ b/compiler/tools/fpp-syntax/test/include-topology.ref.txt
@@ -1,4 +1,7 @@
 def topology
   ident T
-  spec include
-    file constant.fppi
+  @ Included instance
+  spec comp instance
+    public
+    qual ident x
+  @< Included instance

--- a/compiler/tools/fpp-syntax/test/instance.fppi
+++ b/compiler/tools/fpp-syntax/test/instance.fppi
@@ -1,0 +1,3 @@
+@ Included instance
+instance x
+@< Included instance


### PR DESCRIPTION
This fixes #188.  The work performed was to:

1. Add missing `defTopologyAnnotatedNode` that uses the pre-existing and unused function `topologyMember`
2. Change the unit-test from including a constant (invalid syntax for including constants within typologies) to including an instance
3. Fix unit-test output.