### PR TITLE
Remove unused serial input port to typed output port connector function

### DIFF
--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentOutputPorts.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentOutputPorts.scala
@@ -64,35 +64,38 @@ case class ComponentOutputPorts(
         "public",
         s"Connect serial input ports to $typeStr output ports",
         mapPorts(ports, p =>
-          List(
-            functionClassMember(
-              Some(s"Connect port to ${p.getUnqualifiedName}[portNum]"),
-              outputPortConnectorName(p.getUnqualifiedName),
-              List(
-                portNumParam,
-                CppDoc.Function.Param(
-                  p.getType.get match {
-                    case PortInstance.Type.DefPort(_) =>
-                      CppDoc.Type("Fw::InputSerializePort*")
-                    case PortInstance.Type.Serial =>
-                      CppDoc.Type("Fw::InputPortBase*")
-                  },
-                  "port",
-                  Some("The port")
-                )
-              ),
-              CppDoc.Type("void"),
-              lines(
-                s"""|FW_ASSERT(
-                    |  portNum < this->${portNumGetterName(p)}(),
-                    |  static_cast<FwAssertArgType>(portNum)
-                    |);
-                    |
-                    |this->${portVariableName(p)}[portNum].registerSerialPort(port);
-                    |"""
-              ),
+          getPortReturnType(p) match {
+            case None => List(
+              functionClassMember(
+                Some(s"Connect port to ${p.getUnqualifiedName}[portNum]"),
+                outputPortConnectorName(p.getUnqualifiedName),
+                List(
+                  portNumParam,
+                  CppDoc.Function.Param(
+                    p.getType.get match {
+                      case PortInstance.Type.DefPort(_) =>
+                        CppDoc.Type("Fw::InputSerializePort*")
+                      case PortInstance.Type.Serial =>
+                        CppDoc.Type("Fw::InputPortBase*")
+                    },
+                    "port",
+                    Some("The port")
+                  )
+                ),
+                CppDoc.Type("void"),
+                lines(
+                  s"""|FW_ASSERT(
+                      |  portNum < this->${portNumGetterName(p)}(),
+                      |  static_cast<FwAssertArgType>(portNum)
+                      |);
+                      |
+                      |this->${portVariableName(p)}[portNum].registerSerialPort(port);
+                      |"""
+                ),
+              )
             )
-          )
+            case Some(_) => Nil
+          }
         )
       )
     )

--- a/compiler/lib/src/main/scala/codegen/CppWriter/CppWriterUtils.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/CppWriterUtils.scala
@@ -29,7 +29,7 @@ trait CppWriterUtils extends LineUtils {
   def addSeparatedPreComment(str: String, commentOpt: Option[String]): String = {
     commentOpt match {
       case Some(s) => s"//! $str\n//!\n//! $s"
-      case None => str
+      case None => s"//! $str"
     }
   }
 

--- a/compiler/tools/fpp-to-cpp/test/component/ActiveCommandsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/ActiveCommandsComponentAc.ref.cpp
@@ -1042,20 +1042,6 @@ void ActiveCommandsComponentBase ::
 }
 
 void ActiveCommandsComponentBase ::
-  set_prmGetOut_OutputPort(
-      NATIVE_INT_TYPE portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    portNum < this->getNum_prmGetOut_OutputPorts(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-
-  this->m_prmGetOut_OutputPort[portNum].registerSerialPort(port);
-}
-
-void ActiveCommandsComponentBase ::
   set_prmSetOut_OutputPort(
       NATIVE_INT_TYPE portNum,
       Fw::InputSerializePort* port
@@ -1135,20 +1121,6 @@ void ActiveCommandsComponentBase ::
   );
 
   this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
-}
-
-void ActiveCommandsComponentBase ::
-  set_typedReturnOut_OutputPort(
-      NATIVE_INT_TYPE portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    portNum < this->getNum_typedReturnOut_OutputPorts(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-
-  this->m_typedReturnOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/component/ActiveCommandsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/ActiveCommandsComponentAc.ref.hpp
@@ -338,12 +338,6 @@ class ActiveCommandsComponentBase :
         Fw::InputSerializePort* port //!< The port
     );
 
-    //! Connect port to prmGetOut[portNum]
-    void set_prmGetOut_OutputPort(
-        NATIVE_INT_TYPE portNum, //!< The port number
-        Fw::InputSerializePort* port //!< The port
-    );
-
     //! Connect port to prmSetOut[portNum]
     void set_prmSetOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
@@ -384,12 +378,6 @@ class ActiveCommandsComponentBase :
 
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
-        NATIVE_INT_TYPE portNum, //!< The port number
-        Fw::InputSerializePort* port //!< The port
-    );
-
-    //! Connect port to typedReturnOut[portNum]
-    void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
         Fw::InputSerializePort* port //!< The port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/ActiveEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/ActiveEventsComponentAc.ref.cpp
@@ -1037,20 +1037,6 @@ void ActiveEventsComponentBase ::
 }
 
 void ActiveEventsComponentBase ::
-  set_prmGetOut_OutputPort(
-      NATIVE_INT_TYPE portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    portNum < this->getNum_prmGetOut_OutputPorts(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-
-  this->m_prmGetOut_OutputPort[portNum].registerSerialPort(port);
-}
-
-void ActiveEventsComponentBase ::
   set_prmSetOut_OutputPort(
       NATIVE_INT_TYPE portNum,
       Fw::InputSerializePort* port
@@ -1130,20 +1116,6 @@ void ActiveEventsComponentBase ::
   );
 
   this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
-}
-
-void ActiveEventsComponentBase ::
-  set_typedReturnOut_OutputPort(
-      NATIVE_INT_TYPE portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    portNum < this->getNum_typedReturnOut_OutputPorts(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-
-  this->m_typedReturnOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/component/ActiveEventsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/ActiveEventsComponentAc.ref.hpp
@@ -335,12 +335,6 @@ class ActiveEventsComponentBase :
         Fw::InputSerializePort* port //!< The port
     );
 
-    //! Connect port to prmGetOut[portNum]
-    void set_prmGetOut_OutputPort(
-        NATIVE_INT_TYPE portNum, //!< The port number
-        Fw::InputSerializePort* port //!< The port
-    );
-
     //! Connect port to prmSetOut[portNum]
     void set_prmSetOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
@@ -381,12 +375,6 @@ class ActiveEventsComponentBase :
 
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
-        NATIVE_INT_TYPE portNum, //!< The port number
-        Fw::InputSerializePort* port //!< The port
-    );
-
-    //! Connect port to typedReturnOut[portNum]
-    void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
         Fw::InputSerializePort* port //!< The port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/ActiveParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/ActiveParamsComponentAc.ref.cpp
@@ -1037,20 +1037,6 @@ void ActiveParamsComponentBase ::
 }
 
 void ActiveParamsComponentBase ::
-  set_prmGetOut_OutputPort(
-      NATIVE_INT_TYPE portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    portNum < this->getNum_prmGetOut_OutputPorts(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-
-  this->m_prmGetOut_OutputPort[portNum].registerSerialPort(port);
-}
-
-void ActiveParamsComponentBase ::
   set_prmSetOut_OutputPort(
       NATIVE_INT_TYPE portNum,
       Fw::InputSerializePort* port
@@ -1130,20 +1116,6 @@ void ActiveParamsComponentBase ::
   );
 
   this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
-}
-
-void ActiveParamsComponentBase ::
-  set_typedReturnOut_OutputPort(
-      NATIVE_INT_TYPE portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    portNum < this->getNum_typedReturnOut_OutputPorts(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-
-  this->m_typedReturnOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/component/ActiveParamsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/ActiveParamsComponentAc.ref.hpp
@@ -344,12 +344,6 @@ class ActiveParamsComponentBase :
         Fw::InputSerializePort* port //!< The port
     );
 
-    //! Connect port to prmGetOut[portNum]
-    void set_prmGetOut_OutputPort(
-        NATIVE_INT_TYPE portNum, //!< The port number
-        Fw::InputSerializePort* port //!< The port
-    );
-
     //! Connect port to prmSetOut[portNum]
     void set_prmSetOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
@@ -390,12 +384,6 @@ class ActiveParamsComponentBase :
 
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
-        NATIVE_INT_TYPE portNum, //!< The port number
-        Fw::InputSerializePort* port //!< The port
-    );
-
-    //! Connect port to typedReturnOut[portNum]
-    void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
         Fw::InputSerializePort* port //!< The port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/ActiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/ActiveSerialComponentAc.ref.cpp
@@ -1349,20 +1349,6 @@ void ActiveSerialComponentBase ::
 }
 
 void ActiveSerialComponentBase ::
-  set_prmGetOut_OutputPort(
-      NATIVE_INT_TYPE portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    portNum < this->getNum_prmGetOut_OutputPorts(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-
-  this->m_prmGetOut_OutputPort[portNum].registerSerialPort(port);
-}
-
-void ActiveSerialComponentBase ::
   set_prmSetOut_OutputPort(
       NATIVE_INT_TYPE portNum,
       Fw::InputSerializePort* port
@@ -1442,20 +1428,6 @@ void ActiveSerialComponentBase ::
   );
 
   this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
-}
-
-void ActiveSerialComponentBase ::
-  set_typedReturnOut_OutputPort(
-      NATIVE_INT_TYPE portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    portNum < this->getNum_typedReturnOut_OutputPorts(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-
-  this->m_typedReturnOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/component/ActiveSerialComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/ActiveSerialComponentAc.ref.hpp
@@ -478,12 +478,6 @@ class ActiveSerialComponentBase :
         Fw::InputSerializePort* port //!< The port
     );
 
-    //! Connect port to prmGetOut[portNum]
-    void set_prmGetOut_OutputPort(
-        NATIVE_INT_TYPE portNum, //!< The port number
-        Fw::InputSerializePort* port //!< The port
-    );
-
     //! Connect port to prmSetOut[portNum]
     void set_prmSetOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
@@ -524,12 +518,6 @@ class ActiveSerialComponentBase :
 
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
-        NATIVE_INT_TYPE portNum, //!< The port number
-        Fw::InputSerializePort* port //!< The port
-    );
-
-    //! Connect port to typedReturnOut[portNum]
-    void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
         Fw::InputSerializePort* port //!< The port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/ActiveTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/ActiveTelemetryComponentAc.ref.cpp
@@ -1037,20 +1037,6 @@ void ActiveTelemetryComponentBase ::
 }
 
 void ActiveTelemetryComponentBase ::
-  set_prmGetOut_OutputPort(
-      NATIVE_INT_TYPE portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    portNum < this->getNum_prmGetOut_OutputPorts(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-
-  this->m_prmGetOut_OutputPort[portNum].registerSerialPort(port);
-}
-
-void ActiveTelemetryComponentBase ::
   set_prmSetOut_OutputPort(
       NATIVE_INT_TYPE portNum,
       Fw::InputSerializePort* port
@@ -1130,20 +1116,6 @@ void ActiveTelemetryComponentBase ::
   );
 
   this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
-}
-
-void ActiveTelemetryComponentBase ::
-  set_typedReturnOut_OutputPort(
-      NATIVE_INT_TYPE portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    portNum < this->getNum_typedReturnOut_OutputPorts(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-
-  this->m_typedReturnOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/component/ActiveTelemetryComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/ActiveTelemetryComponentAc.ref.hpp
@@ -332,12 +332,6 @@ class ActiveTelemetryComponentBase :
         Fw::InputSerializePort* port //!< The port
     );
 
-    //! Connect port to prmGetOut[portNum]
-    void set_prmGetOut_OutputPort(
-        NATIVE_INT_TYPE portNum, //!< The port number
-        Fw::InputSerializePort* port //!< The port
-    );
-
     //! Connect port to prmSetOut[portNum]
     void set_prmSetOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
@@ -378,12 +372,6 @@ class ActiveTelemetryComponentBase :
 
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
-        NATIVE_INT_TYPE portNum, //!< The port number
-        Fw::InputSerializePort* port //!< The port
-    );
-
-    //! Connect port to typedReturnOut[portNum]
-    void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
         Fw::InputSerializePort* port //!< The port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/ActiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/ActiveTestComponentAc.ref.cpp
@@ -1073,20 +1073,6 @@ void ActiveTestComponentBase ::
 }
 
 void ActiveTestComponentBase ::
-  set_prmGetOut_OutputPort(
-      NATIVE_INT_TYPE portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    portNum < this->getNum_prmGetOut_OutputPorts(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-
-  this->m_prmGetOut_OutputPort[portNum].registerSerialPort(port);
-}
-
-void ActiveTestComponentBase ::
   set_prmSetOut_OutputPort(
       NATIVE_INT_TYPE portNum,
       Fw::InputSerializePort* port
@@ -1166,20 +1152,6 @@ void ActiveTestComponentBase ::
   );
 
   this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
-}
-
-void ActiveTestComponentBase ::
-  set_typedReturnOut_OutputPort(
-      NATIVE_INT_TYPE portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    portNum < this->getNum_typedReturnOut_OutputPorts(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-
-  this->m_typedReturnOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/component/ActiveTestComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/ActiveTestComponentAc.ref.hpp
@@ -397,12 +397,6 @@ class ActiveTestComponentBase :
         Fw::InputSerializePort* port //!< The port
     );
 
-    //! Connect port to prmGetOut[portNum]
-    void set_prmGetOut_OutputPort(
-        NATIVE_INT_TYPE portNum, //!< The port number
-        Fw::InputSerializePort* port //!< The port
-    );
-
     //! Connect port to prmSetOut[portNum]
     void set_prmSetOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
@@ -443,12 +437,6 @@ class ActiveTestComponentBase :
 
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
-        NATIVE_INT_TYPE portNum, //!< The port number
-        Fw::InputSerializePort* port //!< The port
-    );
-
-    //! Connect port to typedReturnOut[portNum]
-    void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
         Fw::InputSerializePort* port //!< The port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/PassiveCommandsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/PassiveCommandsComponentAc.ref.cpp
@@ -826,20 +826,6 @@ void PassiveCommandsComponentBase ::
 }
 
 void PassiveCommandsComponentBase ::
-  set_prmGetOut_OutputPort(
-      NATIVE_INT_TYPE portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    portNum < this->getNum_prmGetOut_OutputPorts(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-
-  this->m_prmGetOut_OutputPort[portNum].registerSerialPort(port);
-}
-
-void PassiveCommandsComponentBase ::
   set_prmSetOut_OutputPort(
       NATIVE_INT_TYPE portNum,
       Fw::InputSerializePort* port
@@ -919,20 +905,6 @@ void PassiveCommandsComponentBase ::
   );
 
   this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
-}
-
-void PassiveCommandsComponentBase ::
-  set_typedReturnOut_OutputPort(
-      NATIVE_INT_TYPE portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    portNum < this->getNum_typedReturnOut_OutputPorts(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-
-  this->m_typedReturnOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/component/PassiveCommandsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/PassiveCommandsComponentAc.ref.hpp
@@ -292,12 +292,6 @@ class PassiveCommandsComponentBase :
         Fw::InputSerializePort* port //!< The port
     );
 
-    //! Connect port to prmGetOut[portNum]
-    void set_prmGetOut_OutputPort(
-        NATIVE_INT_TYPE portNum, //!< The port number
-        Fw::InputSerializePort* port //!< The port
-    );
-
     //! Connect port to prmSetOut[portNum]
     void set_prmSetOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
@@ -338,12 +332,6 @@ class PassiveCommandsComponentBase :
 
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
-        NATIVE_INT_TYPE portNum, //!< The port number
-        Fw::InputSerializePort* port //!< The port
-    );
-
-    //! Connect port to typedReturnOut[portNum]
-    void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
         Fw::InputSerializePort* port //!< The port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/PassiveEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/PassiveEventsComponentAc.ref.cpp
@@ -826,20 +826,6 @@ void PassiveEventsComponentBase ::
 }
 
 void PassiveEventsComponentBase ::
-  set_prmGetOut_OutputPort(
-      NATIVE_INT_TYPE portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    portNum < this->getNum_prmGetOut_OutputPorts(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-
-  this->m_prmGetOut_OutputPort[portNum].registerSerialPort(port);
-}
-
-void PassiveEventsComponentBase ::
   set_prmSetOut_OutputPort(
       NATIVE_INT_TYPE portNum,
       Fw::InputSerializePort* port
@@ -919,20 +905,6 @@ void PassiveEventsComponentBase ::
   );
 
   this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
-}
-
-void PassiveEventsComponentBase ::
-  set_typedReturnOut_OutputPort(
-      NATIVE_INT_TYPE portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    portNum < this->getNum_typedReturnOut_OutputPorts(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-
-  this->m_typedReturnOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/component/PassiveEventsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/PassiveEventsComponentAc.ref.hpp
@@ -294,12 +294,6 @@ class PassiveEventsComponentBase :
         Fw::InputSerializePort* port //!< The port
     );
 
-    //! Connect port to prmGetOut[portNum]
-    void set_prmGetOut_OutputPort(
-        NATIVE_INT_TYPE portNum, //!< The port number
-        Fw::InputSerializePort* port //!< The port
-    );
-
     //! Connect port to prmSetOut[portNum]
     void set_prmSetOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
@@ -340,12 +334,6 @@ class PassiveEventsComponentBase :
 
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
-        NATIVE_INT_TYPE portNum, //!< The port number
-        Fw::InputSerializePort* port //!< The port
-    );
-
-    //! Connect port to typedReturnOut[portNum]
-    void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
         Fw::InputSerializePort* port //!< The port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/PassiveParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/PassiveParamsComponentAc.ref.cpp
@@ -826,20 +826,6 @@ void PassiveParamsComponentBase ::
 }
 
 void PassiveParamsComponentBase ::
-  set_prmGetOut_OutputPort(
-      NATIVE_INT_TYPE portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    portNum < this->getNum_prmGetOut_OutputPorts(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-
-  this->m_prmGetOut_OutputPort[portNum].registerSerialPort(port);
-}
-
-void PassiveParamsComponentBase ::
   set_prmSetOut_OutputPort(
       NATIVE_INT_TYPE portNum,
       Fw::InputSerializePort* port
@@ -919,20 +905,6 @@ void PassiveParamsComponentBase ::
   );
 
   this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
-}
-
-void PassiveParamsComponentBase ::
-  set_typedReturnOut_OutputPort(
-      NATIVE_INT_TYPE portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    portNum < this->getNum_typedReturnOut_OutputPorts(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-
-  this->m_typedReturnOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/component/PassiveParamsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/PassiveParamsComponentAc.ref.hpp
@@ -303,12 +303,6 @@ class PassiveParamsComponentBase :
         Fw::InputSerializePort* port //!< The port
     );
 
-    //! Connect port to prmGetOut[portNum]
-    void set_prmGetOut_OutputPort(
-        NATIVE_INT_TYPE portNum, //!< The port number
-        Fw::InputSerializePort* port //!< The port
-    );
-
     //! Connect port to prmSetOut[portNum]
     void set_prmSetOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
@@ -349,12 +343,6 @@ class PassiveParamsComponentBase :
 
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
-        NATIVE_INT_TYPE portNum, //!< The port number
-        Fw::InputSerializePort* port //!< The port
-    );
-
-    //! Connect port to typedReturnOut[portNum]
-    void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
         Fw::InputSerializePort* port //!< The port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/PassiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/PassiveSerialComponentAc.ref.cpp
@@ -943,20 +943,6 @@ void PassiveSerialComponentBase ::
 }
 
 void PassiveSerialComponentBase ::
-  set_prmGetOut_OutputPort(
-      NATIVE_INT_TYPE portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    portNum < this->getNum_prmGetOut_OutputPorts(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-
-  this->m_prmGetOut_OutputPort[portNum].registerSerialPort(port);
-}
-
-void PassiveSerialComponentBase ::
   set_prmSetOut_OutputPort(
       NATIVE_INT_TYPE portNum,
       Fw::InputSerializePort* port
@@ -1036,20 +1022,6 @@ void PassiveSerialComponentBase ::
   );
 
   this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
-}
-
-void PassiveSerialComponentBase ::
-  set_typedReturnOut_OutputPort(
-      NATIVE_INT_TYPE portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    portNum < this->getNum_typedReturnOut_OutputPorts(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-
-  this->m_typedReturnOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/component/PassiveSerialComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/PassiveSerialComponentAc.ref.hpp
@@ -398,12 +398,6 @@ class PassiveSerialComponentBase :
         Fw::InputSerializePort* port //!< The port
     );
 
-    //! Connect port to prmGetOut[portNum]
-    void set_prmGetOut_OutputPort(
-        NATIVE_INT_TYPE portNum, //!< The port number
-        Fw::InputSerializePort* port //!< The port
-    );
-
     //! Connect port to prmSetOut[portNum]
     void set_prmSetOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
@@ -444,12 +438,6 @@ class PassiveSerialComponentBase :
 
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
-        NATIVE_INT_TYPE portNum, //!< The port number
-        Fw::InputSerializePort* port //!< The port
-    );
-
-    //! Connect port to typedReturnOut[portNum]
-    void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
         Fw::InputSerializePort* port //!< The port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/PassiveTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/PassiveTelemetryComponentAc.ref.cpp
@@ -826,20 +826,6 @@ void PassiveTelemetryComponentBase ::
 }
 
 void PassiveTelemetryComponentBase ::
-  set_prmGetOut_OutputPort(
-      NATIVE_INT_TYPE portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    portNum < this->getNum_prmGetOut_OutputPorts(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-
-  this->m_prmGetOut_OutputPort[portNum].registerSerialPort(port);
-}
-
-void PassiveTelemetryComponentBase ::
   set_prmSetOut_OutputPort(
       NATIVE_INT_TYPE portNum,
       Fw::InputSerializePort* port
@@ -919,20 +905,6 @@ void PassiveTelemetryComponentBase ::
   );
 
   this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
-}
-
-void PassiveTelemetryComponentBase ::
-  set_typedReturnOut_OutputPort(
-      NATIVE_INT_TYPE portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    portNum < this->getNum_typedReturnOut_OutputPorts(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-
-  this->m_typedReturnOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/component/PassiveTelemetryComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/PassiveTelemetryComponentAc.ref.hpp
@@ -291,12 +291,6 @@ class PassiveTelemetryComponentBase :
         Fw::InputSerializePort* port //!< The port
     );
 
-    //! Connect port to prmGetOut[portNum]
-    void set_prmGetOut_OutputPort(
-        NATIVE_INT_TYPE portNum, //!< The port number
-        Fw::InputSerializePort* port //!< The port
-    );
-
     //! Connect port to prmSetOut[portNum]
     void set_prmSetOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
@@ -337,12 +331,6 @@ class PassiveTelemetryComponentBase :
 
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
-        NATIVE_INT_TYPE portNum, //!< The port number
-        Fw::InputSerializePort* port //!< The port
-    );
-
-    //! Connect port to typedReturnOut[portNum]
-    void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
         Fw::InputSerializePort* port //!< The port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/PassiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/PassiveTestComponentAc.ref.cpp
@@ -826,20 +826,6 @@ void PassiveTestComponentBase ::
 }
 
 void PassiveTestComponentBase ::
-  set_prmGetOut_OutputPort(
-      NATIVE_INT_TYPE portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    portNum < this->getNum_prmGetOut_OutputPorts(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-
-  this->m_prmGetOut_OutputPort[portNum].registerSerialPort(port);
-}
-
-void PassiveTestComponentBase ::
   set_prmSetOut_OutputPort(
       NATIVE_INT_TYPE portNum,
       Fw::InputSerializePort* port
@@ -919,20 +905,6 @@ void PassiveTestComponentBase ::
   );
 
   this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
-}
-
-void PassiveTestComponentBase ::
-  set_typedReturnOut_OutputPort(
-      NATIVE_INT_TYPE portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    portNum < this->getNum_typedReturnOut_OutputPorts(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-
-  this->m_typedReturnOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/component/PassiveTestComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/PassiveTestComponentAc.ref.hpp
@@ -350,12 +350,6 @@ class PassiveTestComponentBase :
         Fw::InputSerializePort* port //!< The port
     );
 
-    //! Connect port to prmGetOut[portNum]
-    void set_prmGetOut_OutputPort(
-        NATIVE_INT_TYPE portNum, //!< The port number
-        Fw::InputSerializePort* port //!< The port
-    );
-
     //! Connect port to prmSetOut[portNum]
     void set_prmSetOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
@@ -396,12 +390,6 @@ class PassiveTestComponentBase :
 
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
-        NATIVE_INT_TYPE portNum, //!< The port number
-        Fw::InputSerializePort* port //!< The port
-    );
-
-    //! Connect port to typedReturnOut[portNum]
-    void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
         Fw::InputSerializePort* port //!< The port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/QueuedCommandsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/QueuedCommandsComponentAc.ref.cpp
@@ -1042,20 +1042,6 @@ void QueuedCommandsComponentBase ::
 }
 
 void QueuedCommandsComponentBase ::
-  set_prmGetOut_OutputPort(
-      NATIVE_INT_TYPE portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    portNum < this->getNum_prmGetOut_OutputPorts(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-
-  this->m_prmGetOut_OutputPort[portNum].registerSerialPort(port);
-}
-
-void QueuedCommandsComponentBase ::
   set_prmSetOut_OutputPort(
       NATIVE_INT_TYPE portNum,
       Fw::InputSerializePort* port
@@ -1135,20 +1121,6 @@ void QueuedCommandsComponentBase ::
   );
 
   this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
-}
-
-void QueuedCommandsComponentBase ::
-  set_typedReturnOut_OutputPort(
-      NATIVE_INT_TYPE portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    portNum < this->getNum_typedReturnOut_OutputPorts(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-
-  this->m_typedReturnOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/component/QueuedCommandsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/QueuedCommandsComponentAc.ref.hpp
@@ -338,12 +338,6 @@ class QueuedCommandsComponentBase :
         Fw::InputSerializePort* port //!< The port
     );
 
-    //! Connect port to prmGetOut[portNum]
-    void set_prmGetOut_OutputPort(
-        NATIVE_INT_TYPE portNum, //!< The port number
-        Fw::InputSerializePort* port //!< The port
-    );
-
     //! Connect port to prmSetOut[portNum]
     void set_prmSetOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
@@ -384,12 +378,6 @@ class QueuedCommandsComponentBase :
 
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
-        NATIVE_INT_TYPE portNum, //!< The port number
-        Fw::InputSerializePort* port //!< The port
-    );
-
-    //! Connect port to typedReturnOut[portNum]
-    void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
         Fw::InputSerializePort* port //!< The port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/QueuedEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/QueuedEventsComponentAc.ref.cpp
@@ -1037,20 +1037,6 @@ void QueuedEventsComponentBase ::
 }
 
 void QueuedEventsComponentBase ::
-  set_prmGetOut_OutputPort(
-      NATIVE_INT_TYPE portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    portNum < this->getNum_prmGetOut_OutputPorts(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-
-  this->m_prmGetOut_OutputPort[portNum].registerSerialPort(port);
-}
-
-void QueuedEventsComponentBase ::
   set_prmSetOut_OutputPort(
       NATIVE_INT_TYPE portNum,
       Fw::InputSerializePort* port
@@ -1130,20 +1116,6 @@ void QueuedEventsComponentBase ::
   );
 
   this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
-}
-
-void QueuedEventsComponentBase ::
-  set_typedReturnOut_OutputPort(
-      NATIVE_INT_TYPE portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    portNum < this->getNum_typedReturnOut_OutputPorts(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-
-  this->m_typedReturnOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/component/QueuedEventsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/QueuedEventsComponentAc.ref.hpp
@@ -335,12 +335,6 @@ class QueuedEventsComponentBase :
         Fw::InputSerializePort* port //!< The port
     );
 
-    //! Connect port to prmGetOut[portNum]
-    void set_prmGetOut_OutputPort(
-        NATIVE_INT_TYPE portNum, //!< The port number
-        Fw::InputSerializePort* port //!< The port
-    );
-
     //! Connect port to prmSetOut[portNum]
     void set_prmSetOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
@@ -381,12 +375,6 @@ class QueuedEventsComponentBase :
 
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
-        NATIVE_INT_TYPE portNum, //!< The port number
-        Fw::InputSerializePort* port //!< The port
-    );
-
-    //! Connect port to typedReturnOut[portNum]
-    void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
         Fw::InputSerializePort* port //!< The port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/QueuedParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/QueuedParamsComponentAc.ref.cpp
@@ -1037,20 +1037,6 @@ void QueuedParamsComponentBase ::
 }
 
 void QueuedParamsComponentBase ::
-  set_prmGetOut_OutputPort(
-      NATIVE_INT_TYPE portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    portNum < this->getNum_prmGetOut_OutputPorts(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-
-  this->m_prmGetOut_OutputPort[portNum].registerSerialPort(port);
-}
-
-void QueuedParamsComponentBase ::
   set_prmSetOut_OutputPort(
       NATIVE_INT_TYPE portNum,
       Fw::InputSerializePort* port
@@ -1130,20 +1116,6 @@ void QueuedParamsComponentBase ::
   );
 
   this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
-}
-
-void QueuedParamsComponentBase ::
-  set_typedReturnOut_OutputPort(
-      NATIVE_INT_TYPE portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    portNum < this->getNum_typedReturnOut_OutputPorts(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-
-  this->m_typedReturnOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/component/QueuedParamsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/QueuedParamsComponentAc.ref.hpp
@@ -344,12 +344,6 @@ class QueuedParamsComponentBase :
         Fw::InputSerializePort* port //!< The port
     );
 
-    //! Connect port to prmGetOut[portNum]
-    void set_prmGetOut_OutputPort(
-        NATIVE_INT_TYPE portNum, //!< The port number
-        Fw::InputSerializePort* port //!< The port
-    );
-
     //! Connect port to prmSetOut[portNum]
     void set_prmSetOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
@@ -390,12 +384,6 @@ class QueuedParamsComponentBase :
 
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
-        NATIVE_INT_TYPE portNum, //!< The port number
-        Fw::InputSerializePort* port //!< The port
-    );
-
-    //! Connect port to typedReturnOut[portNum]
-    void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
         Fw::InputSerializePort* port //!< The port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/QueuedSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/QueuedSerialComponentAc.ref.cpp
@@ -1349,20 +1349,6 @@ void QueuedSerialComponentBase ::
 }
 
 void QueuedSerialComponentBase ::
-  set_prmGetOut_OutputPort(
-      NATIVE_INT_TYPE portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    portNum < this->getNum_prmGetOut_OutputPorts(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-
-  this->m_prmGetOut_OutputPort[portNum].registerSerialPort(port);
-}
-
-void QueuedSerialComponentBase ::
   set_prmSetOut_OutputPort(
       NATIVE_INT_TYPE portNum,
       Fw::InputSerializePort* port
@@ -1442,20 +1428,6 @@ void QueuedSerialComponentBase ::
   );
 
   this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
-}
-
-void QueuedSerialComponentBase ::
-  set_typedReturnOut_OutputPort(
-      NATIVE_INT_TYPE portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    portNum < this->getNum_typedReturnOut_OutputPorts(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-
-  this->m_typedReturnOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/component/QueuedSerialComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/QueuedSerialComponentAc.ref.hpp
@@ -478,12 +478,6 @@ class QueuedSerialComponentBase :
         Fw::InputSerializePort* port //!< The port
     );
 
-    //! Connect port to prmGetOut[portNum]
-    void set_prmGetOut_OutputPort(
-        NATIVE_INT_TYPE portNum, //!< The port number
-        Fw::InputSerializePort* port //!< The port
-    );
-
     //! Connect port to prmSetOut[portNum]
     void set_prmSetOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
@@ -524,12 +518,6 @@ class QueuedSerialComponentBase :
 
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
-        NATIVE_INT_TYPE portNum, //!< The port number
-        Fw::InputSerializePort* port //!< The port
-    );
-
-    //! Connect port to typedReturnOut[portNum]
-    void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
         Fw::InputSerializePort* port //!< The port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/QueuedTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/QueuedTelemetryComponentAc.ref.cpp
@@ -1037,20 +1037,6 @@ void QueuedTelemetryComponentBase ::
 }
 
 void QueuedTelemetryComponentBase ::
-  set_prmGetOut_OutputPort(
-      NATIVE_INT_TYPE portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    portNum < this->getNum_prmGetOut_OutputPorts(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-
-  this->m_prmGetOut_OutputPort[portNum].registerSerialPort(port);
-}
-
-void QueuedTelemetryComponentBase ::
   set_prmSetOut_OutputPort(
       NATIVE_INT_TYPE portNum,
       Fw::InputSerializePort* port
@@ -1130,20 +1116,6 @@ void QueuedTelemetryComponentBase ::
   );
 
   this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
-}
-
-void QueuedTelemetryComponentBase ::
-  set_typedReturnOut_OutputPort(
-      NATIVE_INT_TYPE portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    portNum < this->getNum_typedReturnOut_OutputPorts(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-
-  this->m_typedReturnOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/component/QueuedTelemetryComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/QueuedTelemetryComponentAc.ref.hpp
@@ -332,12 +332,6 @@ class QueuedTelemetryComponentBase :
         Fw::InputSerializePort* port //!< The port
     );
 
-    //! Connect port to prmGetOut[portNum]
-    void set_prmGetOut_OutputPort(
-        NATIVE_INT_TYPE portNum, //!< The port number
-        Fw::InputSerializePort* port //!< The port
-    );
-
     //! Connect port to prmSetOut[portNum]
     void set_prmSetOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
@@ -378,12 +372,6 @@ class QueuedTelemetryComponentBase :
 
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
-        NATIVE_INT_TYPE portNum, //!< The port number
-        Fw::InputSerializePort* port //!< The port
-    );
-
-    //! Connect port to typedReturnOut[portNum]
-    void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
         Fw::InputSerializePort* port //!< The port
     );

--- a/compiler/tools/fpp-to-cpp/test/component/QueuedTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/QueuedTestComponentAc.ref.cpp
@@ -1073,20 +1073,6 @@ void QueuedTestComponentBase ::
 }
 
 void QueuedTestComponentBase ::
-  set_prmGetOut_OutputPort(
-      NATIVE_INT_TYPE portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    portNum < this->getNum_prmGetOut_OutputPorts(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-
-  this->m_prmGetOut_OutputPort[portNum].registerSerialPort(port);
-}
-
-void QueuedTestComponentBase ::
   set_prmSetOut_OutputPort(
       NATIVE_INT_TYPE portNum,
       Fw::InputSerializePort* port
@@ -1166,20 +1152,6 @@ void QueuedTestComponentBase ::
   );
 
   this->m_typedOut_OutputPort[portNum].registerSerialPort(port);
-}
-
-void QueuedTestComponentBase ::
-  set_typedReturnOut_OutputPort(
-      NATIVE_INT_TYPE portNum,
-      Fw::InputSerializePort* port
-  )
-{
-  FW_ASSERT(
-    portNum < this->getNum_typedReturnOut_OutputPorts(),
-    static_cast<FwAssertArgType>(portNum)
-  );
-
-  this->m_typedReturnOut_OutputPort[portNum].registerSerialPort(port);
 }
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/component/QueuedTestComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/QueuedTestComponentAc.ref.hpp
@@ -397,12 +397,6 @@ class QueuedTestComponentBase :
         Fw::InputSerializePort* port //!< The port
     );
 
-    //! Connect port to prmGetOut[portNum]
-    void set_prmGetOut_OutputPort(
-        NATIVE_INT_TYPE portNum, //!< The port number
-        Fw::InputSerializePort* port //!< The port
-    );
-
     //! Connect port to prmSetOut[portNum]
     void set_prmSetOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
@@ -443,12 +437,6 @@ class QueuedTestComponentBase :
 
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
-        NATIVE_INT_TYPE portNum, //!< The port number
-        Fw::InputSerializePort* port //!< The port
-    );
-
-    //! Connect port to typedReturnOut[portNum]
-    void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
         Fw::InputSerializePort* port //!< The port
     );


### PR DESCRIPTION
Closes #256.

Also fixes the comment formatting in `addSeparatedPrecomment()`  in `CppWriterUtils`.