### PR TITLE
Revise Cpp Doc Writer

### DIFF
--- a/compiler/lib/src/main/scala/codegen/CppWriter/CppDocWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/CppDocWriter.scala
@@ -59,7 +59,10 @@ object CppDocWriter extends LineUtils {
     
   /** Write a Doxygen comment */
   def writeDoxygenComment(comment: String): List[Line] = 
-    Line.blank ::lines(comment).map(Line.join(" ")(line("//!"))_)
+    Line.blank :: lines(comment).map(l => l.string match {
+      case "" => line("//!")
+      case _ => Line.join(" ")(line("//!"))(l)
+    })
 
   /** Write a Doxygen post comment */
   def writeDoxygenPostComment(comment: String): List[Line] =

--- a/compiler/lib/src/main/scala/codegen/CppWriter/CppDocWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/CppDocWriter.scala
@@ -16,7 +16,7 @@ trait CppDocWriter extends CppDocVisitor with LineUtils {
 
     /** Get the enclosing class name, including any qualifier */
     def getEnclosingClassQualified: String = classNameList.reverse.mkString("::")
- 
+
     /** Get the enclosing class name with no qualifier */
     def getEnclosingClassUnqualified: String = classNameList.head.split("::").reverse.head
 
@@ -56,23 +56,24 @@ object CppDocWriter extends LineUtils {
       case Some(comment) => writeDoxygenPostComment(comment)
       case None => Line.blank :: Nil
     }
-    
+
+  /** Add a a prefix to a comment line */
+  def addCommentPrefix (prefix: String) (l: Line): Line = l.string match {
+    case "" => line(prefix)
+    case _ => Line.join(" ")(line(prefix))(l)
+  }
+
   /** Write a Doxygen comment */
-  def writeDoxygenComment(comment: String): List[Line] = 
-    Line.blank :: lines(comment).map(l => l.string match {
-      case "" => line("//!")
-      case _ => Line.join(" ")(line("//!"))(l)
-    })
+  def writeDoxygenComment(comment: String): List[Line] =
+    Line.blank :: lines(comment).map(addCommentPrefix("//!")_)
 
   /** Write a Doxygen post comment */
   def writeDoxygenPostComment(comment: String): List[Line] =
-    lines(comment).map(l => l.string match {
-      case "" => line("//<!")
-      case _ => Line.join(" ")(line("//!<"))(l)
-    })
-    
+    lines(comment).map(addCommentPrefix("//!<")_)
+
   /** Write a comment body */
-  def writeCommentBody(comment: String): List[Line] = lines(comment).map(Line.join(" ")(line("//"))_)
+  def writeCommentBody(comment: String): List[Line] =
+    lines(comment).map(addCommentPrefix("//")_)
 
   /** Left align a compiler directive */
   def leftAlignDirective(line: Line): Line =

--- a/compiler/lib/src/main/scala/codegen/CppWriter/CppDocWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/CppDocWriter.scala
@@ -66,7 +66,10 @@ object CppDocWriter extends LineUtils {
 
   /** Write a Doxygen post comment */
   def writeDoxygenPostComment(comment: String): List[Line] =
-    lines(comment).map(Line.join(" ")(line("//!<"))_)
+    lines(comment).map(l => l.string match {
+      case "" => line("//<!")
+      case _ => Line.join(" ")(line("//!<"))(l)
+    })
     
   /** Write a comment body */
   def writeCommentBody(comment: String): List[Line] = lines(comment).map(Line.join(" ")(line("//"))_)

--- a/compiler/lib/test/codegen/CppWriter/Main.scala
+++ b/compiler/lib/test/codegen/CppWriter/Main.scala
@@ -51,7 +51,7 @@ object Program extends LineUtils {
                         ),
                         Class.Member.Constructor(
                           constructor = Class.Constructor(
-                            comment = Some("This is line 1.\nThis is line 2."),
+                            comment = Some("This is line 1.\n\nThis is line 3."),
                             params = Nil,
                             initializers = Nil,
                             body = lines("// line1\n// line2")
@@ -71,7 +71,7 @@ object Program extends LineUtils {
                               Function.Param(
                                 Type("const double"),
                                 "x",
-                                Some("This is parameter x line 1.\nThis is parameter x line 2.")
+                                Some("This is parameter x line 1.\n\nThis is parameter x line 3.")
                               ),
                               Function.Param(
                                 Type("const int"),


### PR DESCRIPTION
When a comment has a blank line, don't write out a space after the comment prefix.