### PR TITLE
C++ writer refactor

### DIFF
--- a/compiler/lib/src/main/scala/codegen/CppWriter/ArrayCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ArrayCppWriter.scala
@@ -32,10 +32,7 @@ case class ArrayCppWriter (
 
   private val arraySize = arrayType.getArraySize.get
 
-  private val eltTypeName = eltType match {
-    case t: Type.String => strCppWriter.getClassName(t)
-    case _ => typeCppWriter.write(eltType)
-  }
+  private val eltTypeName = typeCppWriter.write(eltType)
 
   private val formatStr = FormatCppWriter.write(
     arrayType.format.getOrElse(Format("", List((Format.Field.Default, "")))),

--- a/compiler/lib/src/main/scala/codegen/CppWriter/CppWriterUtils.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/CppWriterUtils.scala
@@ -94,8 +94,9 @@ trait CppWriterUtils extends LineUtils {
     body: List[T],
     constructMemberLines: CppDoc.Lines => T,
     linesOutput: CppDoc.Lines.Output = CppDoc.Lines.Both
-  ): List[T] =
-    List(
+  ): List[T] = body match {
+    case Nil => Nil
+    case _ => List(
       List(
         constructMemberLines(
           CppDoc.Lines(
@@ -114,6 +115,7 @@ trait CppWriterUtils extends LineUtils {
         )
       ),
     ).flatten
+  }
 
   def writeOstreamOperator(
     name: String,

--- a/compiler/lib/src/main/scala/codegen/CppWriter/CppWriterUtils.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/CppWriterUtils.scala
@@ -17,32 +17,6 @@ trait CppWriterUtils extends LineUtils {
       members
   }
 
-  /** Add an access tag and comment to a nonempty list of class members */
-  def addAccessTagAndComment(
-    accessTag: String,
-    comment: List[CppDoc.Class.Member],
-    members: List[CppDoc.Class.Member]
-  ): List[CppDoc.Class.Member] = members match {
-    case Nil => Nil
-    case _ =>
-      linesClassMember(CppDocHppWriter.writeAccessTag(accessTag)) ::
-        (comment ++ members)
-  }
-
-  /** Write a comment with a description that appears only in the hpp file */
-  def writeComment(
-    comment: String,
-    description: Option[String] = None
-  ): List[CppDoc.Class.Member] = description match {
-    case Some(s) => List(
-      linesClassMember(CppDocWriter.writeBannerComment(comment), CppDoc.Lines.Both),
-      linesClassMember(CppDocWriter.writeBannerComment(s"$comment\n\n$s"))
-    )
-    case None => List(
-      linesClassMember(CppDocWriter.writeBannerComment(comment), CppDoc.Lines.Both)
-    )
-  }
-
   def wrapInScope(
     s1: String,
     ll: List[Line],

--- a/compiler/lib/src/main/scala/codegen/CppWriter/FormalParamsCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/FormalParamsCppWriter.scala
@@ -1,0 +1,69 @@
+package fpp.compiler.codegen
+
+import fpp.compiler.analysis._
+import fpp.compiler.ast._
+
+/** Write formal parameters as C++ */
+case class FormalParamsWriter(
+  s: CppWriterState
+) {
+
+  /** Writes a formal parameter as a C++ parameter */
+  def writeFormalParam(
+    param: Ast.FormalParam,
+    strName: Option[String] = None,
+    namespaceNames: List[String] = Nil,
+    passingConvention: FormalParamsCppWriter.SerializablePassingConvention = FormalParamsCppWriter.ConstRef
+  ): String = {
+    val t = s.a.typeMap(param.typeName.id)
+    val typeName = TypeCppWriter(s, strName, namespaceNames).write(t)
+
+    param.kind match {
+      // Reference formal parameters become non-constant C++ reference parameters
+      case Ast.FormalParam.Ref => s"$typeName&"
+      case Ast.FormalParam.Value => t match {
+        // Primitive, non-reference formal parameters become C++ value parameters
+        case t if s.isPrimitive(t, typeName) => typeName
+        // String formal parameters become constant C++ reference parameters
+        case _: Type.String => s"const $typeName&"
+        // Serializable formal parameters become C++ value or constant reference parameters
+        case _ => passingConvention match {
+          case FormalParamsCppWriter.ConstRef => s"const $typeName&"
+          case FormalParamsCppWriter.Value => typeName
+        }
+      }
+    }
+  }
+
+  /** Writes a list of formal parameters as a list of CppDoc Function Params */
+  def writeFormalParamList(
+    params: Ast.FormalParamList,
+    namespaceNames: List[String] = Nil,
+    strName: Option[String] = None,
+    passingConvention: FormalParamsCppWriter.SerializablePassingConvention = FormalParamsCppWriter.ConstRef
+  ): List[CppDoc.Function.Param] =
+    params.map(aNode => {
+      CppDoc.Function.Param(
+        CppDoc.Type(writeFormalParam(
+          aNode._2.data,
+          strName,
+          namespaceNames,
+          passingConvention
+        )),
+        aNode._2.data.name,
+        AnnotationCppWriter.asStringOpt(aNode)
+      )
+    })
+
+}
+
+object FormalParamsCppWriter {
+
+  /** The passing convention for a serializable type */
+  sealed trait SerializablePassingConvention
+
+  case object ConstRef extends SerializablePassingConvention
+
+  case object Value extends SerializablePassingConvention
+
+}

--- a/compiler/lib/src/main/scala/codegen/CppWriter/PortCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/PortCppWriter.scala
@@ -21,11 +21,11 @@ case class PortCppWriter (
 
   private val namespaceIdentList = s.getNamespaceIdentList(symbol)
 
-  private val typeCppWriter = TypeCppWriter(s)
+  private val strNamespace = s"${name}PortStrings"
+
+  private val typeCppWriter = TypeCppWriter(s, None, List(strNamespace))
 
   private val strCppWriter = StringCppWriter(s)
-
-  private val strNamespace = s"${name}PortStrings"
 
   private val params = data.params
 
@@ -54,14 +54,9 @@ case class PortCppWriter (
   private val paramList = params.map((_, node, _) => {
     val n = node.data.name
     val k = node.data.kind
-    paramTypeMap(n) match {
-      case t: Type.String => (
-        n,
-        strCppWriter.getQualifiedClassName(t, List(strNamespace)),
-        k
-      )
-      case t => (n, typeCppWriter.write(t), k)
-    }
+    val t = paramTypeMap(n)
+
+    (n, typeCppWriter.write(t), k)
   })
 
   // Port params as CppDoc Function Params
@@ -75,10 +70,7 @@ case class PortCppWriter (
 
   // Return type as a C++ type
   private val returnType = data.returnType match {
-    case Some(value) => s.a.typeMap(value.id) match {
-      case t: Type.String => strCppWriter.getQualifiedClassName(t, List(strNamespace))
-      case t => typeCppWriter.write(t)
-    }
+    case Some(value) => typeCppWriter.write(s.a.typeMap(value.id))
     case None => "void"
   }
 

--- a/compiler/lib/src/main/scala/codegen/CppWriter/StructCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/StructCppWriter.scala
@@ -39,10 +39,9 @@ case class StructCppWriter(
   // Preserves ordering of struct members
   private val memberList = typeMembers.map((_, node, _) => {
     val n = node.data.name
-    members(n) match {
-      case t: Type.String => (n, strCppWriter.getClassName(t))
-      case t => (n, typeCppWriter.write(t))
-    }
+    val t = members(n)
+
+    (n, typeCppWriter.write(t))
   })
 
   private val memberNames = memberList.map((n, _) => n)

--- a/compiler/lib/src/main/scala/codegen/CppWriter/TypeCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/TypeCppWriter.scala
@@ -5,7 +5,12 @@ import fpp.compiler.util._
 
 /** Write an FPP type as C++ */
 case class TypeCppWriter(
-  s: CppWriterState
+  /** CppWriterState */
+  s: CppWriterState,
+  /** Specific string type name */
+  stringTypeName: Option[String] = None,
+  /** List of namespace qualifiers for a string type */
+  stringNamespaceNames: List[String] = Nil
 ) {
 
   private object NameVisitor extends TypeVisitor {
@@ -27,7 +32,10 @@ case class TypeCppWriter(
 
     override def primitiveInt(s: CppWriterState, t: Type.PrimitiveInt) = t.toString
 
-    override def string(s: CppWriterState, t: Type.String) = "string"
+    override def string(s: CppWriterState, t: Type.String) = stringTypeName match {
+      case Some(tn) => tn
+      case None => StringCppWriter(s).getQualifiedClassName(t, stringNamespaceNames)
+    }
 
     override def struct(s: CppWriterState, t: Type.Struct) =
       s.writeSymbol(Symbol.Struct(t.node))
@@ -46,7 +54,12 @@ case class TypeCppWriter(
 object TypeCppWriter {
 
   /** Get the name of a type */
-  def getName(s: CppWriterState, t: Type): String =
-    TypeCppWriter(s).write(t)
+  def getName(
+    s: CppWriterState,
+    t: Type,
+    stringTypeName: Option[String] = None,
+    stringNamespaceNames: List[String] = Nil
+  ): String =
+    TypeCppWriter(s, stringTypeName, stringNamespaceNames).write(t)
 
 }

--- a/compiler/lib/src/main/scala/codegen/XmlWriter/TypeXmlWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/XmlWriter/TypeXmlWriter.scala
@@ -8,7 +8,7 @@ object TypeXmlWriter {
 
   /** Get the name of a type */
   def getName(s: XmlWriterState, t: Type): String =
-    TypeCppWriter.getName(s.cppWriterState, t)
+    TypeCppWriter.getName(s.cppWriterState, t, Some("string"))
 
   /** Get the size of a type */
   def getSize(s: XmlWriterState, t: Type): Option[String] = t match {


### PR DESCRIPTION
- Write string types in C++ using names from `StringCppWriter` by default
- Add `stringTypeName` parameter to `TypeCppWriter` to optionally specify a string type name
- Add `FormalParamsCppWriter` for writing formal parameters as `CppDoc.Function.Param`s
- Add C++ writer utilities