### PR TITLE
odroid runner for building aarch64 packages, rhel8.7 runner to replace ubuntu-18.04

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -17,11 +17,9 @@ jobs:
     - name: Image Build Step
       working-directory: ./compiler
       if: ${{ matrix.os == 'odroid' }}
-        run: |
-          echo "architecture=aarch64" >> "$GITHUB_ENV"
+        run: echo "architecture=aarch64" >> "$GITHUB_ENV"
       if: ${{ matrix.os != 'odroid' }}
-        run: |
-          echo "architecture=amd64" >> "$GITHUB_ENV"
+        run: echo "architecture=amd64" >> "$GITHUB_ENV"
       run: |
         . ${GITHUB_WORKSPACE}/.github/workflows/env-setup ${{ env.architecture }}
         ./release

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -14,12 +14,14 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+    - name: Set architecture type (aarch64)
+      if: ${{ matrix.os == 'odroid' }}
+      run: echo "architecture=aarch64" >> "$GITHUB_ENV"
+    - name: Set architecture type (amd64)
+      if: ${{ matrix.os != 'odroid' }}
+      run: echo "architecture=amd64" >> "$GITHUB_ENV"
     - name: Image Build Step
       working-directory: ./compiler
-      if: ${{ matrix.os == 'odroid' }}
-        run: echo "architecture=aarch64" >> "$GITHUB_ENV"
-      if: ${{ matrix.os != 'odroid' }}
-        run: echo "architecture=amd64" >> "$GITHUB_ENV"
       run: |
         . ${GITHUB_WORKSPACE}/.github/workflows/env-setup ${{ env.architecture }}
         ./release

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -3,11 +3,12 @@ on:
   release:
     types: [published]
   pull_request:
+    branches: [main]
 jobs:
   Build-Native-Images:
     strategy:
       matrix:
-        os: ["ubuntu-18.04", "macos-11", "odroid"]
+        os: ["rhel-8.7", "macos-11", "odroid"]
     runs-on: ${{ matrix.os }}
     steps:
     - name: "Checkout FPP Repository"

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -2,11 +2,12 @@ name: Build Native Images
 on:
   release:
     types: [published]
+  pull_request:
 jobs:
   Build-Native-Images:
     strategy:
       matrix:
-        os: ["ubuntu-18.04", "macos-11"]
+        os: ["ubuntu-18.04", "macos-11", "odroid"]
     runs-on: ${{ matrix.os }}
     steps:
     - name: "Checkout FPP Repository"
@@ -15,34 +16,40 @@ jobs:
         fetch-depth: 0
     - name: Image Build Step
       working-directory: ./compiler
+      if: ${{ matrix.os == 'odroid' }}
+        run: |
+          echo "architecture=aarch64" >> "$GITHUB_ENV"
+      if: ${{ matrix.os != 'odroid' }}
+        run: |
+          echo "architecture=amd64" >> "$GITHUB_ENV"
       run: |
-        . ${GITHUB_WORKSPACE}/.github/workflows/env-setup
+        . ${GITHUB_WORKSPACE}/.github/workflows/env-setup ${{ env.architecture }}
         ./release
-        mv native-fpp-*.tar.gz "${GITHUB_WORKSPACE}"
-    - name: Publish Release Binaries
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: ${GITHUB_WORKSPACE}/.github/workflows/publish native-fpp-*.tar.gz
-  Build-PyPI-Package:
-    needs: Build-Native-Images
-    runs-on: ubuntu-latest
-    steps:
-    - name: "Checkout FPP Repository"
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - name: Test PyPI
-      uses: fprime-community/publish-pypi@main
-      env:
-        TWINE_PASSWORD: ${{ secrets.TESTPYPI_CREDENTIAL }}
-      with:
-        package: "fprime-fpp"
-        steps: "sdist"
-    - name: PyPI
-      uses: fprime-community/publish-pypi@main
-      env:
-        TWINE_PASSWORD: ${{ secrets.PYPI_CREDENTIAL }}
-      with:
-        repo: "pypi"
-        package: "fprime-fpp"
-        steps: "sdist"
+        mv native-fpp-*.tar.gz "${GITHUB_WORKSPACE}" 
+  #   - name: Publish Release Binaries
+  #     env:
+  #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #     run: ${GITHUB_WORKSPACE}/.github/workflows/publish native-fpp-*.tar.gz
+  # Build-PyPI-Package:
+  #   needs: Build-Native-Images
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - name: "Checkout FPP Repository"
+  #     uses: actions/checkout@v2
+  #     with:
+  #       fetch-depth: 0
+  #   - name: Test PyPI
+  #     uses: fprime-community/publish-pypi@main
+  #     env:
+  #       TWINE_PASSWORD: ${{ secrets.TESTPYPI_CREDENTIAL }}
+  #     with:
+  #       package: "fprime-fpp"
+  #       steps: "sdist"
+  #   - name: PyPI
+  #     uses: fprime-community/publish-pypi@main
+  #     env:
+  #       TWINE_PASSWORD: ${{ secrets.PYPI_CREDENTIAL }}
+  #     with:
+  #       repo: "pypi"
+  #       package: "fprime-fpp"
+  #       steps: "sdist"

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -26,30 +26,32 @@ jobs:
         . ${GITHUB_WORKSPACE}/.github/workflows/env-setup ${{ env.architecture }}
         ./release
         mv native-fpp-*.tar.gz "${GITHUB_WORKSPACE}" 
-  #   - name: Publish Release Binaries
-  #     env:
-  #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #     run: ${GITHUB_WORKSPACE}/.github/workflows/publish native-fpp-*.tar.gz
-  # Build-PyPI-Package:
-  #   needs: Build-Native-Images
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - name: "Checkout FPP Repository"
-  #     uses: actions/checkout@v2
-  #     with:
-  #       fetch-depth: 0
-  #   - name: Test PyPI
-  #     uses: fprime-community/publish-pypi@main
-  #     env:
-  #       TWINE_PASSWORD: ${{ secrets.TESTPYPI_CREDENTIAL }}
-  #     with:
-  #       package: "fprime-fpp"
-  #       steps: "sdist"
-  #   - name: PyPI
-  #     uses: fprime-community/publish-pypi@main
-  #     env:
-  #       TWINE_PASSWORD: ${{ secrets.PYPI_CREDENTIAL }}
-  #     with:
-  #       repo: "pypi"
-  #       package: "fprime-fpp"
-  #       steps: "sdist"
+    - name: Publish Release Binaries
+      if: ${{ github.event_name == 'release' }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: ${GITHUB_WORKSPACE}/.github/workflows/publish native-fpp-*.tar.gz
+  Build-PyPI-Package:
+    if: ${{ github.event_name == 'release' }}
+    needs: Build-Native-Images
+    runs-on: ubuntu-latest
+    steps:
+    - name: "Checkout FPP Repository"
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Test PyPI
+      uses: fprime-community/publish-pypi@main
+      env:
+        TWINE_PASSWORD: ${{ secrets.TESTPYPI_CREDENTIAL }}
+      with:
+        package: "fprime-fpp"
+        steps: "sdist"
+    - name: PyPI
+      uses: fprime-community/publish-pypi@main
+      env:
+        TWINE_PASSWORD: ${{ secrets.PYPI_CREDENTIAL }}
+      with:
+        repo: "pypi"
+        package: "fprime-fpp"
+        steps: "sdist"

--- a/.github/workflows/env-setup
+++ b/.github/workflows/env-setup
@@ -1,7 +1,8 @@
 #!/bin/bash
+graal_arch=$1
 graal_ver="22.3.0"
 graal_os="$( uname -s | tr "[:upper:]" "[:lower:]")"
-graal_ar="graalvm-ce-java11-${graal_os}-amd64-${graal_ver}.tar.gz"
+graal_ar="graalvm-ce-java11-${graal_os}-${graal_arch}-${graal_ver}.tar.gz"
 graal_dir="$(pwd)/graalvm-ce-java11-${graal_ver}"
 graal_url="https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${graal_ver}/${graal_ar}"
 


### PR DESCRIPTION
Updated workflow for building native images to include:
- "odroid" label for building on a self-hosted runner
- condition for determining the architecture type (used when installing GraalVM in env-setup)
- condition for publishing binaries and building PyPI packages ONLY when triggered by a release 
- "rhel-8.7" label for building on self-hosted runner (replaces ubuntu-18.04)
- scope PR trigger to those merging to the "main" branch