### PR TITLE
Refactor C++ writer utilities

### DIFF
--- a/compiler/lib/src/main/scala/codegen/CppWriter/ArrayCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ArrayCppWriter.scala
@@ -82,7 +82,7 @@ case class ArrayCppWriter (
     )
     List(
       List(hppIncludes, cppIncludes),
-      CppWriter.wrapInNamespaces(namespaceIdentList, List(cls))
+      wrapInNamespaces(namespaceIdentList, List(cls))
     ).flatten
   }
 
@@ -94,7 +94,7 @@ case class ArrayCppWriter (
     ).map(CppWriter.headerString)
     val symbolHeaders = writeIncludeDirectives(s, aNode)
     val headers = standardHeaders ++ symbolHeaders
-    CppWriter.linesMember(addBlankPrefix(headers.sorted.map(line)))
+    linesMember(addBlankPrefix(headers.sorted.map(line)))
   }
 
   private def getCppIncludes: CppDoc.Member = {
@@ -107,7 +107,7 @@ case class ArrayCppWriter (
       "Fw/Types/StringUtils.hpp",
       s"${s.getRelativePath(fileName).toString}.hpp"
     ).sorted.map(CppWriter.headerString).map(line)
-    CppWriter.linesMember(
+    linesMember(
       List(
         Line.blank :: systemHeaders,
         Line.blank :: userHeaders

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ArrayCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ArrayCppWriter.scala
@@ -8,7 +8,7 @@ import fpp.compiler.util._
 case class ArrayCppWriter (
   s: CppWriterState,
   aNode: Ast.Annotated[AstNode[Ast.DefArray]]
-) extends CppWriterLineUtils {
+) extends CppWriterUtils {
 
   private val node = aNode._2
 

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ConstantCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ConstantCppWriter.scala
@@ -6,7 +6,7 @@ import fpp.compiler.util._
 
 /** Writes out C++ for constant definitions 
  *  Writes only primitive values, enum values, and strings (no structs or arrays) */
-object ConstantCppWriter {
+object ConstantCppWriter extends CppWriterUtils {
 
   /** Writes out constant hpp and cpp */
   def write(s: CppWriterState, tuList: List[Ast.TransUnit]): Result.Result[Any] =
@@ -23,8 +23,8 @@ object ConstantCppWriter {
           val headers = List(path.toString)
           Line.blank :: headers.map(CppWriter.headerLine)
         }
-        val members = CppWriter.linesMember(hppHeaderLines) :: 
-          CppWriter.linesMember(cppHeaderLines, CppDoc.Lines.Cpp) :: 
+        val members = linesMember(hppHeaderLines) ::
+          linesMember(cppHeaderLines, CppDoc.Lines.Cpp) ::
           constantMembers
         val includeGuard = s.includeGuardFromPrefix(fileName)
         val cppDoc = CppWriter.createCppDoc(
@@ -67,7 +67,7 @@ object ConstantCppWriter {
           case Nil => Nil
           case _ => {
             val ls = (Line.blank :: AnnotationCppWriter.writePreComment(aNode)) ++ hppLines
-            List(CppWriter.linesMember(ls))
+            List(linesMember(ls))
           }
         }
       }
@@ -76,7 +76,7 @@ object ConstantCppWriter {
           case Nil => Nil
           case _ => {
             val ls = Line.blank :: cppLines
-            List(CppWriter.linesMember(ls, CppDoc.Lines.Cpp))
+            List(linesMember(ls, CppDoc.Lines.Cpp))
           }
         }
       }
@@ -93,7 +93,7 @@ object ConstantCppWriter {
       members match {
         case Nil => Nil
         case _ =>
-          val namespace = CppWriter.namespaceMember(data.name, members)
+          val namespace = namespaceMember(data.name, members)
           List(namespace)
       }
     }

--- a/compiler/lib/src/main/scala/codegen/CppWriter/CppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/CppWriter.scala
@@ -103,25 +103,6 @@ object CppWriter extends AstStateVisitor with LineUtils {
 
   def headerLine(s: String): Line = line(headerString(s))
 
-  def linesMember(
-    content: List[Line],
-    output: CppDoc.Lines.Output = CppDoc.Lines.Hpp
-  ): CppDoc.Member.Lines = CppDoc.Member.Lines(CppDoc.Lines(content, output))
-
-  def namespaceMember(
-    name: String,
-    members: List[CppDoc.Member]
-  ): CppDoc.Member.Namespace = CppDoc.Member.Namespace(CppDoc.Namespace(name, members))
-
-  def wrapInNamespaces(
-    namespaceNames: List[String],
-    members: List[CppDoc.Member]
-  ): List[CppDoc.Member] = namespaceNames match {
-    case Nil => members
-    case head :: tail =>
-      List(namespaceMember(head, wrapInNamespaces(tail, members)))
-  }
-
   def writeCppDoc(s: State, cppDoc: CppDoc): Result.Result[State] =
     for {
       _ <- writeHppFile(s, cppDoc)

--- a/compiler/lib/src/main/scala/codegen/CppWriter/CppWriterUtils.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/CppWriterUtils.scala
@@ -109,4 +109,95 @@ trait CppWriterUtils extends LineUtils {
       )
     )
 
+  def linesMember(
+    content: List[Line],
+    output: CppDoc.Lines.Output = CppDoc.Lines.Hpp
+  ): CppDoc.Member.Lines = CppDoc.Member.Lines(CppDoc.Lines(content, output))
+
+  def namespaceMember(
+    name: String,
+    members: List[CppDoc.Member]
+  ): CppDoc.Member.Namespace = CppDoc.Member.Namespace(CppDoc.Namespace(name, members))
+
+  def classClassMember(
+    comment: Option[String],
+    name: String,
+    superclassDecls: Option[String],
+    members: List[CppDoc.Class.Member],
+  ): CppDoc.Class.Member.Class =
+    CppDoc.Class.Member.Class(
+      CppDoc.Class(
+        comment,
+        name,
+        superclassDecls,
+        members
+      )
+    )
+
+  def constructorClassMember(
+    comment: Option[String],
+    params: List[CppDoc.Function.Param],
+    initializers: List[String],
+    body: List[Line]
+  ): CppDoc.Class.Member.Constructor =
+    CppDoc.Class.Member.Constructor(
+      CppDoc.Class.Constructor(
+        comment,
+        params,
+        initializers,
+        body
+      )
+    )
+
+  def destructorClassMember(
+    comment: Option[String],
+    body: List[Line],
+    virtualQualifier: CppDoc.Class.Destructor.VirtualQualifier = CppDoc.Class.Destructor.NonVirtual
+  ): CppDoc.Class.Member.Destructor =
+    CppDoc.Class.Member.Destructor(
+      CppDoc.Class.Destructor(
+        comment,
+        body,
+        virtualQualifier
+      )
+    )
+
+  def functionClassMember(
+    comment: Option[String],
+    name: String,
+    params: List[CppDoc.Function.Param],
+    retType: CppDoc.Type,
+    body: List[Line],
+    svQualifier: CppDoc.Function.SVQualifier = CppDoc.Function.NonSV,
+    constQualifier: CppDoc.Function.ConstQualifier = CppDoc.Function.NonConst,
+  ): CppDoc.Class.Member.Function =
+    CppDoc.Class.Member.Function(
+      CppDoc.Function(
+        comment,
+        name,
+        params,
+        retType,
+        body,
+        svQualifier,
+        constQualifier
+      )
+    )
+
+  def linesClassMember(
+   content: List[Line],
+   output: CppDoc.Lines.Output = CppDoc.Lines.Hpp
+ ): CppDoc.Class.Member.Lines =
+    CppDoc.Class.Member.Lines(
+      CppDoc.Lines(content, output)
+    )
+
+  def wrapInNamespaces(
+    namespaceNames: List[String],
+    members: List[CppDoc.Member]
+  ): List[CppDoc.Member] = namespaceNames match {
+    case Nil => members
+    case head :: tail =>
+      List(namespaceMember(head, wrapInNamespaces(tail, members)))
+  }
+
 }

--- a/compiler/lib/src/main/scala/codegen/CppWriter/CppWriterUtils.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/CppWriterUtils.scala
@@ -109,6 +109,42 @@ trait CppWriterUtils extends LineUtils {
       )
     )
 
+  def classMember(
+    comment: Option[String],
+    name: String,
+    superclassDecls: Option[String],
+    members: List[CppDoc.Class.Member],
+  ): CppDoc.Member.Class =
+    CppDoc.Member.Class(
+      CppDoc.Class(
+        comment,
+        name,
+        superclassDecls,
+        members
+      )
+    )
+
+  def functionMember(
+    comment: Option[String],
+    name: String,
+    params: List[CppDoc.Function.Param],
+    retType: CppDoc.Type,
+    body: List[Line],
+    svQualifier: CppDoc.Function.SVQualifier = CppDoc.Function.NonSV,
+    constQualifier: CppDoc.Function.ConstQualifier = CppDoc.Function.NonConst,
+  ): CppDoc.Member.Function =
+    CppDoc.Member.Function(
+      CppDoc.Function(
+        comment,
+        name,
+        params,
+        retType,
+        body,
+        svQualifier,
+        constQualifier
+      )
+    )
+
   def linesMember(
     content: List[Line],
     output: CppDoc.Lines.Output = CppDoc.Lines.Hpp
@@ -118,21 +154,6 @@ trait CppWriterUtils extends LineUtils {
     name: String,
     members: List[CppDoc.Member]
   ): CppDoc.Member.Namespace = CppDoc.Member.Namespace(CppDoc.Namespace(name, members))
-
-  def classClassMember(
-    comment: Option[String],
-    name: String,
-    superclassDecls: Option[String],
-    members: List[CppDoc.Class.Member],
-  ): CppDoc.Class.Member.Class =
-    CppDoc.Class.Member.Class(
-      CppDoc.Class(
-        comment,
-        name,
-        superclassDecls,
-        members
-      )
-    )
 
   def constructorClassMember(
     comment: Option[String],
@@ -184,11 +205,14 @@ trait CppWriterUtils extends LineUtils {
     )
 
   def linesClassMember(
-   content: List[Line],
-   output: CppDoc.Lines.Output = CppDoc.Lines.Hpp
- ): CppDoc.Class.Member.Lines =
+    content: List[Line],
+    output: CppDoc.Lines.Output = CppDoc.Lines.Hpp
+  ): CppDoc.Class.Member.Lines =
     CppDoc.Class.Member.Lines(
-      CppDoc.Lines(content, output)
+      CppDoc.Lines(
+        content,
+        output
+      )
     )
 
   def wrapInNamespaces(

--- a/compiler/lib/src/main/scala/codegen/CppWriter/CppWriterUtils.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/CppWriterUtils.scala
@@ -1,7 +1,7 @@
 package fpp.compiler.codegen
 
-/** Utilities for writing C++ lines */
-trait CppWriterLineUtils extends LineUtils {
+/** Utilities for writing C++ */
+trait CppWriterUtils extends LineUtils {
 
   def wrapInScope(
     s1: String,

--- a/compiler/lib/src/main/scala/codegen/CppWriter/EnumCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/EnumCppWriter.scala
@@ -8,7 +8,7 @@ import fpp.compiler.util._
 case class EnumCppWriter(
   s: CppWriterState,
   aNode: Ast.Annotated[AstNode[Ast.DefEnum]]
-) extends CppWriterLineUtils {
+) extends CppWriterUtils {
 
   private val node = aNode._2
 

--- a/compiler/lib/src/main/scala/codegen/CppWriter/EnumCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/EnumCppWriter.scala
@@ -79,7 +79,7 @@ case class EnumCppWriter(
     )
     List(
       List(hppIncludes, cppIncludes),
-      CppWriter.wrapInNamespaces(namespaceIdentList, List(cls))
+      wrapInNamespaces(namespaceIdentList, List(cls))
     ).flatten
   }
 
@@ -89,7 +89,7 @@ case class EnumCppWriter(
       "Fw/Types/Serializable.hpp",
       "Fw/Types/String.hpp"
     )
-    CppWriter.linesMember(
+    linesMember(
       Line.blank ::
       strings.map(CppWriter.headerString).map(line)
     )
@@ -101,7 +101,7 @@ case class EnumCppWriter(
       "Fw/Types/Assert.hpp",
       s"${s.getRelativePath(fileName).toString}.hpp"
     )
-    CppWriter.linesMember(
+    linesMember(
       List(
         List(Line.blank),
         systemStrings.map(CppWriter.systemHeaderString).map(line),

--- a/compiler/lib/src/main/scala/codegen/CppWriter/PortCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/PortCppWriter.scala
@@ -152,7 +152,7 @@ case class PortCppWriter (
     ).flatten
     List(
       List(hppIncludes, cppIncludes),
-      CppWriter.wrapInNamespaces(namespaceIdentList, classes)
+      wrapInNamespaces(namespaceIdentList, classes)
     ).flatten
   }
 
@@ -176,7 +176,7 @@ case class PortCppWriter (
     ).map(CppWriter.headerString)
     val symbolHeaders = writeIncludeDirectives
     val userHeaders = (standardHeaders ++ symbolHeaders).sorted.map(line)
-    CppWriter.linesMember(
+    linesMember(
       List(
         Line.blank :: systemHeaders,
         Line.blank :: userHeaders
@@ -190,7 +190,7 @@ case class PortCppWriter (
       "Fw/Types/StringUtils.hpp",
       s"${s.getRelativePath(fileName).toString}.hpp"
     ).sorted.map(CppWriter.headerString).map(line)
-    CppWriter.linesMember(
+    linesMember(
       Line.blank :: userHeaders,
       CppDoc.Lines.Cpp
     )
@@ -226,7 +226,7 @@ case class PortCppWriter (
     }).filter(_.isDefined).map(_.get).toList
     strTypes match {
       case Nil => Nil
-      case l => CppWriter.wrapInNamespaces(
+      case l => wrapInNamespaces(
         List(strNamespace),
         strCppWriter.write(l)
       )

--- a/compiler/lib/src/main/scala/codegen/CppWriter/PortCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/PortCppWriter.scala
@@ -119,11 +119,9 @@ case class PortCppWriter (
     val portBufferClass = data.returnType match {
       case Some(_) => Nil
       case None => List(
-        CppDoc.Member.Lines(
-          CppDoc.Lines(
-            Line.blank :: wrapInAnonymousNamespace(getPortBufferClass),
-            CppDoc.Lines.Cpp
-          )
+        linesMember(
+          Line.blank :: wrapInAnonymousNamespace(getPortBufferClass),
+          CppDoc.Lines.Cpp
         )
       )
     }
@@ -132,21 +130,17 @@ case class PortCppWriter (
       getStringTypedefs,
       portBufferClass,
       List(
-        CppDoc.Member.Class(
-          CppDoc.Class(
-            Some(s"Input $name port" + annotation),
-            s"Input${name}Port",
-            Some("public Fw::InputPortBase"),
-            getInputPortClassMembers
-          )
+        classMember(
+          Some(s"Input $name port" + annotation),
+          s"Input${name}Port",
+          Some("public Fw::InputPortBase"),
+          getInputPortClassMembers
         ),
-        CppDoc.Member.Class(
-          CppDoc.Class(
-            Some(s"Output $name port" + annotation),
-            s"Output${name}Port",
-            Some("public Fw::OutputPortBase"),
-            getOutputPortClassMembers
-          )
+        classMember(
+          Some(s"Output $name port" + annotation),
+          s"Output${name}Port",
+          Some("public Fw::OutputPortBase"),
+          getOutputPortClassMembers
         ),
       )
     ).flatten
@@ -199,22 +193,20 @@ case class PortCppWriter (
   private def getStringTypedefs: List[CppDoc.Member] = {
     if strParamList.isEmpty then Nil
     else List(
-      CppDoc.Member.Lines(
-        CppDoc.Lines(
-          List(
-            CppDocWriter.writeBannerComment(
-              "String types for backwards compatibility"
-            ),
-            Line.blank ::
-              strNameMap.flatMap((size, l) => {
-                l.map(strName => line(
-                  s"typedef ${
-                    strCppWriter.getQualifiedClassName(size, List(strNamespace))
-                  } ${strName}String;"
-                ))
-              }).toList
-          ).flatten
-        )
+      linesMember(
+        List(
+          CppDocWriter.writeBannerComment(
+            "String types for backwards compatibility"
+          ),
+          Line.blank ::
+            strNameMap.flatMap((size, l) => {
+              l.map(strName => line(
+                s"typedef ${
+                  strCppWriter.getQualifiedClassName(size, List(strNamespace))
+                } ${strName}String;"
+              ))
+            }).toList
+        ).flatten
       )
     )
   }
@@ -279,27 +271,25 @@ case class PortCppWriter (
 
   private def getInputPortConstantMembers: List[CppDoc.Class.Member] = {
     List(
-      CppDoc.Class.Member.Lines(
-        CppDoc.Lines(
-          List(
-            CppDocHppWriter.writeAccessTag("public"),
-            CppDocWriter.writeBannerComment("Constants"),
-            addBlankPrefix(
-              wrapInEnum(
-                List(
-                  lines("//! The size of the serial representations of the port arguments"),
-                  if params.isEmpty then
-                    lines("SERIALIZED_SIZE = 0")
-                  else
-                    line("SERIALIZED_SIZE =") ::
-                      lines(paramList.map((n, tn, _) =>
-                        s.getSerializedSizeExpr(paramTypeMap(n), tn)
-                      ).mkString(" +\n")).map(indentIn)
-                ).flatten
-              )
+      linesClassMember(
+        List(
+          CppDocHppWriter.writeAccessTag("public"),
+          CppDocWriter.writeBannerComment("Constants"),
+          addBlankPrefix(
+            wrapInEnum(
+              List(
+                lines("//! The size of the serial representations of the port arguments"),
+                if params.isEmpty then
+                  lines("SERIALIZED_SIZE = 0")
+                else
+                  line("SERIALIZED_SIZE =") ::
+                    lines(paramList.map((n, tn, _) =>
+                      s.getSerializedSizeExpr(paramTypeMap(n), tn)
+                    ).mkString(" +\n")).map(indentIn)
+              ).flatten
             )
-          ).flatten
-        )
+          )
+        ).flatten
       )
     )
   }
@@ -316,17 +306,15 @@ case class PortCppWriter (
             }).mkString(",\n")))
 
     List(
-      CppDoc.Class.Member.Lines(
-        CppDoc.Lines(
-          List(
-            CppDocHppWriter.writeAccessTag("public"),
-            CppDocWriter.writeBannerComment("Types"),
-            Line.blank :: lines("//! The port callback function type"),
-            lines(s"typedef $returnType (*CompFuncPtr)("),
-            compFuncParams.map(indentIn),
-            lines(");")
-          ).flatten
-        )
+      linesClassMember(
+        List(
+          CppDocHppWriter.writeAccessTag("public"),
+          CppDocWriter.writeBannerComment("Types"),
+          Line.blank :: lines("//! The port callback function type"),
+          lines(s"typedef $returnType (*CompFuncPtr)("),
+          compFuncParams.map(indentIn),
+          lines(");")
+        ).flatten
       )
     )
   }
@@ -376,119 +364,101 @@ case class PortCppWriter (
     }
 
     List(
-      CppDoc.Class.Member.Lines(
-        CppDoc.Lines(
-          CppDocHppWriter.writeAccessTag("public")
-        )
+      linesClassMember(
+        CppDocHppWriter.writeAccessTag("public")
       ),
-      CppDoc.Class.Member.Lines(
-        CppDoc.Lines(
-          CppDocWriter.writeBannerComment("Input Port Member functions"),
-          CppDoc.Lines.Both
-        )
+      linesClassMember(
+        CppDocWriter.writeBannerComment("Input Port Member functions"),
+        CppDoc.Lines.Both
       ),
-      CppDoc.Class.Member.Constructor(
-        CppDoc.Class.Constructor(
-          Some("Constructor"),
-          Nil,
-          List("Fw::InputPortBase()", "m_func(nullptr)"),
-          Nil
-        )
+      constructorClassMember(
+        Some("Constructor"),
+        Nil,
+        List("Fw::InputPortBase()", "m_func(nullptr)"),
+        Nil
       ),
-      CppDoc.Class.Member.Function(
-        CppDoc.Function(
-          Some("Initialization function"),
-          "init",
-          Nil,
-          CppDoc.Type("void"),
-          lines("Fw::InputPortBase::init();")
-        )
+      functionClassMember(
+        Some("Initialization function"),
+        "init",
+        Nil,
+        CppDoc.Type("void"),
+        lines("Fw::InputPortBase::init();")
       ),
-      CppDoc.Class.Member.Function(
-        CppDoc.Function(
-          Some("Register a component"),
-          "addCallComp",
-          List(
-            CppDoc.Function.Param(
-              CppDoc.Type("Fw::PassiveComponentBase*"),
-              "callComp",
-              Some("The containing component")
-            ),
-            CppDoc.Function.Param(
-              CppDoc.Type("CompFuncPtr"),
-              "funcPtr",
-              Some("The port callback function")
-            )
+      functionClassMember(
+        Some("Register a component"),
+        "addCallComp",
+        List(
+          CppDoc.Function.Param(
+            CppDoc.Type("Fw::PassiveComponentBase*"),
+            "callComp",
+            Some("The containing component")
           ),
-          CppDoc.Type("void"),
-          lines(
-            """|FW_ASSERT(callComp != nullptr);
-               |FW_ASSERT(funcPtr != nullptr);
-               |
-               |this->m_comp = callComp;
-               |this->m_func = funcPtr;
-               |this->m_connObj = callComp;
-               |"""
+          CppDoc.Function.Param(
+            CppDoc.Type("CompFuncPtr"),
+            "funcPtr",
+            Some("The port callback function")
           )
+        ),
+        CppDoc.Type("void"),
+        lines(
+          """|FW_ASSERT(callComp != nullptr);
+             |FW_ASSERT(funcPtr != nullptr);
+             |
+             |this->m_comp = callComp;
+             |this->m_func = funcPtr;
+             |this->m_connObj = callComp;
+             |"""
         )
       ),
-      CppDoc.Class.Member.Function(
-        CppDoc.Function(
-          Some("Invoke a port interface"),
-          "invoke",
-          functionParams,
-          CppDoc.Type(returnType),
-          lines(
-            s"""|#if FW_PORT_TRACING == 1
-                |this->trace();
-                |#endif
-                |
-                |FW_ASSERT(this->m_comp != nullptr);
-                |FW_ASSERT(this->m_func != nullptr);
-                |
-                |return this->m_func(this->m_comp, this->m_portNum${paramNames});
-                |"""
-          )
+      functionClassMember(
+        Some("Invoke a port interface"),
+        "invoke",
+        functionParams,
+        CppDoc.Type(returnType),
+        lines(
+          s"""|#if FW_PORT_TRACING == 1
+              |this->trace();
+              |#endif
+              |
+              |FW_ASSERT(this->m_comp != nullptr);
+              |FW_ASSERT(this->m_func != nullptr);
+              |
+              |return this->m_func(this->m_comp, this->m_portNum${paramNames});
+              |"""
         )
       ),
-      CppDoc.Class.Member.Lines(
-        CppDoc.Lines(
-          CppDocHppWriter.writeAccessTag("private")
-        )
+      linesClassMember(
+        CppDocHppWriter.writeAccessTag("private")
       ),
     ) ++
       wrapClassMembersInIfDirective(
         "\n#if FW_PORT_SERIALIZATION == 1",
         List(
-          CppDoc.Class.Member.Function(
-            CppDoc.Function(
-              Some("Invoke the port with serialized arguments"),
-              "invokeSerial",
-              List(
-                CppDoc.Function.Param(
-                  CppDoc.Type("Fw::SerializeBufferBase&"),
-                  "_buffer"
-                )
-              ),
-              CppDoc.Type("Fw::SerializeStatus"),
-              invokeSerialBody
-            )
+          functionClassMember(
+            Some("Invoke the port with serialized arguments"),
+            "invokeSerial",
+            List(
+              CppDoc.Function.Param(
+                CppDoc.Type("Fw::SerializeBufferBase&"),
+                "_buffer"
+              )
+            ),
+            CppDoc.Type("Fw::SerializeStatus"),
+            invokeSerialBody
           )
-        ),
+        )
       )
   }
 
   private def getInputPortVariableMembers: List[CppDoc.Class.Member] = {
     List(
-      CppDoc.Class.Member.Lines(
-        CppDoc.Lines(
-          List(
-            CppDocHppWriter.writeAccessTag("private"),
-            CppDocWriter.writeBannerComment("Member variables"),
-            Line.blank :: lines("//! The pointer to the port callback function"),
-            lines("CompFuncPtr m_func;")
-          ).flatten
-        )
+      linesClassMember(
+        List(
+          CppDocHppWriter.writeAccessTag("private"),
+          CppDocWriter.writeBannerComment("Member variables"),
+          Line.blank :: lines("//! The pointer to the port callback function"),
+          lines("CompFuncPtr m_func;")
+        ).flatten
       )
     )
   }
@@ -546,88 +516,74 @@ case class PortCppWriter (
     }
 
     List(
-      CppDoc.Class.Member.Lines(
-        CppDoc.Lines(
-          CppDocHppWriter.writeAccessTag("public")
-        )
+      linesClassMember(
+        CppDocHppWriter.writeAccessTag("public")
       ),
-      CppDoc.Class.Member.Lines(
-        CppDoc.Lines(
-          CppDocWriter.writeBannerComment("Output Port Member functions"),
-          CppDoc.Lines.Both
-        )
+      linesClassMember(
+        CppDocWriter.writeBannerComment("Output Port Member functions"),
+        CppDoc.Lines.Both
       ),
-      CppDoc.Class.Member.Constructor(
-        CppDoc.Class.Constructor(
-          Some("Constructor"),
-          Nil,
-          List("Fw::OutputPortBase()", "m_port(nullptr)"),
-          Nil
-        )
+      constructorClassMember(
+        Some("Constructor"),
+        Nil,
+        List("Fw::OutputPortBase()", "m_port(nullptr)"),
+        Nil
       ),
-      CppDoc.Class.Member.Function(
-        CppDoc.Function(
-          Some("Initialization function"),
-          "init",
-          Nil,
-          CppDoc.Type("void"),
-          lines("Fw::OutputPortBase::init();")
-        )
+      functionClassMember(
+        Some("Initialization function"),
+        "init",
+        Nil,
+        CppDoc.Type("void"),
+        lines("Fw::OutputPortBase::init();")
       ),
-      CppDoc.Class.Member.Function(
-        CppDoc.Function(
-          Some("Register an input port"),
-          "addCallPort",
-          List(
-            CppDoc.Function.Param(
-              CppDoc.Type(s"Input${name}Port*"),
-              "callPort",
-              Some("The input port")
-            )
-          ),
-          CppDoc.Type("void"),
-          lines(
-            """|FW_ASSERT(callPort != nullptr);
-               |
-               |this->m_port = callPort;
-               |this->m_connObj = callPort;
-               |
-               |#if FW_PORT_SERIALIZATION == 1
-               |this->m_serPort = nullptr;
-               |#endif
-               |"""
+      functionClassMember(
+        Some("Register an input port"),
+        "addCallPort",
+        List(
+          CppDoc.Function.Param(
+            CppDoc.Type(s"Input${name}Port*"),
+            "callPort",
+            Some("The input port")
           )
+        ),
+        CppDoc.Type("void"),
+        lines(
+          """|FW_ASSERT(callPort != nullptr);
+             |
+             |this->m_port = callPort;
+             |this->m_connObj = callPort;
+             |
+             |#if FW_PORT_SERIALIZATION == 1
+             |this->m_serPort = nullptr;
+             |#endif
+             |"""
         )
       ),
-      CppDoc.Class.Member.Function(
-        CppDoc.Function(
-          Some("Invoke a port interface"),
-          "invoke",
-          functionParams,
-          CppDoc.Type(returnType),
-          lines(
-            s"""|#if FW_PORT_TRACING == 1
-                |this->trace();
-                |#endif
-                |"""
-          ) ++
-            invokeBody
-        )
+      functionClassMember(
+        Some("Invoke a port interface"),
+        "invoke",
+        functionParams,
+        CppDoc.Type(returnType),
+        lines(
+          s"""|#if FW_PORT_TRACING == 1
+              |this->trace();
+              |#endif
+              |"""
+        ) ++
+          invokeBody
       )
     )
   }
 
   private def getOutputPortVariableMembers: List[CppDoc.Class.Member] = {
     List(
-      CppDoc.Class.Member.Lines(
-        CppDoc.Lines(
-          List(
-            CppDocHppWriter.writeAccessTag("private"),
-            CppDocWriter.writeBannerComment("Member variables"),
-            Line.blank :: lines("//! The pointer to the input port"),
-            lines(s"Input${name}Port* m_port;")
-          ).flatten
-        )
+      linesClassMember(
+        List(
+          CppDocHppWriter.writeAccessTag("private"),
+          CppDocWriter.writeBannerComment("Member variables"),
+          Line.blank :: lines("//! The pointer to the input port"),
+          lines(s"Input${name}Port* m_port;")
+        ).flatten
       )
     )
   }

--- a/compiler/lib/src/main/scala/codegen/CppWriter/PortCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/PortCppWriter.scala
@@ -7,7 +7,7 @@ import fpp.compiler.util._
 case class PortCppWriter (
   s: CppWriterState,
   aNode: Ast.Annotated[AstNode[Ast.DefPort]]
-) extends CppWriterLineUtils {
+) extends CppWriterUtils {
 
   private val node = aNode._2
 

--- a/compiler/lib/src/main/scala/codegen/CppWriter/StringCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/StringCppWriter.scala
@@ -64,10 +64,8 @@ case class StringCppWriter(
 
   /** Writes the C++ string classes as nested classes */
   def writeNested(strTypes: List[Type.String]): List[CppDoc.Class.Member] =
-    CppDoc.Class.Member.Lines(
-      CppDoc.Lines(
-        CppDocHppWriter.writeAccessTag("public")
-      )
+    linesClassMember(
+      CppDocHppWriter.writeAccessTag("public")
     ) ::
       writeHelper(
         strTypes,
@@ -87,176 +85,152 @@ case class StringCppWriter(
   private def getClassMembers(size: Int): List[CppDoc.Class.Member] = {
     val name = getClassName(size)
     List(
-      CppDoc.Class.Member.Lines(
-        CppDoc.Lines(
-          List(
-            CppDocHppWriter.writeAccessTag("public"),
-            addBlankPrefix(
-              wrapInEnum(
-                List(
-                  line("//! The size of the string length plus the size of the string buffer"),
-                  line(s"SERIALIZED_SIZE = sizeof(FwBuffSizeType) + $size")
-                )
+      linesClassMember(
+        List(
+          CppDocHppWriter.writeAccessTag("public"),
+          addBlankPrefix(
+            wrapInEnum(
+              List(
+                line("//! The size of the string length plus the size of the string buffer"),
+                line(s"SERIALIZED_SIZE = sizeof(FwBuffSizeType) + $size")
               )
-            ),
-          ).flatten
-        )
-      ),
-      CppDoc.Class.Member.Constructor(
-        CppDoc.Class.Constructor(
-          Some("Default constructor"),
-          Nil,
-          List("StringBase()"),
-          lines("this->m_buf[0] = 0;")
-        )
-      ),
-      CppDoc.Class.Member.Constructor(
-        CppDoc.Class.Constructor(
-          Some("Char array constructor"),
-          List(
-            CppDoc.Function.Param(
-              CppDoc.Type("const char*"),
-              "src",
-              None
             )
           ),
-          List("StringBase()"),
-          lines(
-            "Fw::StringUtils::string_copy(this->m_buf, src, sizeof(this->m_buf));"
+        ).flatten
+      ),
+      constructorClassMember(
+        Some("Default constructor"),
+        Nil,
+        List("StringBase()"),
+        lines("this->m_buf[0] = 0;")
+      ),
+      constructorClassMember(
+        Some("Char array constructor"),
+        List(
+          CppDoc.Function.Param(
+            CppDoc.Type("const char*"),
+            "src",
+            None
           )
+        ),
+        List("StringBase()"),
+        lines(
+          "Fw::StringUtils::string_copy(this->m_buf, src, sizeof(this->m_buf));"
         )
       ),
-      CppDoc.Class.Member.Constructor(
-        CppDoc.Class.Constructor(
-          Some("String base constructor"),
-          List(
-            CppDoc.Function.Param(
-              CppDoc.Type("const Fw::StringBase&"),
-              "src",
-              None
-            )
-          ),
-          List("StringBase()"),
-          lines(
-            "Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));"
+      constructorClassMember(
+        Some("String base constructor"),
+        List(
+          CppDoc.Function.Param(
+            CppDoc.Type("const Fw::StringBase&"),
+            "src",
+            None
           )
+        ),
+        List("StringBase()"),
+        lines(
+          "Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));"
         )
       ),
-      CppDoc.Class.Member.Constructor(
-        CppDoc.Class.Constructor(
-          Some("Copy constructor"),
-          List(
-            CppDoc.Function.Param(
-              CppDoc.Type(s"const $name&"),
-              "src",
-              None
-            )
-          ),
-          List("StringBase()"),
-          lines(
-            "Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));"
+      constructorClassMember(
+        Some("Copy constructor"),
+        List(
+          CppDoc.Function.Param(
+            CppDoc.Type(s"const $name&"),
+            "src",
+            None
           )
+        ),
+        List("StringBase()"),
+        lines(
+          "Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));"
         )
       ),
-      CppDoc.Class.Member.Destructor(
-        CppDoc.Class.Destructor(
-          Some("Destructor"),
-          Nil
-        )
+      destructorClassMember(
+        Some("Destructor"),
+        Nil
       ),
-      CppDoc.Class.Member.Function(
-        CppDoc.Function(
-          Some("Copy assignment operator"),
-          "operator=",
+      functionClassMember(
+        Some("Copy assignment operator"),
+        "operator=",
+        List(
+          CppDoc.Function.Param(
+            CppDoc.Type(s"const $name&"),
+            "other",
+            None
+          )
+        ),
+        getCppType(s"$name&"),
+        List(
+          wrapInIf("this == &other", lines("return *this;")),
           List(
-            CppDoc.Function.Param(
-              CppDoc.Type(s"const $name&"),
-              "other",
-              None
-            )
-          ),
-          getCppType(s"$name&"),
-          List(
-            wrapInIf("this == &other", lines("return *this;")),
-            List(
-              Line.blank,
-              line("Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));"),
-              line("return *this;"),
-            ),
-          ).flatten
-        )
-      ),
-      CppDoc.Class.Member.Function(
-        CppDoc.Function(
-          Some("String base assignment operator"),
-          "operator=",
-          List(
-            CppDoc.Function.Param(
-              CppDoc.Type("const Fw::StringBase&"),
-              "other",
-              None
-            )
-          ),
-          getCppType(s"$name&"),
-          List(
-            wrapInIf("this == &other", lines("return *this;")),
-            List(
-              Line.blank,
-              line("Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));"),
-              line("return *this;"),
-            ),
-          ).flatten
-        )
-      ),
-      CppDoc.Class.Member.Function(
-        CppDoc.Function(
-          Some("char* assignment operator"),
-          "operator=",
-          List(
-            CppDoc.Function.Param(
-              CppDoc.Type("const char*"),
-              "other",
-              None
-            )
-          ),
-          getCppType(s"$name&"),
-          List(
-            line("Fw::StringUtils::string_copy(this->m_buf, other, sizeof(this->m_buf));"),
+            Line.blank,
+            line("Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));"),
             line("return *this;"),
+          ),
+        ).flatten
+      ),
+      functionClassMember(
+        Some("String base assignment operator"),
+        "operator=",
+        List(
+          CppDoc.Function.Param(
+            CppDoc.Type("const Fw::StringBase&"),
+            "other",
+            None
           )
-        )
-      ),
-      CppDoc.Class.Member.Function(
-        CppDoc.Function(
-          Some("Retrieves char buffer of string"),
-          "toChar",
-          Nil,
-          CppDoc.Type("const char*"),
-          lines("return this->m_buf;"),
-          CppDoc.Function.NonSV,
-          CppDoc.Function.Const
-        )
-      ),
-      CppDoc.Class.Member.Function(
-        CppDoc.Function(
-          None,
-          "getCapacity",
-          Nil,
-          CppDoc.Type("NATIVE_UINT_TYPE"),
-          lines("return sizeof(this->m_buf);"),
-          CppDoc.Function.NonSV,
-          CppDoc.Function.Const
-        )
-      ),
-      CppDoc.Class.Member.Lines(
-        CppDoc.Lines(
+        ),
+        getCppType(s"$name&"),
+        List(
+          wrapInIf("this == &other", lines("return *this;")),
           List(
-            CppDocHppWriter.writeAccessTag("private"),
-            addBlankPrefix(lines(
-              s"char m_buf[$size]; //!< Buffer for string storage"
-            )),
-          ).flatten
+            Line.blank,
+            line("Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));"),
+            line("return *this;"),
+          ),
+        ).flatten
+      ),
+      functionClassMember(
+        Some("char* assignment operator"),
+        "operator=",
+        List(
+          CppDoc.Function.Param(
+            CppDoc.Type("const char*"),
+            "other",
+            None
+          )
+        ),
+        getCppType(s"$name&"),
+        List(
+          line("Fw::StringUtils::string_copy(this->m_buf, other, sizeof(this->m_buf));"),
+          line("return *this;"),
         )
+      ),
+      functionClassMember(
+        Some("Retrieves char buffer of string"),
+        "toChar",
+        Nil,
+        CppDoc.Type("const char*"),
+        lines("return this->m_buf;"),
+        CppDoc.Function.NonSV,
+        CppDoc.Function.Const
+      ),
+      functionClassMember(
+        None,
+        "getCapacity",
+        Nil,
+        CppDoc.Type("NATIVE_UINT_TYPE"),
+        lines("return sizeof(this->m_buf);"),
+        CppDoc.Function.NonSV,
+        CppDoc.Function.Const
+      ),
+      linesClassMember(
+        List(
+          CppDocHppWriter.writeAccessTag("private"),
+          addBlankPrefix(lines(
+            s"char m_buf[$size]; //!< Buffer for string storage"
+          )),
+        ).flatten
       )
     )
   }

--- a/compiler/lib/src/main/scala/codegen/CppWriter/StringCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/StringCppWriter.scala
@@ -11,7 +11,7 @@ case class StringCppWriter(
   s: CppWriterState,
   /** Enclosing class name, including any qualifiers */
   enclosingClassQualified: Option[String] = None
-) extends CppWriterLineUtils {
+) extends CppWriterUtils {
 
   /** Get max string size */
   def getSize(str: Type.String): Int = str.size match {

--- a/compiler/lib/src/main/scala/codegen/CppWriter/StructCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/StructCppWriter.scala
@@ -94,7 +94,7 @@ case class StructCppWriter(
       // If struct is empty, write an empty .cpp file
       if memberList.isEmpty then List(hppIncludes)
       else List(hppIncludes, cppIncludes),
-      CppWriter.wrapInNamespaces(namespaceIdentList, List(cls))
+      wrapInNamespaces(namespaceIdentList, List(cls))
     ).flatten
   }
 
@@ -111,7 +111,7 @@ case class StructCppWriter(
     ).map(CppWriter.headerString)
     val symbolHeaders = writeIncludeDirectives
     val headers = userHeaders ++ symbolHeaders
-    CppWriter.linesMember(addBlankPrefix(headers.sorted.map(line)))
+    linesMember(addBlankPrefix(headers.sorted.map(line)))
   }
 
   private def getCppIncludes: CppDoc.Member = {
@@ -124,7 +124,7 @@ case class StructCppWriter(
       "Fw/Types/StringUtils.hpp",
       s"${s.getRelativePath(fileName).toString}.hpp",
     ).sorted.map(CppWriter.headerString).map(line)
-    CppWriter.linesMember(
+    linesMember(
       List(
         Line.blank :: systemheaders,
         Line.blank :: userHeaders,

--- a/compiler/lib/src/main/scala/codegen/CppWriter/StructCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/StructCppWriter.scala
@@ -7,7 +7,7 @@ import fpp.compiler.ast._
 case class StructCppWriter(
   s: CppWriterState,
   aNode: Ast.Annotated[AstNode[Ast.DefStruct]]
-) extends CppWriterLineUtils {
+) extends CppWriterUtils {
 
   private val node = aNode._2
 

--- a/compiler/lib/src/main/scala/codegen/CppWriter/StructCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/StructCppWriter.scala
@@ -80,15 +80,13 @@ case class StructCppWriter(
   private def getMembers: List[CppDoc.Member] = {
     val hppIncludes = getHppIncludes
     val cppIncludes = getCppIncludes
-    val cls = CppDoc.Member.Class(
-      CppDoc.Class(
-        AnnotationCppWriter.asStringOpt(aNode),
-        name,
-        Some("public Fw::Serializable"),
-        // If struct is empty, write an empty class
-        if memberList.isEmpty then Nil
-        else getClassMembers
-      )
+    val cls = classMember(
+      AnnotationCppWriter.asStringOpt(aNode),
+      name,
+      Some("public Fw::Serializable"),
+      // If struct is empty, write an empty class
+      if memberList.isEmpty then Nil
+      else getClassMembers
     )
     List(
       // If struct is empty, write an empty .cpp file
@@ -157,24 +155,22 @@ case class StructCppWriter(
 
   private def getConstantMembers: List[CppDoc.Class.Member] =
     List(
-      CppDoc.Class.Member.Lines(
-        CppDoc.Lines(
-          CppDocHppWriter.writeAccessTag("public") ++
-            CppDocWriter.writeBannerComment("Constants") ++
-            addBlankPrefix(
-              wrapInEnum(
-                List(
-                  lines("//! The size of the serial representation"),
-                  lines("SERIALIZED_SIZE ="),
-                  lines(memberList.map((n, tn) =>
-                    s.getSerializedSizeExpr(members(n), tn) + (
-                      if sizes.contains(n) then s" * ${sizes(n)}"
-                      else ""
-                      )).mkString(" +\n")).map(indentIn),
-                ).flatten
-              )
+      linesClassMember(
+        CppDocHppWriter.writeAccessTag("public") ++
+          CppDocWriter.writeBannerComment("Constants") ++
+          addBlankPrefix(
+            wrapInEnum(
+              List(
+                lines("//! The size of the serial representation"),
+                lines("SERIALIZED_SIZE ="),
+                lines(memberList.map((n, tn) =>
+                  s.getSerializedSizeExpr(members(n), tn) + (
+                    if sizes.contains(n) then s" * ${sizes(n)}"
+                    else ""
+                    )).mkString(" +\n")).map(indentIn),
+              ).flatten
             )
-        )
+          )
       )
     )
 
@@ -183,17 +179,15 @@ case class StructCppWriter(
     else
       // Write types for array members to simplify C++ array reference syntax
       List(
-        CppDoc.Class.Member.Lines(
-          CppDoc.Lines(
-            List(
-              CppDocHppWriter.writeAccessTag("public"),
-              CppDocWriter.writeBannerComment("Types"),
-              Line.blank :: lines("//! The array member types"),
-              memberList.filter((n, _) => sizes.contains(n)).map((n, tn) =>
-                line(s"typedef $tn ${getArrayTypeName(n)}[${sizes(n)}];")
-              )
-            ).flatten
-          )
+        linesClassMember(
+          List(
+            CppDocHppWriter.writeAccessTag("public"),
+            CppDocWriter.writeBannerComment("Types"),
+            Line.blank :: lines("//! The array member types"),
+            memberList.filter((n, _) => sizes.contains(n)).map((n, tn) =>
+              line(s"typedef $tn ${getArrayTypeName(n)}[${sizes(n)}];")
+            )
+          ).flatten
         )
       )
 
@@ -203,63 +197,51 @@ case class StructCppWriter(
     val scalarConstructor =
       if sizes.isEmpty then None
       else Some(
-        CppDoc.Class.Member.Constructor(
-          CppDoc.Class.Constructor(
-            Some("Member constructor (scalar values for arrays)"),
-            memberList.map(writeMemberAsParamScalar),
-            writeInitializerList(n => n),
-            writeArraySetters(n => n)
-          )
+        constructorClassMember(
+          Some("Member constructor (scalar values for arrays)"),
+          memberList.map(writeMemberAsParamScalar),
+          writeInitializerList(n => n),
+          writeArraySetters(n => n)
         )
       )
 
     List(
-      CppDoc.Class.Member.Lines(
-        CppDoc.Lines(
-          CppDocHppWriter.writeAccessTag("public")
-        )
+      linesClassMember(
+        CppDocHppWriter.writeAccessTag("public")
       ),
-      CppDoc.Class.Member.Lines(
-        CppDoc.Lines(
-          CppDocWriter.writeBannerComment("Constructors"),
-          CppDoc.Lines.Both
-        )
+      linesClassMember(
+        CppDocWriter.writeBannerComment("Constructors"),
+        CppDoc.Lines.Both
       ),
-      CppDoc.Class.Member.Constructor(
-        CppDoc.Class.Constructor(
-          Some("Constructor (default value)"),
-          Nil,
-          "Serializable()" :: nonArrayMemberNames.map(n => {
-            defaultValues(n) match {
-              case v: Value.Struct => s"$n(${ValueCppWriter.writeStructMembers(s, v)})"
-              case _: Value.AbsType => s"$n()"
-              case v => s"$n(${ValueCppWriter.write(s, v)})"
-            }
-          }),
-          writeArraySetters(n => ValueCppWriter.write(s, defaultValues(n)))
-        )
+      constructorClassMember(
+        Some("Constructor (default value)"),
+        Nil,
+        "Serializable()" :: nonArrayMemberNames.map(n => {
+          defaultValues(n) match {
+            case v: Value.Struct => s"$n(${ValueCppWriter.writeStructMembers(s, v)})"
+            case _: Value.AbsType => s"$n()"
+            case v => s"$n(${ValueCppWriter.write(s, v)})"
+          }
+        }),
+        writeArraySetters(n => ValueCppWriter.write(s, defaultValues(n)))
       ),
-      CppDoc.Class.Member.Constructor(
-        CppDoc.Class.Constructor(
-          Some("Member constructor"),
-          memberList.map(writeMemberAsParam),
-          writeInitializerList(n => n),
-          writeArraySetters(n => s"$n[i]")
-        )
+      constructorClassMember(
+        Some("Member constructor"),
+        memberList.map(writeMemberAsParam),
+        writeInitializerList(n => n),
+        writeArraySetters(n => s"$n[i]")
       ),
-      CppDoc.Class.Member.Constructor(
-        CppDoc.Class.Constructor(
-          Some("Copy constructor"),
-          List(
-            CppDoc.Function.Param(
-              CppDoc.Type(s"const $name&"),
-              "obj",
-              Some("The source object")
-            )
-          ),
-          writeInitializerList(n => s"obj.$n"),
-          writeArraySetters(n => s"obj.$n[i]")
-        )
+      constructorClassMember(
+        Some("Copy constructor"),
+        List(
+          CppDoc.Function.Param(
+            CppDoc.Type(s"const $name&"),
+            "obj",
+            Some("The source object")
+          )
+        ),
+        writeInitializerList(n => s"obj.$n"),
+        writeArraySetters(n => s"obj.$n[i]")
       ),
     ) ++
       scalarConstructor
@@ -312,78 +294,66 @@ case class StructCppWriter(
       ).flatten
 
     List(
-      CppDoc.Class.Member.Lines(
-        CppDoc.Lines(
-          CppDocHppWriter.writeAccessTag("public")
-        )
+      linesClassMember(
+        CppDocHppWriter.writeAccessTag("public")
       ),
-      CppDoc.Class.Member.Lines(
-        CppDoc.Lines(
-          CppDocWriter.writeBannerComment("Operators"),
-          CppDoc.Lines.Both
-        )
+      linesClassMember(
+        CppDocWriter.writeBannerComment("Operators"),
+        CppDoc.Lines.Both
       ),
-      CppDoc.Class.Member.Function(
-        CppDoc.Function(
-          Some("Copy assignment operator"),
-          "operator=",
-          List(
-            CppDoc.Function.Param(
-              CppDoc.Type(s"const $name&"),
-              "obj",
-              Some("The source object")
-            ),
+      functionClassMember(
+        Some("Copy assignment operator"),
+        "operator=",
+        List(
+          CppDoc.Function.Param(
+            CppDoc.Type(s"const $name&"),
+            "obj",
+            Some("The source object")
           ),
-          CppDoc.Type(s"$name&"),
-          List(
-            wrapInIf("this == &obj", lines("return *this;")),
-            Line.blank :: lines(
-              s"set(${memberNames.map(n => s"obj.$n").mkString(", ")});"
-            ),
-            lines("return *this;"),
-          ).flatten
-        )
-      ),
-      CppDoc.Class.Member.Function(
-        CppDoc.Function(
-          Some("Equality operator"),
-          "operator==",
-          List(
-            CppDoc.Function.Param(
-              CppDoc.Type(s"const $name&"),
-              "obj",
-              Some("The other object")
-            )
-          ),
-          CppDoc.Type("bool"),
-          equalityOpBody,
-          CppDoc.Function.NonSV,
-          CppDoc.Function.Const
         ),
-      ),
-      CppDoc.Class.Member.Function(
-        CppDoc.Function(
-          Some("Inequality operator"),
-          "operator!=",
-          List(
-            CppDoc.Function.Param(
-              CppDoc.Type(s"const $name&"),
-              "obj",
-              Some("The other object")
-            )
+        CppDoc.Type(s"$name&"),
+        List(
+          wrapInIf("this == &obj", lines("return *this;")),
+          Line.blank :: lines(
+            s"set(${memberNames.map(n => s"obj.$n").mkString(", ")});"
           ),
-          CppDoc.Type("bool"),
-          lines("return !(*this == obj);"),
-          CppDoc.Function.NonSV,
-          CppDoc.Function.Const
+          lines("return *this;"),
+        ).flatten
+      ),
+      functionClassMember(
+        Some("Equality operator"),
+        "operator==",
+        List(
+          CppDoc.Function.Param(
+            CppDoc.Type(s"const $name&"),
+            "obj",
+            Some("The other object")
+          )
         ),
+        CppDoc.Type("bool"),
+        equalityOpBody,
+        CppDoc.Function.NonSV,
+        CppDoc.Function.Const
+      ),
+      functionClassMember(
+        Some("Inequality operator"),
+        "operator!=",
+        List(
+          CppDoc.Function.Param(
+            CppDoc.Type(s"const $name&"),
+            "obj",
+            Some("The other object")
+          )
+        ),
+        CppDoc.Type("bool"),
+        lines("return !(*this == obj);"),
+        CppDoc.Function.NonSV,
+        CppDoc.Function.Const
       ),
     ) ++ (
-      CppDoc.Class.Member.Lines(
-        CppDoc.Lines(
-          List(Line.blank),
-          CppDoc.Lines.Both
-        )
+      linesClassMember(
+        List(Line.blank),
+        CppDoc.Lines.Both
       ) :: writeOstreamOperator(
         name,
         lines(
@@ -440,151 +410,139 @@ case class StructCppWriter(
 
     List(
       List(
-        CppDoc.Class.Member.Lines(
-          CppDoc.Lines(CppDocHppWriter.writeAccessTag("public"))
+        linesClassMember(
+          CppDocHppWriter.writeAccessTag("public")
         ),
-        CppDoc.Class.Member.Lines(
-          CppDoc.Lines(
-            CppDocWriter.writeBannerComment("Member functions"),
-            CppDoc.Lines.Both
-          )
+        linesClassMember(
+          CppDocWriter.writeBannerComment("Member functions"),
+          CppDoc.Lines.Both
         ),
-        CppDoc.Class.Member.Function(
-          CppDoc.Function(
-            Some("Serialization"),
-            "serialize",
-            List(
-              CppDoc.Function.Param(
-                CppDoc.Type("Fw::SerializeBufferBase&"),
-                "buffer",
-                Some("The serial buffer")
-              )
-            ),
-            CppDoc.Type("Fw::SerializeStatus"),
-            List(
-              lines("Fw::SerializeStatus status;"),
-              Line.blank :: memberNames.flatMap(n =>
-                if sizes.contains(n) then
-                  iterateN(sizes(n), writeSerializeCall(s"$n[i]"))
-                else
-                  writeSerializeCall(n)
-              ),
-              Line.blank :: lines("return status;"),
-            ).flatten,
-            CppDoc.Function.NonSV,
-            CppDoc.Function.Const
+        functionClassMember(
+          Some("Serialization"),
+          "serialize",
+          List(
+            CppDoc.Function.Param(
+              CppDoc.Type("Fw::SerializeBufferBase&"),
+              "buffer",
+              Some("The serial buffer")
+            )
           ),
-        ),
-        CppDoc.Class.Member.Function(
-          CppDoc.Function(
-            Some("Deserialization"),
-            "deserialize",
-            List(
-              CppDoc.Function.Param(
-                CppDoc.Type("Fw::SerializeBufferBase&"),
-                "buffer",
-                Some("The serial buffer")
-              )
+          CppDoc.Type("Fw::SerializeStatus"),
+          List(
+            lines("Fw::SerializeStatus status;"),
+            Line.blank :: memberNames.flatMap(n =>
+              if sizes.contains(n) then
+                iterateN(sizes(n), writeSerializeCall(s"$n[i]"))
+              else
+                writeSerializeCall(n)
             ),
-            CppDoc.Type("Fw::SerializeStatus"),
-            List(
-              lines("Fw::SerializeStatus status;"),
-              Line.blank :: memberNames.flatMap(n =>
-                if sizes.contains(n) then
-                  iterateN(sizes(n), writeDeserializeCall(s"$n[i]"))
-                else
-                  writeDeserializeCall(n)
-              ),
-              Line.blank :: lines("return status;"),
-            ).flatten
-          )
+            Line.blank :: lines("return status;"),
+          ).flatten,
+          CppDoc.Function.NonSV,
+          CppDoc.Function.Const
         ),
+        functionClassMember(
+          Some("Deserialization"),
+          "deserialize",
+          List(
+            CppDoc.Function.Param(
+              CppDoc.Type("Fw::SerializeBufferBase&"),
+              "buffer",
+              Some("The serial buffer")
+            )
+          ),
+          CppDoc.Type("Fw::SerializeStatus"),
+          List(
+            lines("Fw::SerializeStatus status;"),
+            Line.blank :: memberNames.flatMap(n =>
+              if sizes.contains(n) then
+                iterateN(sizes(n), writeDeserializeCall(s"$n[i]"))
+              else
+                writeDeserializeCall(n)
+            ),
+            Line.blank :: lines("return status;"),
+          ).flatten
+        )
       ),
       wrapClassMembersInIfDirective(
         "\n#if FW_SERIALIZABLE_TO_STRING || BUILD_UT",
         List(
-          CppDoc.Class.Member.Function(
-            CppDoc.Function(
-              Some("Convert struct to string"),
-              "toString",
-              List(
-                CppDoc.Function.Param(
-                  CppDoc.Type("Fw::StringBase&"),
-                  "sb",
-                  Some("The StringBase object to hold the result")
+          functionClassMember(
+            Some("Convert struct to string"),
+            "toString",
+            List(
+              CppDoc.Function.Param(
+                CppDoc.Type("Fw::StringBase&"),
+                "sb",
+                Some("The StringBase object to hold the result")
+              )
+            ),
+            CppDoc.Type("void"),
+            List(
+              lines("static const char* formatString ="),
+              lines(typeMembers.flatMap((_, node, _) => {
+                val n = node.data.name
+                val formatStr = FormatCppWriter.write(
+                  getFormatStr(n),
+                  node.data.typeName
                 )
-              ),
-              CppDoc.Type("void"),
-              List(
-                lines("static const char* formatString ="),
-                lines(typeMembers.flatMap((_, node, _) => {
-                  val n = node.data.name
-                  val formatStr = FormatCppWriter.write(
-                    getFormatStr(n),
-                    node.data.typeName
-                  )
-                  if sizes.contains(n) then {
-                    if sizes(n) == 1 then
-                      List(s"$n = [ $formatStr ]")
-                    else
-                      s"$n = [ $formatStr" ::
-                        List.fill(sizes(n) - 2)(formatStr) ++
-                          List(s"$formatStr ]")
-                  } else
-                    List(s"$n = $formatStr")
-                }).mkString("\"( \"\n\"", ", \"\n\"", "\"\n\" )\";")).map(indentIn),
-                initStrings,
-                Line.blank ::
-                  lines("char outputString[FW_SERIALIZABLE_TO_STRING_BUFFER_SIZE];"),
-                wrapInScope(
-                  "(void) snprintf(",
-                  List(
-                    List(
-                      line("outputString,"),
-                      line("FW_SERIALIZABLE_TO_STRING_BUFFER_SIZE,"),
-                      line("formatString,"),
-                    ),
-                    // Write format arguments
-                    lines(memberList.flatMap((n, tn) =>
-                      (sizes.contains(n), members(n)) match {
-                        case (false, _: Type.String) =>
-                          List(s"this->$n.toChar()")
-                        case (false, t) if s.isPrimitive(t, tn) =>
-                          List(s"this->$n")
-                        case (false, _) =>
-                          List(s"${n}Str.toChar()")
-                        case (true, _: Type.String) =>
-                          List.range(0, sizes(n)).map(i => s"this->$n[$i].toChar()")
-                        case (true, t) if s.isPrimitive(t, tn) =>
-                          List.range(0, sizes(n)).map(i => s"this->$n[$i]")
-                        case _ =>
-                          List.range(0, sizes(n)).map(i => s"${n}Str[$i].toChar()")
-                      }).mkString(",\n")),
-                  ).flatten,
-                  ");"
-                ),
+                if sizes.contains(n) then {
+                  if sizes(n) == 1 then
+                    List(s"$n = [ $formatStr ]")
+                  else
+                    s"$n = [ $formatStr" ::
+                      List.fill(sizes(n) - 2)(formatStr) ++
+                        List(s"$formatStr ]")
+                } else
+                  List(s"$n = $formatStr")
+              }).mkString("\"( \"\n\"", ", \"\n\"", "\"\n\" )\";")).map(indentIn),
+              initStrings,
+              Line.blank ::
+                lines("char outputString[FW_SERIALIZABLE_TO_STRING_BUFFER_SIZE];"),
+              wrapInScope(
+                "(void) snprintf(",
                 List(
-                  Line.blank,
-                  line("outputString[FW_SERIALIZABLE_TO_STRING_BUFFER_SIZE-1] = 0; // NULL terminate"),
-                  line("sb = outputString;"),
-                ),
-              ).flatten,
-              CppDoc.Function.NonSV,
-              CppDoc.Function.Const
-            )
+                  List(
+                    line("outputString,"),
+                    line("FW_SERIALIZABLE_TO_STRING_BUFFER_SIZE,"),
+                    line("formatString,"),
+                  ),
+                  // Write format arguments
+                  lines(memberList.flatMap((n, tn) =>
+                    (sizes.contains(n), members(n)) match {
+                      case (false, _: Type.String) =>
+                        List(s"this->$n.toChar()")
+                      case (false, t) if s.isPrimitive(t, tn) =>
+                        List(s"this->$n")
+                      case (false, _) =>
+                        List(s"${n}Str.toChar()")
+                      case (true, _: Type.String) =>
+                        List.range(0, sizes(n)).map(i => s"this->$n[$i].toChar()")
+                      case (true, t) if s.isPrimitive(t, tn) =>
+                        List.range(0, sizes(n)).map(i => s"this->$n[$i]")
+                      case _ =>
+                        List.range(0, sizes(n)).map(i => s"${n}Str[$i].toChar()")
+                    }).mkString(",\n")),
+                ).flatten,
+                ");"
+              ),
+              List(
+                Line.blank,
+                line("outputString[FW_SERIALIZABLE_TO_STRING_BUFFER_SIZE-1] = 0; // NULL terminate"),
+                line("sb = outputString;"),
+              ),
+            ).flatten,
+            CppDoc.Function.NonSV,
+            CppDoc.Function.Const
           )
         )
       ),
-      CppDoc.Class.Member.Lines(
-        CppDoc.Lines(
-          CppDocWriter.writeBannerComment("Getter functions"),
-        )
+      linesClassMember(
+        CppDocWriter.writeBannerComment("Getter functions"),
       ) :: getGetterFunctionMembers,
-      CppDoc.Class.Member.Lines(
-        CppDoc.Lines(
-          CppDocWriter.writeBannerComment("Setter functions"),
-          CppDoc.Lines.Both
-        )
+      linesClassMember(
+        CppDocWriter.writeBannerComment("Setter functions"),
+        CppDoc.Lines.Both
       ) :: getSetterFunctionMembers,
     ).flatten
   }
@@ -608,92 +566,76 @@ case class StructCppWriter(
         )
       )
       case (false, t) if s.isPrimitive(t, tn) => List(
-        CppDoc.Class.Member.Lines(
-          CppDoc.Lines(
-            lines(
-              s"""|
-                  |//! Get member $n
-                  |${writeMemberAsReturnType((n, tn))} ${getGetterName(n)}() const
-                  |{
-                  |  return this->$n;
-                  |}"""
-            ),
-          )
+        linesClassMember(
+          lines(
+            s"""|
+                |//! Get member $n
+                |${writeMemberAsReturnType((n, tn))} ${getGetterName(n)}() const
+                |{
+                |  return this->$n;
+                |}"""
+          ),
         )
       )
       case _ => List(
-        CppDoc.Class.Member.Lines(
-          CppDoc.Lines(
-            lines(
-              s"""|
-                  |//! Get member $n
-                  |${writeMemberAsReturnType((n, tn))} ${getGetterName(n)}()
-                  |{
-                  |  return this->$n;
-                  |}"""
-            ),
-          )
-        ),
-        CppDoc.Class.Member.Lines(
-          CppDoc.Lines(
-            lines(
-              s"""|
-                  |//! Get member $n (const)
-                  |${writeMemberAsReturnType((n, tn), true)} ${getGetterName(n)}() const
-                  |{
-                  |  return this->$n;
-                  |}"""
-            ),
-          )
-        ),
+        linesClassMember(
+          lines(
+            s"""|
+                |//! Get member $n
+                |${writeMemberAsReturnType((n, tn))} ${getGetterName(n)}()
+                |{
+                |  return this->$n;
+                |}
+                |
+                |//! Get member $n (const)
+                |${writeMemberAsReturnType((n, tn), true)} ${getGetterName(n)}() const
+                |{
+                |  return this->$n;
+                |}"""
+          ),
+        )
       )
     })
   }
 
   private def getSetterFunctionMembers: List[CppDoc.Class.Member] =
-    CppDoc.Class.Member.Function(
-      CppDoc.Function(
-        Some("Set all members"),
-        "set",
-        memberList.map(writeMemberAsParam),
-        CppDoc.Type("void"),
-        List(
-          nonArrayMemberNames.map(n => line(s"this->$n = $n;")),
-          if arrayMemberNames.isEmpty then Nil
-          else Line.blank :: writeArraySetters(n => s"$n[i]"),
-        ).flatten
-      )
+    functionClassMember(
+      Some("Set all members"),
+      "set",
+      memberList.map(writeMemberAsParam),
+      CppDoc.Type("void"),
+      List(
+        nonArrayMemberNames.map(n => line(s"this->$n = $n;")),
+        if arrayMemberNames.isEmpty then Nil
+        else Line.blank :: writeArraySetters(n => s"$n[i]"),
+      ).flatten
     ) ::
       memberList.map((n, tn) =>
-        CppDoc.Class.Member.Function(
-          CppDoc.Function(
-            Some(s"Set member $n"),
-            s"set$n",
-            List(
-              writeMemberAsParam((n, tn))
-            ),
-            CppDoc.Type("void"),
-            if sizes.contains(n) then
-              iterateN(sizes(n), lines(s"this->$n[i] = $n[i];"))
-            else
-              lines(s"this->$n = $n;")
-          )
+        functionClassMember(
+          Some(s"Set member $n"),
+          s"set$n",
+          List(
+            writeMemberAsParam((n, tn))
+          ),
+          CppDoc.Type("void"),
+          if sizes.contains(n) then
+            iterateN(sizes(n), lines(s"this->$n[i] = $n[i];"))
+          else
+            lines(s"this->$n = $n;")
         )
       )
 
   private def getMemberVariableMembers: List[CppDoc.Class.Member] =
     List(
-      CppDoc.Class.Member.Lines(
-        CppDoc.Lines(CppDocHppWriter.writeAccessTag("protected"))
+      linesClassMember(
+        CppDocHppWriter.writeAccessTag("protected")
       ),
-      CppDoc.Class.Member.Lines(
-        CppDoc.Lines(
-          CppDocWriter.writeBannerComment("Member variables") ++
-            addBlankPrefix(memberList.map((n, tn) =>
-              if sizes.contains(n) then line(s"$tn $n[${sizes(n)}];")
-              else line(s"$tn $n;")
-            ))
-        )
+      linesClassMember(
+        CppDocWriter.writeBannerComment("Member variables") ++
+          addBlankPrefix(memberList.map((n, tn) =>
+            if sizes.contains(n) then line(s"$tn $n[${sizes(n)}];")
+            else line(s"$tn $n;")
+          ))
       )
     )
 

--- a/compiler/lib/src/main/scala/codegen/CppWriter/TopologyCppWriter/TopHelperFns.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/TopologyCppWriter/TopHelperFns.scala
@@ -304,11 +304,9 @@ case class TopHelperFns(
     )
   }
 
-  private def getBannerComment = CppDoc.Member.Lines(
-    CppDoc.Lines(
-      CppDocWriter.writeBannerComment("Helper functions"),
-      CppDoc.Lines.Both
-    )
+  private def getBannerComment = linesMember(
+    CppDocWriter.writeBannerComment("Helper functions"),
+    CppDoc.Lines.Both
   )
 
 }

--- a/compiler/lib/src/main/scala/codegen/CppWriter/TopologyCppWriter/TopSetupTeardownFns.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/TopologyCppWriter/TopSetupTeardownFns.scala
@@ -25,11 +25,9 @@ case class TopSetupTeardownFns(
     )
   )
 
-  private def getBannerComment = CppDoc.Member.Lines(
-    CppDoc.Lines(
-      CppDocWriter.writeBannerComment("Setup and teardown functions"),
-      CppDoc.Lines.Both
-    )
+  private def getBannerComment = linesMember(
+    CppDocWriter.writeBannerComment("Setup and teardown functions"),
+    CppDoc.Lines.Both
   )
 
   private def writeFnCall(pair: (String, String)): List[Line] = {
@@ -39,37 +37,33 @@ case class TopSetupTeardownFns(
     else Nil
   }
 
-  private def getSetupFn = CppDoc.Member.Function(
-    CppDoc.Function(
-      Some("Set up the topology"),
-      "setup",
-      params,
-      CppDoc.Type("void"),
-      List(
-        ("initComponents", "state"),
-        ("configComponents", "state"),
-        ("setBaseIds", ""),
-        ("connectComponents", ""),
-        ("regCommands", ""),
-        ("readParameters", ""),
-        ("loadParameters", ""),
-        ("startTasks", "state"),
-      ).flatMap(writeFnCall)
-    )
+  private def getSetupFn = functionMember(
+    Some("Set up the topology"),
+    "setup",
+    params,
+    CppDoc.Type("void"),
+    List(
+      ("initComponents", "state"),
+      ("configComponents", "state"),
+      ("setBaseIds", ""),
+      ("connectComponents", ""),
+      ("regCommands", ""),
+      ("readParameters", ""),
+      ("loadParameters", ""),
+      ("startTasks", "state"),
+    ).flatMap(writeFnCall)
   )
 
-  private def getTeardownFn = CppDoc.Member.Function(
-    CppDoc.Function(
-      Some("Tear down the topology"),
-      "teardown",
-      params,
-      CppDoc.Type("void"),
-      List(
-        ("stopTasks", "state"),
-        ("freeThreads", "state"),
-        ("tearDownComponents" ,"state"),
-      ).flatMap(writeFnCall)
-    )
+  private def getTeardownFn = functionMember(
+    Some("Tear down the topology"),
+    "teardown",
+    params,
+    CppDoc.Type("void"),
+    List(
+      ("stopTasks", "state"),
+      ("freeThreads", "state"),
+      ("tearDownComponents" ,"state"),
+    ).flatMap(writeFnCall)
   )
 
 }

--- a/compiler/lib/src/main/scala/codegen/CppWriter/TopologyCppWriter/TopologyCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/TopologyCppWriter/TopologyCppWriter.scala
@@ -32,15 +32,15 @@ case class TopologyCppWriter(
           s.getRelativePath(s"${name}TopologyDefs.hpp").toString
         )
       ).sorted
-      CppWriter.linesMember(Line.blank :: strings.map(line))
+      linesMember(Line.blank :: strings.map(line))
     }
-    val hppLines = CppWriter.linesMember(
+    val hppLines = linesMember(
       TopConstants(s, aNode).getLines ++
       TopComponentInstances(s, aNode).getHppLines
     )
     val cppIncludes = {
       val fileName = s"${ComputeCppFiles.FileNames.getTopology(name)}.hpp"
-      CppWriter.linesMember(
+      linesMember(
         List(
           Line.blank,
           CppWriter.headerLine(s.getRelativePath(fileName).toString)
@@ -48,7 +48,7 @@ case class TopologyCppWriter(
         CppDoc.Lines.Cpp
       )
     }
-    val cppLines = CppWriter.linesMember(
+    val cppLines = linesMember(
       Line.blank ::
       List(
         wrapInAnonymousNamespace(
@@ -66,7 +66,7 @@ case class TopologyCppWriter(
     val defs = hppLines :: cppLines :: (helperFns ++ setupTeardownFns)
     List(
       List(hppIncludes, cppIncludes),
-      CppWriter.wrapInNamespaces(namespaceIdentList, defs)
+      wrapInNamespaces(namespaceIdentList, defs)
     ).flatten
   }
 

--- a/compiler/lib/src/main/scala/codegen/CppWriter/TopologyCppWriter/TopologyCppWriterUtils.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/TopologyCppWriter/TopologyCppWriterUtils.scala
@@ -8,7 +8,7 @@ import fpp.compiler.util._
 abstract class TopologyCppWriterUtils(
   s: CppWriterState,
   aNode: Ast.Annotated[AstNode[Ast.DefTopology]]
-) extends CppWriterLineUtils {
+) extends CppWriterUtils {
 
   val symbol: Symbol.Topology = Symbol.Topology(aNode)
 


### PR DESCRIPTION
- Rename `CppWriterLineUtils` to `CppWriterUtils`
- Move some utilities from `CppWriter` into `CppWriterUtils`
- Add utilities for creating CppDoc members
- Refactor C++ writers to use the new utilities