### PR TITLE
Minor changes to port cpp

### DIFF
--- a/compiler/lib/src/main/scala/codegen/CppWriter/PortCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/PortCppWriter.scala
@@ -160,7 +160,7 @@ case class PortCppWriter (
     val systemHeaders = List(
       "cstdio",
       "cstring",
-    ).map(CppWriter.systemHeaderString)
+    ).map(CppWriter.systemHeaderString).map(line)
     val serializableHeader = data.returnType match {
       case Some(_) => Nil
       case None => List("Fw/Types/Serializable.hpp")
@@ -172,12 +172,16 @@ case class PortCppWriter (
         "Fw/Port/InputPortBase.hpp",
         "Fw/Port/OutputPortBase.hpp",
         "Fw/Types/StringType.hpp",
-      ) ++
-        serializableHeader
+      ) ++ serializableHeader
     ).map(CppWriter.headerString)
     val symbolHeaders = writeIncludeDirectives
-    val headers = systemHeaders ++ standardHeaders ++ symbolHeaders
-    CppWriter.linesMember(addBlankPrefix(headers.sorted.map(line)))
+    val userHeaders = (standardHeaders ++ symbolHeaders).sorted.map(line)
+    CppWriter.linesMember(
+      List(
+        Line.blank :: systemHeaders,
+        Line.blank :: userHeaders
+      ).flatten
+    )
   }
 
   private def getCppIncludes: CppDoc.Member = {

--- a/compiler/lib/src/main/scala/codegen/CppWriter/PortCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/PortCppWriter.scala
@@ -157,10 +157,6 @@ case class PortCppWriter (
   }
 
   private def getHppIncludes: CppDoc.Member = {
-    val systemHeaders = List(
-      "cstdio",
-      "cstring",
-    ).map(CppWriter.systemHeaderString).map(line)
     val serializableHeader = data.returnType match {
       case Some(_) => Nil
       case None => List("Fw/Types/Serializable.hpp")
@@ -176,12 +172,7 @@ case class PortCppWriter (
     ).map(CppWriter.headerString)
     val symbolHeaders = writeIncludeDirectives
     val userHeaders = (standardHeaders ++ symbolHeaders).sorted.map(line)
-    CppWriter.linesMember(
-      List(
-        Line.blank :: systemHeaders,
-        Line.blank :: userHeaders
-      ).flatten
-    )
+    CppWriter.linesMember(Line.blank :: userHeaders)
   }
 
   private def getCppIncludes: CppDoc.Member = {

--- a/compiler/lib/src/main/scala/codegen/CppWriter/PortCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/PortCppWriter.scala
@@ -157,6 +157,10 @@ case class PortCppWriter (
   }
 
   private def getHppIncludes: CppDoc.Member = {
+    val systemHeaders = List(
+      "cstdio",
+      "cstring",
+    ).map(CppWriter.systemHeaderString).map(line)
     val serializableHeader = data.returnType match {
       case Some(_) => Nil
       case None => List("Fw/Types/Serializable.hpp")
@@ -172,7 +176,12 @@ case class PortCppWriter (
     ).map(CppWriter.headerString)
     val symbolHeaders = writeIncludeDirectives
     val userHeaders = (standardHeaders ++ symbolHeaders).sorted.map(line)
-    CppWriter.linesMember(Line.blank :: userHeaders)
+    CppWriter.linesMember(
+      List(
+        Line.blank :: systemHeaders,
+        Line.blank :: userHeaders
+      ).flatten
+    )
   }
 
   private def getCppIncludes: CppDoc.Member = {

--- a/compiler/tools/fpp-to-cpp/test/port/AbsTypePortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/port/AbsTypePortAc.ref.hpp
@@ -7,6 +7,9 @@
 #ifndef AbsTypePortAc_HPP
 #define AbsTypePortAc_HPP
 
+#include <cstdio>
+#include <cstring>
+
 #include "FpConfig.hpp"
 #include "Fw/Comp/PassiveComponentBase.hpp"
 #include "Fw/Port/InputPortBase.hpp"
@@ -14,8 +17,6 @@
 #include "Fw/Types/Serializable.hpp"
 #include "Fw/Types/StringType.hpp"
 #include "include/T.hpp"
-#include <cstdio>
-#include <cstring>
 
 //! Input AbsType port
 //! A port with abstract type parameters

--- a/compiler/tools/fpp-to-cpp/test/port/AbsTypePortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/port/AbsTypePortAc.ref.hpp
@@ -7,9 +7,6 @@
 #ifndef AbsTypePortAc_HPP
 #define AbsTypePortAc_HPP
 
-#include <cstdio>
-#include <cstring>
-
 #include "FpConfig.hpp"
 #include "Fw/Comp/PassiveComponentBase.hpp"
 #include "Fw/Port/InputPortBase.hpp"

--- a/compiler/tools/fpp-to-cpp/test/port/AbsTypePortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/port/AbsTypePortAc.ref.hpp
@@ -7,6 +7,9 @@
 #ifndef AbsTypePortAc_HPP
 #define AbsTypePortAc_HPP
 
+#include <cstdio>
+#include <cstring>
+
 #include "FpConfig.hpp"
 #include "Fw/Comp/PassiveComponentBase.hpp"
 #include "Fw/Port/InputPortBase.hpp"

--- a/compiler/tools/fpp-to-cpp/test/port/BuiltInTypePortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/port/BuiltInTypePortAc.ref.hpp
@@ -7,6 +7,9 @@
 #ifndef BuiltInTypePortAc_HPP
 #define BuiltInTypePortAc_HPP
 
+#include <cstdio>
+#include <cstring>
+
 #include "FpConfig.hpp"
 #include "Fw/Comp/PassiveComponentBase.hpp"
 #include "Fw/Port/InputPortBase.hpp"

--- a/compiler/tools/fpp-to-cpp/test/port/BuiltInTypePortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/port/BuiltInTypePortAc.ref.hpp
@@ -7,9 +7,6 @@
 #ifndef BuiltInTypePortAc_HPP
 #define BuiltInTypePortAc_HPP
 
-#include <cstdio>
-#include <cstring>
-
 #include "FpConfig.hpp"
 #include "Fw/Comp/PassiveComponentBase.hpp"
 #include "Fw/Port/InputPortBase.hpp"

--- a/compiler/tools/fpp-to-cpp/test/port/BuiltInTypePortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/port/BuiltInTypePortAc.ref.hpp
@@ -7,14 +7,15 @@
 #ifndef BuiltInTypePortAc_HPP
 #define BuiltInTypePortAc_HPP
 
+#include <cstdio>
+#include <cstring>
+
 #include "FpConfig.hpp"
 #include "Fw/Comp/PassiveComponentBase.hpp"
 #include "Fw/Port/InputPortBase.hpp"
 #include "Fw/Port/OutputPortBase.hpp"
 #include "Fw/Types/Serializable.hpp"
 #include "Fw/Types/StringType.hpp"
-#include <cstdio>
-#include <cstring>
 
 //! Input BuiltInType port
 //! A port with built-in type parameters

--- a/compiler/tools/fpp-to-cpp/test/port/EmptyPortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/port/EmptyPortAc.ref.hpp
@@ -7,9 +7,6 @@
 #ifndef EmptyPortAc_HPP
 #define EmptyPortAc_HPP
 
-#include <cstdio>
-#include <cstring>
-
 #include "FpConfig.hpp"
 #include "Fw/Comp/PassiveComponentBase.hpp"
 #include "Fw/Port/InputPortBase.hpp"

--- a/compiler/tools/fpp-to-cpp/test/port/EmptyPortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/port/EmptyPortAc.ref.hpp
@@ -7,6 +7,9 @@
 #ifndef EmptyPortAc_HPP
 #define EmptyPortAc_HPP
 
+#include <cstdio>
+#include <cstring>
+
 #include "FpConfig.hpp"
 #include "Fw/Comp/PassiveComponentBase.hpp"
 #include "Fw/Port/InputPortBase.hpp"

--- a/compiler/tools/fpp-to-cpp/test/port/EmptyPortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/port/EmptyPortAc.ref.hpp
@@ -7,14 +7,15 @@
 #ifndef EmptyPortAc_HPP
 #define EmptyPortAc_HPP
 
+#include <cstdio>
+#include <cstring>
+
 #include "FpConfig.hpp"
 #include "Fw/Comp/PassiveComponentBase.hpp"
 #include "Fw/Port/InputPortBase.hpp"
 #include "Fw/Port/OutputPortBase.hpp"
 #include "Fw/Types/Serializable.hpp"
 #include "Fw/Types/StringType.hpp"
-#include <cstdio>
-#include <cstring>
 
 //! Input Empty port
 //! An empty port

--- a/compiler/tools/fpp-to-cpp/test/port/FppTypePortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/port/FppTypePortAc.ref.hpp
@@ -7,6 +7,9 @@
 #ifndef FppTypePortAc_HPP
 #define FppTypePortAc_HPP
 
+#include <cstdio>
+#include <cstring>
+
 #include "AArrayAc.hpp"
 #include "EEnumAc.hpp"
 #include "FpConfig.hpp"

--- a/compiler/tools/fpp-to-cpp/test/port/FppTypePortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/port/FppTypePortAc.ref.hpp
@@ -7,9 +7,6 @@
 #ifndef FppTypePortAc_HPP
 #define FppTypePortAc_HPP
 
-#include <cstdio>
-#include <cstring>
-
 #include "AArrayAc.hpp"
 #include "EEnumAc.hpp"
 #include "FpConfig.hpp"

--- a/compiler/tools/fpp-to-cpp/test/port/FppTypePortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/port/FppTypePortAc.ref.hpp
@@ -7,6 +7,9 @@
 #ifndef FppTypePortAc_HPP
 #define FppTypePortAc_HPP
 
+#include <cstdio>
+#include <cstring>
+
 #include "AArrayAc.hpp"
 #include "EEnumAc.hpp"
 #include "FpConfig.hpp"
@@ -16,8 +19,6 @@
 #include "Fw/Types/Serializable.hpp"
 #include "Fw/Types/StringType.hpp"
 #include "SSerializableAc.hpp"
-#include <cstdio>
-#include <cstring>
 
 //! Input FppType port
 //! A port with FPP type parameters

--- a/compiler/tools/fpp-to-cpp/test/port/KwdNamePortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/port/KwdNamePortAc.ref.hpp
@@ -7,6 +7,9 @@
 #ifndef KwdNamePortAc_HPP
 #define KwdNamePortAc_HPP
 
+#include <cstdio>
+#include <cstring>
+
 #include "FpConfig.hpp"
 #include "Fw/Comp/PassiveComponentBase.hpp"
 #include "Fw/Port/InputPortBase.hpp"

--- a/compiler/tools/fpp-to-cpp/test/port/KwdNamePortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/port/KwdNamePortAc.ref.hpp
@@ -7,9 +7,6 @@
 #ifndef KwdNamePortAc_HPP
 #define KwdNamePortAc_HPP
 
-#include <cstdio>
-#include <cstring>
-
 #include "FpConfig.hpp"
 #include "Fw/Comp/PassiveComponentBase.hpp"
 #include "Fw/Port/InputPortBase.hpp"

--- a/compiler/tools/fpp-to-cpp/test/port/KwdNamePortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/port/KwdNamePortAc.ref.hpp
@@ -7,14 +7,15 @@
 #ifndef KwdNamePortAc_HPP
 #define KwdNamePortAc_HPP
 
+#include <cstdio>
+#include <cstring>
+
 #include "FpConfig.hpp"
 #include "Fw/Comp/PassiveComponentBase.hpp"
 #include "Fw/Port/InputPortBase.hpp"
 #include "Fw/Port/OutputPortBase.hpp"
 #include "Fw/Types/Serializable.hpp"
 #include "Fw/Types/StringType.hpp"
-#include <cstdio>
-#include <cstring>
 
 //! Input KwdName port
 //! A port with a keyword name

--- a/compiler/tools/fpp-to-cpp/test/port/PrimitivePortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/port/PrimitivePortAc.ref.hpp
@@ -7,9 +7,6 @@
 #ifndef PrimitivePortAc_HPP
 #define PrimitivePortAc_HPP
 
-#include <cstdio>
-#include <cstring>
-
 #include "FpConfig.hpp"
 #include "Fw/Comp/PassiveComponentBase.hpp"
 #include "Fw/Port/InputPortBase.hpp"

--- a/compiler/tools/fpp-to-cpp/test/port/PrimitivePortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/port/PrimitivePortAc.ref.hpp
@@ -7,14 +7,15 @@
 #ifndef PrimitivePortAc_HPP
 #define PrimitivePortAc_HPP
 
+#include <cstdio>
+#include <cstring>
+
 #include "FpConfig.hpp"
 #include "Fw/Comp/PassiveComponentBase.hpp"
 #include "Fw/Port/InputPortBase.hpp"
 #include "Fw/Port/OutputPortBase.hpp"
 #include "Fw/Types/Serializable.hpp"
 #include "Fw/Types/StringType.hpp"
-#include <cstdio>
-#include <cstring>
 
 //! Input Primitive port
 //! A port with primitive parameters

--- a/compiler/tools/fpp-to-cpp/test/port/PrimitivePortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/port/PrimitivePortAc.ref.hpp
@@ -7,6 +7,9 @@
 #ifndef PrimitivePortAc_HPP
 #define PrimitivePortAc_HPP
 
+#include <cstdio>
+#include <cstring>
+
 #include "FpConfig.hpp"
 #include "Fw/Comp/PassiveComponentBase.hpp"
 #include "Fw/Port/InputPortBase.hpp"

--- a/compiler/tools/fpp-to-cpp/test/port/ReturnTypePortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/port/ReturnTypePortAc.ref.hpp
@@ -7,9 +7,6 @@
 #ifndef M_ReturnTypePortAc_HPP
 #define M_ReturnTypePortAc_HPP
 
-#include <cstdio>
-#include <cstring>
-
 #include "FpConfig.hpp"
 #include "Fw/Comp/PassiveComponentBase.hpp"
 #include "Fw/Port/InputPortBase.hpp"

--- a/compiler/tools/fpp-to-cpp/test/port/ReturnTypePortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/port/ReturnTypePortAc.ref.hpp
@@ -7,6 +7,9 @@
 #ifndef M_ReturnTypePortAc_HPP
 #define M_ReturnTypePortAc_HPP
 
+#include <cstdio>
+#include <cstring>
+
 #include "FpConfig.hpp"
 #include "Fw/Comp/PassiveComponentBase.hpp"
 #include "Fw/Port/InputPortBase.hpp"

--- a/compiler/tools/fpp-to-cpp/test/port/ReturnTypePortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/port/ReturnTypePortAc.ref.hpp
@@ -7,13 +7,14 @@
 #ifndef M_ReturnTypePortAc_HPP
 #define M_ReturnTypePortAc_HPP
 
+#include <cstdio>
+#include <cstring>
+
 #include "FpConfig.hpp"
 #include "Fw/Comp/PassiveComponentBase.hpp"
 #include "Fw/Port/InputPortBase.hpp"
 #include "Fw/Port/OutputPortBase.hpp"
 #include "Fw/Types/StringType.hpp"
-#include <cstdio>
-#include <cstring>
 
 namespace M {
 

--- a/compiler/tools/fpp-to-cpp/test/port/StringPortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/port/StringPortAc.ref.hpp
@@ -7,9 +7,6 @@
 #ifndef StringPortAc_HPP
 #define StringPortAc_HPP
 
-#include <cstdio>
-#include <cstring>
-
 #include "FpConfig.hpp"
 #include "Fw/Comp/PassiveComponentBase.hpp"
 #include "Fw/Port/InputPortBase.hpp"

--- a/compiler/tools/fpp-to-cpp/test/port/StringPortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/port/StringPortAc.ref.hpp
@@ -7,6 +7,9 @@
 #ifndef StringPortAc_HPP
 #define StringPortAc_HPP
 
+#include <cstdio>
+#include <cstring>
+
 #include "FpConfig.hpp"
 #include "Fw/Comp/PassiveComponentBase.hpp"
 #include "Fw/Port/InputPortBase.hpp"

--- a/compiler/tools/fpp-to-cpp/test/port/StringPortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/port/StringPortAc.ref.hpp
@@ -7,14 +7,15 @@
 #ifndef StringPortAc_HPP
 #define StringPortAc_HPP
 
+#include <cstdio>
+#include <cstring>
+
 #include "FpConfig.hpp"
 #include "Fw/Comp/PassiveComponentBase.hpp"
 #include "Fw/Port/InputPortBase.hpp"
 #include "Fw/Port/OutputPortBase.hpp"
 #include "Fw/Types/Serializable.hpp"
 #include "Fw/Types/StringType.hpp"
-#include <cstdio>
-#include <cstring>
 
 namespace StringPortStrings {
 


### PR DESCRIPTION
I thought it would be easiest to do these minor changes in a separate PR.

* Consolidate duplicate code in string type generation
* ~Remove system headers -- I don't think they are used~
* Separate system headers from user headers