### PR TITLE
Revise semantic checking of serial port connections

### DIFF
--- a/compiler/lib/src/main/scala/analysis/Semantics/Connection.scala
+++ b/compiler/lib/src/main/scala/analysis/Semantics/Connection.scala
@@ -19,7 +19,7 @@ case class Connection(
     val fromType = fromInstance.getType
     val toInstance = to.port.portInstance
     val toType = toInstance.getType
-    if (PortInstance.Type.areCompatible(fromType, toType)) 
+    if (PortInstance.Type.areCompatible(fromType, toType))
       Right(())
     else {
       val fromTypeString = PortInstance.Type.show(fromType)
@@ -55,7 +55,7 @@ case class Connection(
               msg,
               fromLoc,
               toLoc,
-              None, 
+              None,
               Some(Locations.get(aNode._2.id))
             ))
           case _ => Right(())
@@ -71,7 +71,7 @@ case class Connection(
     val fromDirection = fromInstance.getDirection
     val toInstance = to.port.portInstance
     val toDirection = toInstance.getDirection
-    if (PortInstance.Direction.areCompatible(fromDirection -> toDirection)) 
+    if (PortInstance.Direction.areCompatible(fromDirection -> toDirection))
       Right(())
     else {
       val fromDirString = PortInstance.Direction.show(fromDirection)

--- a/compiler/lib/src/main/scala/util/Error.scala
+++ b/compiler/lib/src/main/scala/util/Error.scala
@@ -106,12 +106,24 @@ sealed trait Error {
         Error.print (Some(loc)) (msg)
       case SemanticError.InvalidComponentInstance(loc, instanceName, topName) =>
         Error.print (Some(loc)) (s"instance $instanceName is not a member of topology $topName")
-      case SemanticError.InvalidConnection(loc, msg, fromLoc, toLoc) =>
+      case SemanticError.InvalidConnection(loc, msg, fromLoc, toLoc, fromPortDefLoc, toPortDefLoc) =>
         Error.print (Some(loc)) (msg)
         System.err.println("from port is specified here:")
         System.err.println(fromLoc)
         System.err.println("to port is specified here:")
         System.err.println(toLoc)
+        fromPortDefLoc match {
+          case Some(loc) =>
+            System.err.println("from port type is defined here:")
+            System.err.println(loc)
+          case _ => ()
+        }
+        toPortDefLoc match {
+          case Some(loc) =>
+            System.err.println("to port type is defined here:")
+            System.err.println(loc)
+          case _ => ()
+        }
       case SemanticError.InvalidDefComponentInstance(name, loc, msg) =>
         Error.print (Some(loc)) (s"invalid component instance definition $name: $msg")
       case SemanticError.InvalidEnumConstants(loc) =>
@@ -349,7 +361,9 @@ object SemanticError {
     loc: Location,
     msg: String,
     fromLoc: Location,
-    toLoc: Location
+    toLoc: Location,
+    fromPortDefLoc: Option[Location] = None,
+    toPortDefLoc: Option[Location] = None
   ) extends Error
   /** Invalid component instance definition */
   final case class InvalidDefComponentInstance(

--- a/compiler/tools/fpp-check/test/connection_direct/instance_not_in_topology.fpp
+++ b/compiler/tools/fpp-check/test/connection_direct/instance_not_in_topology.fpp
@@ -1,16 +1,14 @@
-port P1
-port P2
+port P
 passive component C1 {
-  output port pOut: P1
+  output port pOut: P
 }
 passive component C2 {
-  sync input port pIn: P2
+  sync input port pIn: P
 }
 instance c1: C1 base id 0x100
 instance c2: C2 base id 0x200
 topology T {
   instance c1
-  instance c2
   connections C {
     c1.pOut -> c2.pIn
   }

--- a/compiler/tools/fpp-check/test/connection_direct/instance_not_in_topology.ref.txt
+++ b/compiler/tools/fpp-check/test/connection_direct/instance_not_in_topology.ref.txt
@@ -1,0 +1,5 @@
+fpp-check
+[ local path prefix ]/compiler/tools/fpp-check/test/connection_direct/instance_not_in_topology.fpp: 13.16
+    c1.pOut -> c2.pIn
+               ^
+error: instance c2 is not a member of topology T

--- a/compiler/tools/fpp-check/test/connection_direct/mismatched_port_types.ref.txt
+++ b/compiler/tools/fpp-check/test/connection_direct/mismatched_port_types.ref.txt
@@ -1,5 +1,5 @@
 fpp-check
-[ local path prefix ]/compiler/tools/fpp-check/test/connection_direct/mismatched_port_types.fpp: 13.5
+[ local path prefix ]/compiler/tools/fpp-check/test/connection_direct/mismatched_port_types.fpp: 15.5
     c1.pOut -> c2.pIn
     ^
 error: cannot connect port types P1 and P2

--- a/compiler/tools/fpp-check/test/connection_direct/serial_to_typed_with_return.fpp
+++ b/compiler/tools/fpp-check/test/connection_direct/serial_to_typed_with_return.fpp
@@ -1,10 +1,9 @@
-port P1
-port P2
+port P -> U32
 passive component C1 {
-  output port pOut: P1
+  output port serialOut: serial
 }
 passive component C2 {
-  sync input port pIn: P2
+  sync input port pIn: P
 }
 instance c1: C1 base id 0x100
 instance c2: C2 base id 0x200
@@ -12,6 +11,6 @@ topology T {
   instance c1
   instance c2
   connections C {
-    c1.pOut -> c2.pIn
+    c1.serialOut -> c2.pIn
   }
 }

--- a/compiler/tools/fpp-check/test/connection_direct/serial_to_typed_with_return.ref.txt
+++ b/compiler/tools/fpp-check/test/connection_direct/serial_to_typed_with_return.ref.txt
@@ -1,0 +1,17 @@
+fpp-check
+[ local path prefix ]/compiler/tools/fpp-check/test/connection_direct/serial_to_typed_with_return.fpp: 14.5
+    c1.serialOut -> c2.pIn
+    ^
+error: cannot connect serial output port to input port of type P, which returns a value
+from port is specified here:
+[ local path prefix ]/compiler/tools/fpp-check/test/connection_direct/serial_to_typed_with_return.fpp: 3.3
+  output port serialOut: serial
+  ^
+to port is specified here:
+[ local path prefix ]/compiler/tools/fpp-check/test/connection_direct/serial_to_typed_with_return.fpp: 6.3
+  sync input port pIn: P
+  ^
+to port type is defined here:
+[ local path prefix ]/compiler/tools/fpp-check/test/connection_direct/serial_to_typed_with_return.fpp: 1.1
+port P -> U32
+^

--- a/compiler/tools/fpp-check/test/connection_direct/tests.sh
+++ b/compiler/tools/fpp-check/test/connection_direct/tests.sh
@@ -1,9 +1,11 @@
 tests="
+instance_not_in_topology
+internal_port
 invalid_directions
 invalid_port_instance
 invalid_port_number
-internal_port
 mismatched_port_types
 ok
+serial_to_typed_with_return
 undef_instance
 "

--- a/compiler/tools/fpp-check/test/connection_direct/tests.sh
+++ b/compiler/tools/fpp-check/test/connection_direct/tests.sh
@@ -7,5 +7,6 @@ invalid_port_number
 mismatched_port_types
 ok
 serial_to_typed_with_return
+typed_to_serial_with_return
 undef_instance
 "

--- a/compiler/tools/fpp-check/test/connection_direct/typed_to_serial_with_return.fpp
+++ b/compiler/tools/fpp-check/test/connection_direct/typed_to_serial_with_return.fpp
@@ -1,0 +1,16 @@
+port P -> U32
+passive component C1 {
+  output port pOut: P
+}
+passive component C2 {
+  sync input port serialIn: serial
+}
+instance c1: C1 base id 0x100
+instance c2: C2 base id 0x200
+topology T {
+  instance c1
+  instance c2
+  connections C {
+    c1.pOut -> c2.serialIn
+  }
+}

--- a/compiler/tools/fpp-check/test/connection_direct/typed_to_serial_with_return.ref.txt
+++ b/compiler/tools/fpp-check/test/connection_direct/typed_to_serial_with_return.ref.txt
@@ -1,0 +1,17 @@
+fpp-check
+[ local path prefix ]/compiler/tools/fpp-check/test/connection_direct/typed_to_serial_with_return.fpp: 14.5
+    c1.pOut -> c2.serialIn
+    ^
+error: cannot connect output port of type P, which returns a value, to serial input port
+from port is specified here:
+[ local path prefix ]/compiler/tools/fpp-check/test/connection_direct/typed_to_serial_with_return.fpp: 3.3
+  output port pOut: P
+  ^
+to port is specified here:
+[ local path prefix ]/compiler/tools/fpp-check/test/connection_direct/typed_to_serial_with_return.fpp: 6.3
+  sync input port serialIn: serial
+  ^
+from port type is defined here:
+[ local path prefix ]/compiler/tools/fpp-check/test/connection_direct/typed_to_serial_with_return.fpp: 1.1
+port P -> U32
+^

--- a/docs/fpp-spec.html
+++ b/docs/fpp-spec.html
@@ -3458,9 +3458,9 @@ except that a <code>serial</code> port at either end can be connected
 to any port at the other end.</p>
 </li>
 <li>
-<p>If a <code>serial</code> output port instance is connected to a typed input port
-instance <em>I</em>, then the <a href="#Definitions_Port-Definitions">port type</a>
-specified in <em>I</em> may not have a return type.</p>
+<p>If a <code>serial</code> port instance <em>S</em> is connected to a typed port
+instance <em>T</em>, then the <a href="#Definitions_Port-Definitions">port type</a>
+specified in <em>T</em> may not have a return type.</p>
 </li>
 </ol>
 </div>
@@ -8201,7 +8201,7 @@ equivalent.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2023-01-17 09:52:17 -0800
+Last updated 2023-01-17 13:52:08 -0800
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/fpp-spec.html
+++ b/docs/fpp-spec.html
@@ -3452,9 +3452,15 @@ to an
 <a href="#Specifiers_Port-Instance-Specifiers">input port instance</a>.</p>
 </li>
 <li>
-<p>The types specified in the two port instances must match,
+<p>The <a href="#Specifiers_Port-Instance-Specifiers">port instance types</a>
+specified in the two port instances must match,
 except that a <code>serial</code> port at either end can be connected
 to any port at the other end.</p>
+</li>
+<li>
+<p>If a <code>serial</code> output port instance is connected to a typed input port
+instance <em>I</em>, then the <a href="#Definitions_Port-Definitions">port type</a>
+specified in <em>I</em> may not have a return type.</p>
 </li>
 </ol>
 </div>
@@ -8195,7 +8201,7 @@ equivalent.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2023-01-06 13:47:14 -0800
+Last updated 2023-01-10 13:50:30 -0800
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/fpp-users-guide.html
+++ b/docs/fpp-users-guide.html
@@ -11178,7 +11178,7 @@ function, you may.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2023-01-06 13:48:24 -0800
+Last updated 2023-01-10 13:10:45 -0800
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/fpp-users-guide.html
+++ b/docs/fpp-users-guide.html
@@ -7287,8 +7287,8 @@ type.
 In particular, serial to serial connections are allowed.</p>
 </li>
 <li>
-<p>If a serial output port is connected to a typed input port,
-then the type of the input port may not specify a
+<p>If a typed port <em>P</em> is connected to a serial port in either direction,
+then the port type of <em>P</em> may not specify a
 <a href="#Defining-Ports_Returning-Values">return type</a>.</p>
 </li>
 </ul>
@@ -11242,7 +11242,7 @@ function, you may.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2023-01-17 09:53:36 -0800
+Last updated 2023-01-18 09:03:50 -0800
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/fpp-users-guide.html
+++ b/docs/fpp-users-guide.html
@@ -7179,7 +7179,42 @@ included direct graph specifiers for graphs named
 Here are some more details about direct graph specifiers.</p>
 </div>
 <div class="paragraph">
-<p>Each instance named in a connection must be part of the
+<p>As shown in the previous section, each connection consists
+of an output port specifier, followed by an arrow, followed
+by an input port specifier.
+For example:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="prettyprint highlight"><code data-lang="fpp">connections C {
+  a.p -&gt; b.p
+}</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Each of the two port specifiers consists of a component
+instance name, followed by a dot, followed the name of a port instance.
+The component instance name must refer to a
+<a href="#Defining-Component-Instances">component instance definition</a>
+and may be qualified by a module name.
+For example:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="prettyprint highlight"><code data-lang="fpp">connections C {
+  M.a.p -&gt; N.b.p
+}</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Here component instance <code>a</code> is defined in module <code>M</code> and component
+instance <code>b</code> is defined in module <code>N</code>.
+In a port specifier <code>a.p</code>, the port instance name <code>p</code> must refer to a
+<a href="#Defining-Components_Port-Instances">port instance</a> of the
+component definition associated with the component instance <code>a</code>.</p>
+</div>
+<div class="paragraph">
+<p>Each component instance named in a connection must be part of the
 instance list in the topology.
 For example, if you write a connection <code>a.b -> c.d</code> inside
 a topology <code>T</code>, and the specifier <code>instance a</code> does not
@@ -7228,6 +7263,29 @@ For example, you can write this:</p>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="fpp">connections C { a.p -&gt; b.p, c.p -&gt; d.p }</code></pre>
 </div>
+</div>
+<div class="paragraph">
+<p>The connections appearing in direct graph specifiers must obey the
+following rules:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>Each connection must go from an output port instance to
+an input port instance.</p>
+</li>
+<li>
+<p>The types of the ports must match, except that a
+<a href="#Defining-Components_Port-Instances_Serial-Port-Instances">serial port instance</a> may be connected to a port of any
+type.
+In particular, serial to serial connections are allowed.</p>
+</li>
+<li>
+<p>If a serial output port is connected to a typed input port,
+then the type of the input port may not specify a
+<a href="#Defining-Ports_Returning-Values">return type</a>.</p>
+</li>
+</ul>
 </div>
 </div>
 <div class="sect3">
@@ -11178,7 +11236,7 @@ function, you may.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2023-01-10 13:10:45 -0800
+Last updated 2023-01-10 16:45:43 -0800
 </div>
 </div>
 <script src="code-prettify/run_prettify.js"></script>

--- a/docs/spec/Specifiers/Connection-Graph-Specifiers.adoc
+++ b/docs/spec/Specifiers/Connection-Graph-Specifiers.adoc
@@ -112,9 +112,9 @@ specified in the two port instances must match,
 except that a `serial` port at either end can be connected
 to any port at the other end.
 
-.. If a `serial` output port instance is connected to a typed input port
-instance _I_, then the <<Definitions_Port-Definitions,port type>>
-specified in _I_ may not have a return type.
+.. If a `serial` port instance _S_ is connected to a typed port
+instance _T_, then the <<Definitions_Port-Definitions,port type>>
+specified in _T_ may not have a return type.
 
 *Pattern graph specifiers.*
 A pattern graph specifier indirectly specifies one or more named connection 

--- a/docs/spec/Specifiers/Connection-Graph-Specifiers.adoc
+++ b/docs/spec/Specifiers/Connection-Graph-Specifiers.adoc
@@ -107,9 +107,14 @@ array size of the port instance specifier named in _I_.
 to an
 <<Specifiers_Port-Instance-Specifiers,input port instance>>.
 
-.. The types specified in the two port instances must match,
+.. The <<Specifiers_Port-Instance-Specifiers,port instance types>>
+specified in the two port instances must match,
 except that a `serial` port at either end can be connected
 to any port at the other end.
+
+.. If a `serial` output port instance is connected to a typed input port
+instance _I_, then the <<Definitions_Port-Definitions,port type>>
+specified in _I_ may not have a return type.
 
 *Pattern graph specifiers.*
 A pattern graph specifier indirectly specifies one or more named connection 

--- a/docs/users-guide/Defining-Topologies.adoc
+++ b/docs/users-guide/Defining-Topologies.adoc
@@ -238,8 +238,8 @@ serial port instance>> may be connected to a port of any
 type.
 In particular, serial to serial connections are allowed.
 
-* If a serial output port is connected to a typed input port,
-then the type of the input port may not specify a
+* If a typed port _P_ is connected to a serial port in either direction,
+then the port type of _P_ may not specify a
 <<Defining-Ports_Returning-Values,return type>>.
 
 ==== Pattern Graph Specifiers

--- a/docs/users-guide/Defining-Topologies.adoc
+++ b/docs/users-guide/Defining-Topologies.adoc
@@ -144,7 +144,39 @@ included direct graph specifiers for graphs named
 `C1` and `C2`.
 Here are some more details about direct graph specifiers.
 
-Each instance named in a connection must be part of the
+As shown in the previous section, each connection consists
+of an output port specifier, followed by an arrow, followed
+by an input port specifier.
+For example:
+
+[source,fpp]
+--------
+connections C {
+  a.p -> b.p
+}
+--------
+
+Each of the two port specifiers consists of a component
+instance name, followed by a dot, followed the name of a port instance.
+The component instance name must refer to a
+<<Defining-Component-Instances,component instance definition>>
+and may be qualified by a module name.
+For example:
+
+[source,fpp]
+--------
+connections C {
+  M.a.p -> N.b.p
+}
+--------
+
+Here component instance `a` is defined in module `M` and component
+instance `b` is defined in module `N`.
+In a port specifier `a.p`, the port instance name `p` must refer to a
+<<Defining-Components_Port-Instances,port instance>> of the
+component definition associated with the component instance `a`.
+
+Each component instance named in a connection must be part of the
 instance list in the topology.
 For example, if you write a connection `a.b pass:[->] c.d` inside
 a topology `T`, and the specifier `instance a` does not
@@ -193,6 +225,22 @@ For example, you can write this:
 --------
 connections C { a.p -> b.p, c.p -> d.p }
 --------
+
+The connections appearing in direct graph specifiers must obey the
+following rules:
+
+* Each connection must go from an output port instance to
+an input port instance.
+
+* The types of the ports must match, except that a
+<<Defining-Components_Port-Instances_Serial-Port-Instances,
+serial port instance>> may be connected to a port of any
+type.
+In particular, serial to serial connections are allowed.
+
+* If a serial output port is connected to a typed input port,
+then the type of the input port may not specify a
+<<Defining-Ports_Returning-Values,return type>>.
 
 ==== Pattern Graph Specifiers
 


### PR DESCRIPTION
* Exclude the cases where a serial port is connected to a typed port, and the typed port has a return type.
* Update the spec, implementation, unit tests, and user's guide.
* Make some incidental revisions to the user's guide.

Closes #183.