### PR TITLE
Revise handling of incorrect options to FPP tools

### DIFF
--- a/compiler/lib/src/main/scala/util/Tool.scala
+++ b/compiler/lib/src/main/scala/util/Tool.scala
@@ -1,6 +1,31 @@
 package fpp.compiler.util
 
+import scopt.OParser
+
 /** An FPP compilation tool */
 final case class Tool(name: String) {
+
   override def toString = name
+
+  /** The main method for the tool */
+  def mainMethod[Options,Return](
+    args: Array[String],
+    oparser: OParser[Unit, Options],
+    initialOptions: Options,
+    command: Options => Result.Result[Return]
+  ): Unit = {
+    def errorExit = System.exit(1)
+    Error.setTool(this)
+    OParser.parse(oparser, args, initialOptions) match {
+      case Some(options) => command(options) match {
+        case Left(error) => {
+          error.print
+          errorExit
+        }
+        case _ => ()
+      }
+      case None => errorExit
+    }
+  }
+
 }

--- a/compiler/tools/fpp-check/src/main/scala/fpp-check.scala
+++ b/compiler/tools/fpp-check/src/main/scala/fpp-check.scala
@@ -50,19 +50,20 @@ object FPPCheck {
       }
   }
 
+  def errorExit = System.exit(1)
+
   def main(args: Array[String]) = {
     Error.setTool(Tool(name))
-    val options = OParser.parse(oparser, args, Options())
-    for { result <- options } yield {
-      command(result) match {
+    OParser.parse(oparser, args, Options()) match {
+      case Some(options) => command(options) match {
         case Left(error) => {
           error.print
-          System.exit(1)
+          errorExit
         }
         case _ => ()
       }
+      case None => errorExit
     }
-    ()
   }
 
   val builder = OParser.builder[Options]

--- a/compiler/tools/fpp-check/src/main/scala/fpp-check.scala
+++ b/compiler/tools/fpp-check/src/main/scala/fpp-check.scala
@@ -50,7 +50,8 @@ object FPPCheck {
       }
   }
 
-  def main(args: Array[String]) = Tool(name).mainMethod(args, oparser, Options(), command)
+  def main(args: Array[String]) =
+    Tool(name).mainMethod(args, oparser, Options(), command)
 
   val builder = OParser.builder[Options]
 

--- a/compiler/tools/fpp-check/src/main/scala/fpp-check.scala
+++ b/compiler/tools/fpp-check/src/main/scala/fpp-check.scala
@@ -50,21 +50,7 @@ object FPPCheck {
       }
   }
 
-  def errorExit = System.exit(1)
-
-  def main(args: Array[String]) = {
-    Error.setTool(Tool(name))
-    OParser.parse(oparser, args, Options()) match {
-      case Some(options) => command(options) match {
-        case Left(error) => {
-          error.print
-          errorExit
-        }
-        case _ => ()
-      }
-      case None => errorExit
-    }
-  }
+  def main(args: Array[String]) = Tool(name).mainMethod(args, oparser, Options(), command)
 
   val builder = OParser.builder[Options]
 

--- a/compiler/tools/fpp-depend/src/main/scala/fpp-depend.scala
+++ b/compiler/tools/fpp-depend/src/main/scala/fpp-depend.scala
@@ -110,21 +110,8 @@ object FPPDepend {
       }
   }
 
-  def errorExit = System.exit(1)
-
-  def main(args: Array[String]) = {
-    Error.setTool(Tool(name))
-    OParser.parse(oparser, args, Options()) match {
-      case Some(options) => command(options) match {
-        case Left(error) => {
-          error.print
-          errorExit
-        }
-        case _ => ()
-      }
-      case None => errorExit
-    }
-  }
+  def main(args: Array[String]) =
+    Tool(name).mainMethod(args, oparser, Options(), command)
 
   val builder = OParser.builder[Options]
 

--- a/compiler/tools/fpp-depend/src/main/scala/fpp-depend.scala
+++ b/compiler/tools/fpp-depend/src/main/scala/fpp-depend.scala
@@ -110,19 +110,20 @@ object FPPDepend {
       }
   }
 
+  def errorExit = System.exit(1)
+
   def main(args: Array[String]) = {
     Error.setTool(Tool(name))
-    val options = OParser.parse(oparser, args, Options())
-    for { result <- options } yield {
-      command(result) match {
+    OParser.parse(oparser, args, Options()) match {
+      case Some(options) => command(options) match {
         case Left(error) => {
           error.print
-          System.exit(1)
+          errorExit
         }
         case _ => ()
       }
+      case None => errorExit
     }
-    ()
   }
 
   val builder = OParser.builder[Options]

--- a/compiler/tools/fpp-filenames/src/main/scala/fpp-filenames.scala
+++ b/compiler/tools/fpp-filenames/src/main/scala/fpp-filenames.scala
@@ -36,19 +36,20 @@ object FPPFilenames {
     yield files.sorted.map(System.out.println)
   }
 
+  def errorExit = System.exit(1)
+
   def main(args: Array[String]) = {
     Error.setTool(Tool(name))
-    val options = OParser.parse(oparser, args, Options())
-    for { result <- options } yield {
-      command(result) match {
+    OParser.parse(oparser, args, Options()) match {
+      case Some(options) => command(options) match {
         case Left(error) => {
           error.print
-          System.exit(1)
+          errorExit
         }
         case _ => ()
       }
+      case None => errorExit
     }
-    ()
   }
 
   val builder = OParser.builder[Options]

--- a/compiler/tools/fpp-filenames/src/main/scala/fpp-filenames.scala
+++ b/compiler/tools/fpp-filenames/src/main/scala/fpp-filenames.scala
@@ -36,21 +36,8 @@ object FPPFilenames {
     yield files.sorted.map(System.out.println)
   }
 
-  def errorExit = System.exit(1)
-
-  def main(args: Array[String]) = {
-    Error.setTool(Tool(name))
-    OParser.parse(oparser, args, Options()) match {
-      case Some(options) => command(options) match {
-        case Left(error) => {
-          error.print
-          errorExit
-        }
-        case _ => ()
-      }
-      case None => errorExit
-    }
-  }
+  def main(args: Array[String]) =
+    Tool(name).mainMethod(args, oparser, Options(), command)
 
   val builder = OParser.builder[Options]
 

--- a/compiler/tools/fpp-format/src/main/scala/fpp-format.scala
+++ b/compiler/tools/fpp-format/src/main/scala/fpp-format.scala
@@ -28,17 +28,18 @@ object FPPFormat {
     result match {
       case Left(error) => {
         error.print
-        System.exit(1)
+        errorExit
       }
-      case Right(_) => ()
+      case _ => ()
     }
   }
 
+  def errorExit = System.exit(1)
+
   def main(args: Array[String]) = {
-    val options = OParser.parse(oparser, args, Options())
-    options match {
+    OParser.parse(oparser, args, Options()) match {
       case Some(options) => command(options)
-      case None => ()
+      case None => errorExit
     }
   }
 

--- a/compiler/tools/fpp-format/src/main/scala/fpp-format.scala
+++ b/compiler/tools/fpp-format/src/main/scala/fpp-format.scala
@@ -21,29 +21,18 @@ object FPPFormat {
       case Nil => List(File.StdIn)
       case list => list
     }
-    val result = Result.seq(
+    Result.seq(
       Result.map(files, Parser.parseFile (Parser.transUnit) (None) _),
       List(resolveIncludes (options) _, writeFpp (options) _)
     )
-    result match {
-      case Left(error) => {
-        error.print
-        errorExit
-      }
-      case _ => ()
-    }
   }
 
-  def errorExit = System.exit(1)
+  def main(args: Array[String]) =
+    Tool(name).mainMethod(args, oparser, Options(), command)
 
-  def main(args: Array[String]) = {
-    OParser.parse(oparser, args, Options()) match {
-      case Some(options) => command(options)
-      case None => errorExit
-    }
-  }
-
-  def resolveIncludes(options: Options)(tul: List[Ast.TransUnit]): Result.Result[List[Ast.TransUnit]] = {
+  def resolveIncludes(options: Options)(tul: List[Ast.TransUnit]):
+    Result.Result[List[Ast.TransUnit]] =
+  {
     options.include match {
       case true => for { 
         result <- ResolveSpecInclude.transformList(
@@ -56,7 +45,9 @@ object FPPFormat {
     }
   }
 
-  def writeFpp(options: Options)(tul: List[Ast.TransUnit]): Result.Result[List[Ast.TransUnit]] = {
+  def writeFpp(options: Options)(tul: List[Ast.TransUnit]):
+    Result.Result[List[Ast.TransUnit]] =
+  {
     val lines = tul.map(FppWriter.transUnit).flatten
     lines.map(Line.write(Line.stdout) _)
     Right(tul)

--- a/compiler/tools/fpp-from-xml/src/main/scala/fpp-from-xml.scala
+++ b/compiler/tools/fpp-from-xml/src/main/scala/fpp-from-xml.scala
@@ -30,19 +30,20 @@ object FPPFromXml {
     yield XmlFppWriter.File(file.toString, elem)
   }
 
+  def errorExit = System.exit(1)
+
   def main(args: Array[String]) = {
     Error.setTool(Tool(name))
-    val options = OParser.parse(oparser, args, Options())
-    for { result <- options } yield {
-      command(result) match {
+    OParser.parse(oparser, args, Options()) match {
+      case Some(options) => command(options) match {
         case Left(error) => {
           error.print
-          System.exit(1)
+          errorExit
         }
         case _ => ()
       }
+      case None => errorExit
     }
-    ()
   }
 
   val builder = OParser.builder[Options]

--- a/compiler/tools/fpp-from-xml/src/main/scala/fpp-from-xml.scala
+++ b/compiler/tools/fpp-from-xml/src/main/scala/fpp-from-xml.scala
@@ -30,21 +30,8 @@ object FPPFromXml {
     yield XmlFppWriter.File(file.toString, elem)
   }
 
-  def errorExit = System.exit(1)
-
-  def main(args: Array[String]) = {
-    Error.setTool(Tool(name))
-    OParser.parse(oparser, args, Options()) match {
-      case Some(options) => command(options) match {
-        case Left(error) => {
-          error.print
-          errorExit
-        }
-        case _ => ()
-      }
-      case None => errorExit
-    }
-  }
+  def main(args: Array[String]) =
+    Tool(name).mainMethod(args, oparser, Options(), command)
 
   val builder = OParser.builder[Options]
 

--- a/compiler/tools/fpp-locate-defs/src/main/scala/fpp-locate-defs.scala
+++ b/compiler/tools/fpp-locate-defs/src/main/scala/fpp-locate-defs.scala
@@ -42,21 +42,8 @@ object FPPLocateDefs {
     }
   }
 
-  def errorExit = System.exit(1)
-
-  def main(args: Array[String]) = {
-    Error.setTool(Tool(name))
-    OParser.parse(oparser, args, Options()) match {
-      case Some(options) => command(options) match {
-        case Left(error) => {
-          error.print
-          errorExit
-        }
-        case _ => ()
-      }
-      case None => errorExit
-    }
-  }
+  def main(args: Array[String]) =
+    Tool(name).mainMethod(args, oparser, Options(), command)
 
   val builder = OParser.builder[Options]
 

--- a/compiler/tools/fpp-locate-defs/src/main/scala/fpp-locate-defs.scala
+++ b/compiler/tools/fpp-locate-defs/src/main/scala/fpp-locate-defs.scala
@@ -42,19 +42,20 @@ object FPPLocateDefs {
     }
   }
 
+  def errorExit = System.exit(1)
+
   def main(args: Array[String]) = {
     Error.setTool(Tool(name))
-    for (options <- OParser.parse(oparser, args, Options()))
-    yield {
-      command(options) match {
+    OParser.parse(oparser, args, Options()) match {
+      case Some(options) => command(options) match {
         case Left(error) => {
           error.print
-          System.exit(1)
+          errorExit
         }
         case _ => ()
       }
+      case None => errorExit
     }
-    ()
   }
 
   val builder = OParser.builder[Options]

--- a/compiler/tools/fpp-locate-uses/src/main/scala/fpp-locate-uses.scala
+++ b/compiler/tools/fpp-locate-uses/src/main/scala/fpp-locate-uses.scala
@@ -89,19 +89,20 @@ object FPPLocateUses {
     }
   }
 
+  def errorExit = System.exit(1)
+
   def main(args: Array[String]) = {
     Error.setTool(Tool(name))
-    for { options <- OParser.parse(oparser, args, Options()) }
-    yield {
-      command(options) match {
+    OParser.parse(oparser, args, Options()) match {
+      case Some(options) => command(options) match {
         case Left(error) => {
           error.print
-          System.exit(1)
+          errorExit
         }
         case _ => ()
       }
+      case None => errorExit
     }
-    ()
   }
 
   val builder = OParser.builder[Options]

--- a/compiler/tools/fpp-locate-uses/src/main/scala/fpp-locate-uses.scala
+++ b/compiler/tools/fpp-locate-uses/src/main/scala/fpp-locate-uses.scala
@@ -89,21 +89,8 @@ object FPPLocateUses {
     }
   }
 
-  def errorExit = System.exit(1)
-
-  def main(args: Array[String]) = {
-    Error.setTool(Tool(name))
-    OParser.parse(oparser, args, Options()) match {
-      case Some(options) => command(options) match {
-        case Left(error) => {
-          error.print
-          errorExit
-        }
-        case _ => ()
-      }
-      case None => errorExit
-    }
-  }
+  def main(args: Array[String]) =
+    Tool(name).mainMethod(args, oparser, Options(), command)
 
   val builder = OParser.builder[Options]
 

--- a/compiler/tools/fpp-syntax/src/main/scala/fpp-syntax.scala
+++ b/compiler/tools/fpp-syntax/src/main/scala/fpp-syntax.scala
@@ -22,29 +22,18 @@ object FPPSyntax {
       case Nil => List(File.StdIn)
       case list => list
     }
-    val result = Result.seq(
+    Result.seq(
       Result.map(files, Parser.parseFile (Parser.transUnit) (None) _),
       List(resolveIncludes (options) _, printAst (options) _)
     )
-    result match {
-      case Left(error) => {
-        error.print
-        errorExit
-      }
-      case _ => ()
-    }
   }
 
-  def errorExit = System.exit(1)
+  def main(args: Array[String]) =
+    Tool(name).mainMethod(args, oparser, Options(), command)
 
-  def main(args: Array[String]) = {
-    OParser.parse(oparser, args, Options()) match {
-      case Some(options) => command(options)
-      case None => errorExit
-    }
-  }
-
-  def printAst(options: Options)(tul: List[Ast.TransUnit]): Result.Result[List[Ast.TransUnit]] = {
+  def printAst(options: Options)(tul: List[Ast.TransUnit]):
+    Result.Result[List[Ast.TransUnit]] =
+  {
     options.ast match {
       case true => {
         val lines = tul.map(AstWriter.transUnit).flatten
@@ -55,7 +44,9 @@ object FPPSyntax {
     Right(tul)
   }
 
-  def resolveIncludes(options: Options)(tul: List[Ast.TransUnit]): Result.Result[List[Ast.TransUnit]] = {
+  def resolveIncludes(options: Options)(tul: List[Ast.TransUnit]):
+    Result.Result[List[Ast.TransUnit]] =
+  {
     options.include match {
       case true => for { 
         result <- ResolveSpecInclude.transformList(

--- a/compiler/tools/fpp-syntax/src/main/scala/fpp-syntax.scala
+++ b/compiler/tools/fpp-syntax/src/main/scala/fpp-syntax.scala
@@ -29,17 +29,18 @@ object FPPSyntax {
     result match {
       case Left(error) => {
         error.print
-        System.exit(1)
+        errorExit
       }
-      case Right(_) => ()
+      case _ => ()
     }
   }
 
+  def errorExit = System.exit(1)
+
   def main(args: Array[String]) = {
-    val options = OParser.parse(oparser, args, Options())
-    options match {
+    OParser.parse(oparser, args, Options()) match {
       case Some(options) => command(options)
-      case None => ()
+      case None => errorExit
     }
   }
 

--- a/compiler/tools/fpp-to-cpp/src/main/scala/fpp-to-cpp.scala
+++ b/compiler/tools/fpp-to-cpp/src/main/scala/fpp-to-cpp.scala
@@ -89,19 +89,20 @@ object FPPToCpp {
     }
   }
 
+  def errorExit = System.exit(1)
+
   def main(args: Array[String]) = {
     Error.setTool(Tool(name))
-    val options = OParser.parse(oparser, args, Options())
-    for { result <- options } yield {
-      command(result) match {
+    OParser.parse(oparser, args, Options()) match {
+      case Some(options) => command(options) match {
         case Left(error) => {
           error.print
-          System.exit(1)
+          errorExit
         }
         case _ => ()
       }
+      case None => errorExit
     }
-    ()
   }
 
   val builder = OParser.builder[Options]

--- a/compiler/tools/fpp-to-cpp/src/main/scala/fpp-to-cpp.scala
+++ b/compiler/tools/fpp-to-cpp/src/main/scala/fpp-to-cpp.scala
@@ -89,21 +89,8 @@ object FPPToCpp {
     }
   }
 
-  def errorExit = System.exit(1)
-
-  def main(args: Array[String]) = {
-    Error.setTool(Tool(name))
-    OParser.parse(oparser, args, Options()) match {
-      case Some(options) => command(options) match {
-        case Left(error) => {
-          error.print
-          errorExit
-        }
-        case _ => ()
-      }
-      case None => errorExit
-    }
-  }
+  def main(args: Array[String]) =
+    Tool(name).mainMethod(args, oparser, Options(), command)
 
   val builder = OParser.builder[Options]
 

--- a/compiler/tools/fpp-to-xml/src/main/scala/fpp-to-xml.scala
+++ b/compiler/tools/fpp-to-xml/src/main/scala/fpp-to-xml.scala
@@ -63,19 +63,20 @@ object FPPToXml {
     }
   }
 
+  def errorExit = System.exit(1)
+
   def main(args: Array[String]) = {
     Error.setTool(Tool(name))
-    val options = OParser.parse(oparser, args, Options())
-    for { result <- options } yield {
-      command(result) match {
+    OParser.parse(oparser, args, Options()) match {
+      case Some(options) => command(options) match {
         case Left(error) => {
           error.print
-          System.exit(1)
+          errorExit
         }
         case _ => ()
       }
+      case None => errorExit
     }
-    ()
   }
 
   val builder = OParser.builder[Options]

--- a/compiler/tools/fpp-to-xml/src/main/scala/fpp-to-xml.scala
+++ b/compiler/tools/fpp-to-xml/src/main/scala/fpp-to-xml.scala
@@ -63,21 +63,8 @@ object FPPToXml {
     }
   }
 
-  def errorExit = System.exit(1)
-
-  def main(args: Array[String]) = {
-    Error.setTool(Tool(name))
-    OParser.parse(oparser, args, Options()) match {
-      case Some(options) => command(options) match {
-        case Left(error) => {
-          error.print
-          errorExit
-        }
-        case _ => ()
-      }
-      case None => errorExit
-    }
-  }
+  def main(args: Array[String]) =
+    Tool(name).mainMethod(args, oparser, Options(), command)
 
   val builder = OParser.builder[Options]
 


### PR DESCRIPTION
Ensure that the tools return nonzero status when the command-line options are invalid. Previously, if the option parser returned a None value indicating a parse failure, the tools would exit with status zero.