### PR TITLE
[CppDocCppWriter] Refine handling of pure virtual functions

### DIFF
--- a/compiler/lib/src/main/scala/codegen/CppWriter/CppDocCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/CppDocCppWriter.scala
@@ -86,38 +86,46 @@ object CppDocCppWriter extends CppDocWriter {
     outputLines
   }
 
-  override def visitFunction(in: Input, function: CppDoc.Function) = {
-    val contentLines = {
-      val startLines = {
-        val prototypeLines = {
-          import CppDoc.Function._
-          val lines1 = writeParams(function.name, function.params)
-          function.constQualifier match {
-            case Const => Line.addSuffix(lines1, " const")
-            case NonConst => lines1
+  override def visitFunction(in: Input, function: CppDoc.Function) =
+    (function.svQualifier, function.body) match {
+      // If the function is pure virtual, and the function body is empty,
+      // then there is no implementation, so don't write one out.
+      case (CppDoc.Function.PureVirtual, Nil) => Nil
+      // Otherwise write out the implementation.
+      // For a pure virtual function, this is a default implementation.
+      case _ => {
+        val contentLines = {
+          val startLines = {
+            val prototypeLines = {
+              import CppDoc.Function._
+              val lines1 = writeParams(function.name, function.params)
+              function.constQualifier match {
+                case Const => Line.addSuffix(lines1, " const")
+                case NonConst => lines1
+              }
+            }
+            val retType = function.retType.getCppType match {
+              case "" => ""
+              case t => s"$t "
+            }
+            in.classNameList match {
+              case _ :: _ => {
+                val line1 = line(s"${retType}${in.getEnclosingClassQualified} ::")
+                line1 :: prototypeLines.map(indentIn(_))
+              }
+              case Nil =>
+                Line.addPrefix(retType, prototypeLines)
+            }
+          }
+          val bodyLines = CppDocWriter.writeFunctionBody(function.body)
+          in.classNameList match {
+            case _ :: _ => startLines ++ bodyLines
+            case Nil => Line.joinLists(Line.NoIndent)(startLines)(" ")(bodyLines)
           }
         }
-        val retType = function.retType.getCppType match {
-          case "" => ""
-          case t => s"$t "
-        }
-        in.classNameList match {
-          case _ :: _ => {
-            val line1 = line(s"$retType${in.getEnclosingClassQualified} ::")
-            line1 :: prototypeLines.map(indentIn(_))
-          }
-          case Nil =>
-            Line.addPrefix(retType, prototypeLines)
-        }
-      }
-      val bodyLines = CppDocWriter.writeFunctionBody(function.body)
-      in.classNameList match {
-        case _ :: _ => startLines ++ bodyLines
-        case Nil => Line.joinLists(Line.NoIndent)(startLines)(" ")(bodyLines)
+        Line.blank :: contentLines
       }
     }
-    Line.blank :: contentLines
-  }
 
   override def visitLines(in: Input, lines: CppDoc.Lines) = {
     val content = lines.content

--- a/compiler/lib/test/codegen/CppWriter/Main.scala
+++ b/compiler/lib/test/codegen/CppWriter/Main.scala
@@ -69,17 +69,17 @@ object Program extends LineUtils {
                             name = "f",
                             params = List(
                               Function.Param(
-                                Type("const double", None),
+                                Type("const double"),
                                 "x",
                                 Some("This is parameter x line 1.\nThis is parameter x line 2.")
                               ),
                               Function.Param(
-                                Type("const int", None),
+                                Type("const int"),
                                 "y",
                                 Some("This is parameter y line 1.\nThis is parameter y line 2.")
                               )
                             ),
-                            retType = Type("void", None),
+                            retType = Type("void"),
                             body = Nil
                           )
                         ),
@@ -97,12 +97,12 @@ object Program extends LineUtils {
                       comment = Some("This is line 1.\nThis is line 2."),
                       params = List(
                         Function.Param(
-                          t = Type("const double", None),
+                          t = Type("const double"),
                           name = "x",
                           comment = Some("This is parameter x")
                         ),
                         Function.Param(
-                          t = Type("const int", None),
+                          t = Type("const int"),
                           name = "y",
                           comment = Some("This is parameter y")
                         )
@@ -134,20 +134,31 @@ object Program extends LineUtils {
                       name = "f",
                       params = List(
                         Function.Param(
-                          Type("const double", None),
+                          Type("const double"),
                           "x",
                           Some("This is parameter x"),
                           Some("0.0")
                         ),
                         Function.Param(
-                          Type("const int", None),
+                          Type("const int"),
                           "y",
                           Some("This is parameter y"),
                           Some("0")
                         )
                       ),
-                      retType = Type("void", None),
+                      retType = Type("void"),
                       body = Nil
+                    )
+                  ),
+                  Class.Member.Function(
+                    Function(
+                      comment = Some("This is line 1.\nThis is line 2."),
+                      name = "g",
+                      params = Nil,
+                      retType = Type("void"),
+                      body = Nil,
+                      Function.PureVirtual,
+                      Function.Const
                     )
                   ),
                   Class.Member.Lines(


### PR DESCRIPTION
* When the body of the function is Nil, don't write an implementation.
* Otherwise write out the implementation. This becomes a default implementation for the pure virtual function, which is allowed in C++.