### PR TITLE
Remove private parameter getter in C++ component writer

### DIFF
--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentParameters.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentParameters.scala
@@ -49,7 +49,6 @@ case class ComponentParameters (
   def getPrivateFunctionMembers: List[CppDoc.Class.Member] = {
     if !hasParameters then Nil
     else List(
-      getPrivateGetter,
       getSetters,
       getSaveFunctions
     ).flatten
@@ -254,42 +253,6 @@ case class ComponentParameters (
                 |this->m_paramLock.unLock();
                 |return _local;
                 |"""
-          )
-        )
-      )
-    )
-  }
-
-  private def getPrivateGetter: List[CppDoc.Class.Member] = {
-    addAccessTagAndComment(
-      "PRIVATE",
-      "Private parameter get function",
-      List(
-        functionClassMember(
-          Some(
-            """|Get a parameter by ID
-               |
-               |\return Whether the parameter is valid
-               |"""
-          ),
-          "getParam",
-          List(
-            CppDoc.Function.Param(
-              CppDoc.Type("FwPrmIdType"),
-              "id",
-              Some("The ID")
-            ),
-            CppDoc.Function.Param(
-              CppDoc.Type("Fw::ParamBuffer&"),
-              "buff",
-              Some("The parameter value")
-            )
-          ),
-          CppDoc.Type("Fw::ParamValid"),
-          wrapInIfElse(
-            s"this->${portVariableName(prmGetPort.get)}[0].isConnected()",
-            lines(s"return this->${portVariableName(prmGetPort.get)}[0].invoke(id, buff);"),
-            lines("return Fw::ParamValid::INVALID;")
           )
         )
       )

--- a/compiler/tools/fpp-to-cpp/test/component/ActiveParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/ActiveParamsComponentAc.ref.cpp
@@ -3391,24 +3391,6 @@ void ActiveParamsComponentBase ::
 }
 
 // ----------------------------------------------------------------------
-// Private parameter get function
-// ----------------------------------------------------------------------
-
-Fw::ParamValid ActiveParamsComponentBase ::
-  getParam(
-      FwPrmIdType id,
-      Fw::ParamBuffer& buff
-  )
-{
-  if (this->m_prmGetOut_OutputPort[0].isConnected()) {
-    return this->m_prmGetOut_OutputPort[0].invoke(id, buff);
-  }
-  else {
-    return Fw::ParamValid::INVALID;
-  }
-}
-
-// ----------------------------------------------------------------------
 // Parameter set functions
 // ----------------------------------------------------------------------
 

--- a/compiler/tools/fpp-to-cpp/test/component/ActiveParamsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/ActiveParamsComponentAc.ref.hpp
@@ -1297,20 +1297,6 @@ class ActiveParamsComponentBase :
   PRIVATE:
 
     // ----------------------------------------------------------------------
-    // Private parameter get function
-    // ----------------------------------------------------------------------
-
-    //! Get a parameter by ID
-    //!
-    //! \return Whether the parameter is valid
-    Fw::ParamValid getParam(
-        FwPrmIdType id, //!< The ID
-        Fw::ParamBuffer& buff //!< The parameter value
-    );
-
-  PRIVATE:
-
-    // ----------------------------------------------------------------------
     // Parameter set functions
     // ----------------------------------------------------------------------
 

--- a/compiler/tools/fpp-to-cpp/test/component/ActiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/ActiveSerialComponentAc.ref.cpp
@@ -7278,24 +7278,6 @@ void ActiveSerialComponentBase ::
 #endif
 
 // ----------------------------------------------------------------------
-// Private parameter get function
-// ----------------------------------------------------------------------
-
-Fw::ParamValid ActiveSerialComponentBase ::
-  getParam(
-      FwPrmIdType id,
-      Fw::ParamBuffer& buff
-  )
-{
-  if (this->m_prmGetOut_OutputPort[0].isConnected()) {
-    return this->m_prmGetOut_OutputPort[0].invoke(id, buff);
-  }
-  else {
-    return Fw::ParamValid::INVALID;
-  }
-}
-
-// ----------------------------------------------------------------------
 // Parameter set functions
 // ----------------------------------------------------------------------
 

--- a/compiler/tools/fpp-to-cpp/test/component/ActiveSerialComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/ActiveSerialComponentAc.ref.hpp
@@ -2289,20 +2289,6 @@ class ActiveSerialComponentBase :
   PRIVATE:
 
     // ----------------------------------------------------------------------
-    // Private parameter get function
-    // ----------------------------------------------------------------------
-
-    //! Get a parameter by ID
-    //!
-    //! \return Whether the parameter is valid
-    Fw::ParamValid getParam(
-        FwPrmIdType id, //!< The ID
-        Fw::ParamBuffer& buff //!< The parameter value
-    );
-
-  PRIVATE:
-
-    // ----------------------------------------------------------------------
     // Parameter set functions
     // ----------------------------------------------------------------------
 

--- a/compiler/tools/fpp-to-cpp/test/component/ActiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/ActiveTestComponentAc.ref.cpp
@@ -6438,24 +6438,6 @@ void ActiveTestComponentBase ::
 }
 
 // ----------------------------------------------------------------------
-// Private parameter get function
-// ----------------------------------------------------------------------
-
-Fw::ParamValid ActiveTestComponentBase ::
-  getParam(
-      FwPrmIdType id,
-      Fw::ParamBuffer& buff
-  )
-{
-  if (this->m_prmGetOut_OutputPort[0].isConnected()) {
-    return this->m_prmGetOut_OutputPort[0].invoke(id, buff);
-  }
-  else {
-    return Fw::ParamValid::INVALID;
-  }
-}
-
-// ----------------------------------------------------------------------
 // Parameter set functions
 // ----------------------------------------------------------------------
 

--- a/compiler/tools/fpp-to-cpp/test/component/ActiveTestComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/ActiveTestComponentAc.ref.hpp
@@ -1948,20 +1948,6 @@ class ActiveTestComponentBase :
   PRIVATE:
 
     // ----------------------------------------------------------------------
-    // Private parameter get function
-    // ----------------------------------------------------------------------
-
-    //! Get a parameter by ID
-    //!
-    //! \return Whether the parameter is valid
-    Fw::ParamValid getParam(
-        FwPrmIdType id, //!< The ID
-        Fw::ParamBuffer& buff //!< The parameter value
-    );
-
-  PRIVATE:
-
-    // ----------------------------------------------------------------------
     // Parameter set functions
     // ----------------------------------------------------------------------
 

--- a/compiler/tools/fpp-to-cpp/test/component/PassiveParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/PassiveParamsComponentAc.ref.cpp
@@ -2137,24 +2137,6 @@ void PassiveParamsComponentBase ::
 }
 
 // ----------------------------------------------------------------------
-// Private parameter get function
-// ----------------------------------------------------------------------
-
-Fw::ParamValid PassiveParamsComponentBase ::
-  getParam(
-      FwPrmIdType id,
-      Fw::ParamBuffer& buff
-  )
-{
-  if (this->m_prmGetOut_OutputPort[0].isConnected()) {
-    return this->m_prmGetOut_OutputPort[0].invoke(id, buff);
-  }
-  else {
-    return Fw::ParamValid::INVALID;
-  }
-}
-
-// ----------------------------------------------------------------------
 // Parameter set functions
 // ----------------------------------------------------------------------
 

--- a/compiler/tools/fpp-to-cpp/test/component/PassiveParamsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/PassiveParamsComponentAc.ref.hpp
@@ -995,20 +995,6 @@ class PassiveParamsComponentBase :
   PRIVATE:
 
     // ----------------------------------------------------------------------
-    // Private parameter get function
-    // ----------------------------------------------------------------------
-
-    //! Get a parameter by ID
-    //!
-    //! \return Whether the parameter is valid
-    Fw::ParamValid getParam(
-        FwPrmIdType id, //!< The ID
-        Fw::ParamBuffer& buff //!< The parameter value
-    );
-
-  PRIVATE:
-
-    // ----------------------------------------------------------------------
     // Parameter set functions
     // ----------------------------------------------------------------------
 

--- a/compiler/tools/fpp-to-cpp/test/component/PassiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/PassiveSerialComponentAc.ref.cpp
@@ -4317,24 +4317,6 @@ void PassiveSerialComponentBase ::
 #endif
 
 // ----------------------------------------------------------------------
-// Private parameter get function
-// ----------------------------------------------------------------------
-
-Fw::ParamValid PassiveSerialComponentBase ::
-  getParam(
-      FwPrmIdType id,
-      Fw::ParamBuffer& buff
-  )
-{
-  if (this->m_prmGetOut_OutputPort[0].isConnected()) {
-    return this->m_prmGetOut_OutputPort[0].invoke(id, buff);
-  }
-  else {
-    return Fw::ParamValid::INVALID;
-  }
-}
-
-// ----------------------------------------------------------------------
 // Parameter set functions
 // ----------------------------------------------------------------------
 

--- a/compiler/tools/fpp-to-cpp/test/component/PassiveSerialComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/PassiveSerialComponentAc.ref.hpp
@@ -1617,20 +1617,6 @@ class PassiveSerialComponentBase :
   PRIVATE:
 
     // ----------------------------------------------------------------------
-    // Private parameter get function
-    // ----------------------------------------------------------------------
-
-    //! Get a parameter by ID
-    //!
-    //! \return Whether the parameter is valid
-    Fw::ParamValid getParam(
-        FwPrmIdType id, //!< The ID
-        Fw::ParamBuffer& buff //!< The parameter value
-    );
-
-  PRIVATE:
-
-    // ----------------------------------------------------------------------
     // Parameter set functions
     // ----------------------------------------------------------------------
 

--- a/compiler/tools/fpp-to-cpp/test/component/PassiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/PassiveTestComponentAc.ref.cpp
@@ -4030,24 +4030,6 @@ void PassiveTestComponentBase ::
 }
 
 // ----------------------------------------------------------------------
-// Private parameter get function
-// ----------------------------------------------------------------------
-
-Fw::ParamValid PassiveTestComponentBase ::
-  getParam(
-      FwPrmIdType id,
-      Fw::ParamBuffer& buff
-  )
-{
-  if (this->m_prmGetOut_OutputPort[0].isConnected()) {
-    return this->m_prmGetOut_OutputPort[0].invoke(id, buff);
-  }
-  else {
-    return Fw::ParamValid::INVALID;
-  }
-}
-
-// ----------------------------------------------------------------------
 // Parameter set functions
 // ----------------------------------------------------------------------
 

--- a/compiler/tools/fpp-to-cpp/test/component/PassiveTestComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/PassiveTestComponentAc.ref.hpp
@@ -1439,20 +1439,6 @@ class PassiveTestComponentBase :
   PRIVATE:
 
     // ----------------------------------------------------------------------
-    // Private parameter get function
-    // ----------------------------------------------------------------------
-
-    //! Get a parameter by ID
-    //!
-    //! \return Whether the parameter is valid
-    Fw::ParamValid getParam(
-        FwPrmIdType id, //!< The ID
-        Fw::ParamBuffer& buff //!< The parameter value
-    );
-
-  PRIVATE:
-
-    // ----------------------------------------------------------------------
     // Parameter set functions
     // ----------------------------------------------------------------------
 

--- a/compiler/tools/fpp-to-cpp/test/component/QueuedParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/QueuedParamsComponentAc.ref.cpp
@@ -3396,24 +3396,6 @@ void QueuedParamsComponentBase ::
 }
 
 // ----------------------------------------------------------------------
-// Private parameter get function
-// ----------------------------------------------------------------------
-
-Fw::ParamValid QueuedParamsComponentBase ::
-  getParam(
-      FwPrmIdType id,
-      Fw::ParamBuffer& buff
-  )
-{
-  if (this->m_prmGetOut_OutputPort[0].isConnected()) {
-    return this->m_prmGetOut_OutputPort[0].invoke(id, buff);
-  }
-  else {
-    return Fw::ParamValid::INVALID;
-  }
-}
-
-// ----------------------------------------------------------------------
 // Parameter set functions
 // ----------------------------------------------------------------------
 

--- a/compiler/tools/fpp-to-cpp/test/component/QueuedParamsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/QueuedParamsComponentAc.ref.hpp
@@ -1297,20 +1297,6 @@ class QueuedParamsComponentBase :
   PRIVATE:
 
     // ----------------------------------------------------------------------
-    // Private parameter get function
-    // ----------------------------------------------------------------------
-
-    //! Get a parameter by ID
-    //!
-    //! \return Whether the parameter is valid
-    Fw::ParamValid getParam(
-        FwPrmIdType id, //!< The ID
-        Fw::ParamBuffer& buff //!< The parameter value
-    );
-
-  PRIVATE:
-
-    // ----------------------------------------------------------------------
     // Parameter set functions
     // ----------------------------------------------------------------------
 

--- a/compiler/tools/fpp-to-cpp/test/component/QueuedSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/QueuedSerialComponentAc.ref.cpp
@@ -7283,24 +7283,6 @@ void QueuedSerialComponentBase ::
 #endif
 
 // ----------------------------------------------------------------------
-// Private parameter get function
-// ----------------------------------------------------------------------
-
-Fw::ParamValid QueuedSerialComponentBase ::
-  getParam(
-      FwPrmIdType id,
-      Fw::ParamBuffer& buff
-  )
-{
-  if (this->m_prmGetOut_OutputPort[0].isConnected()) {
-    return this->m_prmGetOut_OutputPort[0].invoke(id, buff);
-  }
-  else {
-    return Fw::ParamValid::INVALID;
-  }
-}
-
-// ----------------------------------------------------------------------
 // Parameter set functions
 // ----------------------------------------------------------------------
 

--- a/compiler/tools/fpp-to-cpp/test/component/QueuedSerialComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/QueuedSerialComponentAc.ref.hpp
@@ -2289,20 +2289,6 @@ class QueuedSerialComponentBase :
   PRIVATE:
 
     // ----------------------------------------------------------------------
-    // Private parameter get function
-    // ----------------------------------------------------------------------
-
-    //! Get a parameter by ID
-    //!
-    //! \return Whether the parameter is valid
-    Fw::ParamValid getParam(
-        FwPrmIdType id, //!< The ID
-        Fw::ParamBuffer& buff //!< The parameter value
-    );
-
-  PRIVATE:
-
-    // ----------------------------------------------------------------------
     // Parameter set functions
     // ----------------------------------------------------------------------
 

--- a/compiler/tools/fpp-to-cpp/test/component/QueuedTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/QueuedTestComponentAc.ref.cpp
@@ -6443,24 +6443,6 @@ void QueuedTestComponentBase ::
 }
 
 // ----------------------------------------------------------------------
-// Private parameter get function
-// ----------------------------------------------------------------------
-
-Fw::ParamValid QueuedTestComponentBase ::
-  getParam(
-      FwPrmIdType id,
-      Fw::ParamBuffer& buff
-  )
-{
-  if (this->m_prmGetOut_OutputPort[0].isConnected()) {
-    return this->m_prmGetOut_OutputPort[0].invoke(id, buff);
-  }
-  else {
-    return Fw::ParamValid::INVALID;
-  }
-}
-
-// ----------------------------------------------------------------------
 // Parameter set functions
 // ----------------------------------------------------------------------
 

--- a/compiler/tools/fpp-to-cpp/test/component/QueuedTestComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/QueuedTestComponentAc.ref.hpp
@@ -1948,20 +1948,6 @@ class QueuedTestComponentBase :
   PRIVATE:
 
     // ----------------------------------------------------------------------
-    // Private parameter get function
-    // ----------------------------------------------------------------------
-
-    //! Get a parameter by ID
-    //!
-    //! \return Whether the parameter is valid
-    Fw::ParamValid getParam(
-        FwPrmIdType id, //!< The ID
-        Fw::ParamBuffer& buff //!< The parameter value
-    );
-
-  PRIVATE:
-
-    // ----------------------------------------------------------------------
     // Parameter set functions
     // ----------------------------------------------------------------------
 


### PR DESCRIPTION
Remove the `getParam` function in component base classes. This is a private function that gets parameters by ID, but it is private and not used elsewhere in the component base class. It is also not used in any of the F Prime framework classes, and the F Prime framework successfully builds and passes all unit tests after the removal of this function.