### PR TITLE
Add cpp file parameter to utilities for creating CppDoc members

### DIFF
--- a/compiler/lib/src/main/scala/codegen/CppWriter/CppDoc.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/CppDoc.scala
@@ -50,13 +50,13 @@ object CppDoc {
       params: List[Function.Param],
       initializers: List[String],
       body: List[Line],
-      cppFile: Option[String] = None,
+      cppFileNameBaseOpt: Option[String] = None,
     )
     case class Destructor(
       comment: Option[String],
       body: List[Line],
       virtualQualifier: Destructor.VirtualQualifier = Destructor.NonVirtual,
-      cppFile: Option[String] = None,
+      cppFileNameBaseOpt: Option[String] = None,
     )
     object Destructor {
       sealed trait VirtualQualifier
@@ -82,7 +82,7 @@ object CppDoc {
     /** The const qualifier */
     constQualifier: Function.ConstQualifier = Function.NonConst,
     /** The cpp file to write to */
-    cppFile: Option[String] = None,
+    cppFileNameBaseOpt: Option[String] = None,
   )
   case object Function {
     case class Param(
@@ -133,7 +133,7 @@ object CppDoc {
   case class Lines(
     content: List[Line],
     output: Lines.Output = Lines.Hpp,
-    cppFile: Option[String] = None,
+    cppFileNameBaseOpt: Option[String] = None,
   )
   object Lines {
     sealed trait Output

--- a/compiler/lib/src/main/scala/codegen/CppWriter/CppDocCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/CppDocCppWriter.scala
@@ -46,7 +46,7 @@ object CppDocCppWriter extends CppDocWriter {
   }
 
   override def visitConstructor(in: Input, constructor: CppDoc.Class.Constructor) =
-    writeSelectedLines(in, constructor.cppFile,
+    writeSelectedLines(in, constructor.cppFileNameBaseOpt,
       {
         val unqualifiedClassName = in.getEnclosingClassUnqualified
         val qualifiedClassName = in.getEnclosingClassQualified
@@ -79,8 +79,8 @@ object CppDocCppWriter extends CppDocWriter {
       }
     )
 
-  override def visitCppDoc(cppDoc: CppDoc, cppFile: Option[String] = None) = {
-    val in = Input(cppDoc.hppFile, cppDoc.cppFileName, cppFile)
+  override def visitCppDoc(cppDoc: CppDoc, cppFileNameBaseOpt: Option[String] = None) = {
+    val in = Input(cppDoc.hppFile, cppDoc.cppFileName, cppFileNameBaseOpt)
     List(
       CppDocWriter.writeBanner(
         in.getOutputCppFileName,
@@ -92,7 +92,7 @@ object CppDocCppWriter extends CppDocWriter {
   }
 
   override def visitDestructor(in: Input, destructor: CppDoc.Class.Destructor) =
-    writeSelectedLines(in, destructor.cppFile,
+    writeSelectedLines(in, destructor.cppFileNameBaseOpt,
       {
         val unqualifiedClassName = in.getEnclosingClassUnqualified
         val qualifiedClassName = in.getEnclosingClassQualified
@@ -107,7 +107,7 @@ object CppDocCppWriter extends CppDocWriter {
     )
 
   override def visitFunction(in: Input, function: CppDoc.Function) =
-    writeSelectedLines(in, function.cppFile,
+    writeSelectedLines(in, function.cppFileNameBaseOpt,
       (function.svQualifier, function.body) match {
         // If the function is pure virtual, and the function body is empty,
         // then there is no implementation, so don't write one out.
@@ -152,7 +152,7 @@ object CppDocCppWriter extends CppDocWriter {
   override def visitLines(in: Input, lines: CppDoc.Lines) =
     lines.output match {
       case CppDoc.Lines.Hpp => Nil
-      case _ => writeSelectedLines(in, lines.cppFile, lines.content)
+      case _ => writeSelectedLines(in, lines.cppFileNameBaseOpt, lines.content)
     }
 
   override def visitNamespace(in: Input, namespace: CppDoc.Namespace) =

--- a/compiler/lib/src/main/scala/codegen/CppWriter/CppDocHppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/CppDocHppWriter.scala
@@ -91,7 +91,7 @@ object CppDocHppWriter extends CppDocWriter {
     outputLines
   }
 
-  override def visitCppDoc(cppDoc: CppDoc, cppFile: Option[String] = None) = {
+  override def visitCppDoc(cppDoc: CppDoc, cppFileNameBaseOpt: Option[String] = None) = {
     val hppFile = cppDoc.hppFile
     val cppFileName = cppDoc.cppFileName
     val in = Input(hppFile, cppFileName)

--- a/compiler/lib/src/main/scala/codegen/CppWriter/CppDocWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/CppDocWriter.scala
@@ -30,7 +30,7 @@ trait CppDocWriter extends CppDocVisitor with LineUtils {
   def default(in: Input) = Nil
 
   /** Visit a CppDoc */
-  def visitCppDoc(cppDoc: CppDoc, cppFile: Option[String]): Output
+  def visitCppDoc(cppDoc: CppDoc, cppFileNameBaseOpt: Option[String]): Output
 
   type Output = List[Line]
 

--- a/compiler/lib/src/main/scala/codegen/CppWriter/CppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/CppWriter.scala
@@ -61,7 +61,11 @@ object CppWriter extends LineUtils{
     cppFile: Option[String] = None
   ) = {
     val lines = CppDocCppWriter.visitCppDoc(cppDoc, cppFile)
-    writeLinesToFile(s, cppFile.getOrElse(cppDoc.cppFileName), lines)
+    val cppFileName = cppFile match {
+      case Some(name) => s"$name.cpp"
+      case None => cppDoc.cppFileName
+    }
+    writeLinesToFile(s, cppFileName, lines)
   }
 
   def writeHppFile(s: CppWriterState, cppDoc: CppDoc) = {

--- a/compiler/lib/src/main/scala/codegen/CppWriter/CppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/CppWriter.scala
@@ -61,7 +61,7 @@ object CppWriter extends LineUtils{
     cppFile: Option[String] = None
   ) = {
     val lines = CppDocCppWriter.visitCppDoc(cppDoc, cppFile)
-    writeLinesToFile(s, cppDoc.cppFileName, lines)
+    writeLinesToFile(s, cppFile.getOrElse(cppDoc.cppFileName), lines)
   }
 
   def writeHppFile(s: CppWriterState, cppDoc: CppDoc) = {

--- a/compiler/lib/src/main/scala/codegen/CppWriter/CppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/CppWriter.scala
@@ -24,15 +24,15 @@ object CppWriter extends LineUtils{
 
   def createCppDoc(
     description: String,
-    fileName: String,
+    fileNameBase: String,
     includeGuard: String,
     members: List[CppDoc.Member],
     toolName: Option[String],
     hppFileExtension: String = "hpp",
     cppFileExtension: String = "cpp",
   ): CppDoc = {
-    val hppFile = CppDoc.HppFile(s"$fileName.$hppFileExtension", includeGuard)
-    CppDoc(description, hppFile, s"$fileName.$cppFileExtension", members, toolName)
+    val hppFile = CppDoc.HppFile(s"$fileNameBase.$hppFileExtension", includeGuard)
+    CppDoc(description, hppFile, s"$fileNameBase.$cppFileExtension", members, toolName)
   }
 
   def headerString(s: String): String = {
@@ -47,22 +47,22 @@ object CppWriter extends LineUtils{
   def writeCppDoc(
     s: CppWriterState,
     cppDoc: CppDoc,
-    cppFile: Option[String] = None
+    cppFileNameBaseOpt: Option[String] = None
   ): Result.Result[CppWriterState] =
     for {
       _ <- writeHppFile(s, cppDoc)
-      _ <- writeCppFile(s, cppDoc, cppFile)
+      _ <- writeCppFile(s, cppDoc, cppFileNameBaseOpt)
     }
     yield s
 
   def writeCppFile(
     s: CppWriterState,
     cppDoc: CppDoc,
-    cppFile: Option[String] = None
+    cppFileNameBaseOpt: Option[String] = None
   ) = {
-    val lines = CppDocCppWriter.visitCppDoc(cppDoc, cppFile)
-    val cppFileName = cppFile match {
-      case Some(name) => s"$name.cpp"
+    val lines = CppDocCppWriter.visitCppDoc(cppDoc, cppFileNameBaseOpt)
+    val cppFileName = cppFileNameBaseOpt match {
+      case Some(base) => s"$base.cpp"
       case None => cppDoc.cppFileName
     }
     writeLinesToFile(s, cppFileName, lines)

--- a/compiler/lib/src/main/scala/codegen/CppWriter/CppWriterUtils.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/CppWriterUtils.scala
@@ -261,7 +261,7 @@ trait CppWriterUtils extends LineUtils {
 
   def namespaceMember(
     name: String,
-    members: List[CppDoc.Member],
+    members: List[CppDoc.Member]
   ): CppDoc.Member.Namespace = CppDoc.Member.Namespace(CppDoc.Namespace(name, members))
 
   def constructorClassMember(

--- a/compiler/lib/src/main/scala/codegen/CppWriter/CppWriterUtils.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/CppWriterUtils.scala
@@ -238,6 +238,7 @@ trait CppWriterUtils extends LineUtils {
     body: List[Line],
     svQualifier: CppDoc.Function.SVQualifier = CppDoc.Function.NonSV,
     constQualifier: CppDoc.Function.ConstQualifier = CppDoc.Function.NonConst,
+    cppFile: Option[String] = None
   ): CppDoc.Member.Function =
     CppDoc.Member.Function(
       CppDoc.Function(
@@ -247,45 +248,51 @@ trait CppWriterUtils extends LineUtils {
         retType,
         body,
         svQualifier,
-        constQualifier
+        constQualifier,
+        cppFile
       )
     )
 
   def linesMember(
     content: List[Line],
-    output: CppDoc.Lines.Output = CppDoc.Lines.Hpp
-  ): CppDoc.Member.Lines = CppDoc.Member.Lines(CppDoc.Lines(content, output))
+    output: CppDoc.Lines.Output = CppDoc.Lines.Hpp,
+    cppFile: Option[String] = None
+  ): CppDoc.Member.Lines = CppDoc.Member.Lines(CppDoc.Lines(content, output, cppFile))
 
   def namespaceMember(
     name: String,
-    members: List[CppDoc.Member]
+    members: List[CppDoc.Member],
   ): CppDoc.Member.Namespace = CppDoc.Member.Namespace(CppDoc.Namespace(name, members))
 
   def constructorClassMember(
     comment: Option[String],
     params: List[CppDoc.Function.Param],
     initializers: List[String],
-    body: List[Line]
+    body: List[Line],
+    cppFile: Option[String] = None
   ): CppDoc.Class.Member.Constructor =
     CppDoc.Class.Member.Constructor(
       CppDoc.Class.Constructor(
         comment,
         params,
         initializers,
-        body
+        body,
+        cppFile
       )
     )
 
   def destructorClassMember(
     comment: Option[String],
     body: List[Line],
-    virtualQualifier: CppDoc.Class.Destructor.VirtualQualifier = CppDoc.Class.Destructor.NonVirtual
+    virtualQualifier: CppDoc.Class.Destructor.VirtualQualifier = CppDoc.Class.Destructor.NonVirtual,
+    cppFile: Option[String] = None
   ): CppDoc.Class.Member.Destructor =
     CppDoc.Class.Member.Destructor(
       CppDoc.Class.Destructor(
         comment,
         body,
-        virtualQualifier
+        virtualQualifier,
+        cppFile
       )
     )
 
@@ -296,7 +303,8 @@ trait CppWriterUtils extends LineUtils {
     retType: CppDoc.Type,
     body: List[Line],
     svQualifier: CppDoc.Function.SVQualifier = CppDoc.Function.NonSV,
-    constQualifier: CppDoc.Function.ConstQualifier = CppDoc.Function.NonConst
+    constQualifier: CppDoc.Function.ConstQualifier = CppDoc.Function.NonConst,
+    cppFile: Option[String] = None
   ): CppDoc.Class.Member.Function =
     CppDoc.Class.Member.Function(
       CppDoc.Function(
@@ -306,18 +314,21 @@ trait CppWriterUtils extends LineUtils {
         retType,
         body,
         svQualifier,
-        constQualifier
+        constQualifier,
+        cppFile
       )
     )
 
   def linesClassMember(
     content: List[Line],
-    output: CppDoc.Lines.Output = CppDoc.Lines.Hpp
+    output: CppDoc.Lines.Output = CppDoc.Lines.Hpp,
+    cppFile: Option[String] = None
   ): CppDoc.Class.Member.Lines =
     CppDoc.Class.Member.Lines(
       CppDoc.Lines(
         content,
-        output
+        output,
+        cppFile
       )
     )
 

--- a/compiler/lib/src/main/scala/codegen/CppWriter/CppWriterUtils.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/CppWriterUtils.scala
@@ -8,12 +8,13 @@ trait CppWriterUtils extends LineUtils {
     accessTag: String,
     comment: String,
     members: List[CppDoc.Class.Member],
-    output: CppDoc.Lines.Output = CppDoc.Lines.Both
+    output: CppDoc.Lines.Output = CppDoc.Lines.Both,
+    cppFileNameBaseOpt: Option[String] = None
   ): List[CppDoc.Class.Member] = members match {
     case Nil => Nil
     case _ =>
       linesClassMember(CppDocHppWriter.writeAccessTag(accessTag)) ::
-      linesClassMember(CppDocWriter.writeBannerComment(comment), output) ::
+      linesClassMember(CppDocWriter.writeBannerComment(comment), output, cppFileNameBaseOpt) ::
       members
   }
 
@@ -238,7 +239,7 @@ trait CppWriterUtils extends LineUtils {
     body: List[Line],
     svQualifier: CppDoc.Function.SVQualifier = CppDoc.Function.NonSV,
     constQualifier: CppDoc.Function.ConstQualifier = CppDoc.Function.NonConst,
-    cppFile: Option[String] = None
+    cppFileNameBaseOpt: Option[String] = None
   ): CppDoc.Member.Function =
     CppDoc.Member.Function(
       CppDoc.Function(
@@ -249,15 +250,15 @@ trait CppWriterUtils extends LineUtils {
         body,
         svQualifier,
         constQualifier,
-        cppFile
+        cppFileNameBaseOpt
       )
     )
 
   def linesMember(
     content: List[Line],
     output: CppDoc.Lines.Output = CppDoc.Lines.Hpp,
-    cppFile: Option[String] = None
-  ): CppDoc.Member.Lines = CppDoc.Member.Lines(CppDoc.Lines(content, output, cppFile))
+    cppFileNameBaseOpt: Option[String] = None
+  ): CppDoc.Member.Lines = CppDoc.Member.Lines(CppDoc.Lines(content, output, cppFileNameBaseOpt))
 
   def namespaceMember(
     name: String,
@@ -269,7 +270,7 @@ trait CppWriterUtils extends LineUtils {
     params: List[CppDoc.Function.Param],
     initializers: List[String],
     body: List[Line],
-    cppFile: Option[String] = None
+    cppFileNameBaseOpt: Option[String] = None
   ): CppDoc.Class.Member.Constructor =
     CppDoc.Class.Member.Constructor(
       CppDoc.Class.Constructor(
@@ -277,7 +278,7 @@ trait CppWriterUtils extends LineUtils {
         params,
         initializers,
         body,
-        cppFile
+        cppFileNameBaseOpt
       )
     )
 
@@ -285,14 +286,14 @@ trait CppWriterUtils extends LineUtils {
     comment: Option[String],
     body: List[Line],
     virtualQualifier: CppDoc.Class.Destructor.VirtualQualifier = CppDoc.Class.Destructor.NonVirtual,
-    cppFile: Option[String] = None
+    cppFileNameBaseOpt: Option[String] = None
   ): CppDoc.Class.Member.Destructor =
     CppDoc.Class.Member.Destructor(
       CppDoc.Class.Destructor(
         comment,
         body,
         virtualQualifier,
-        cppFile
+        cppFileNameBaseOpt
       )
     )
 
@@ -304,7 +305,7 @@ trait CppWriterUtils extends LineUtils {
     body: List[Line],
     svQualifier: CppDoc.Function.SVQualifier = CppDoc.Function.NonSV,
     constQualifier: CppDoc.Function.ConstQualifier = CppDoc.Function.NonConst,
-    cppFile: Option[String] = None
+    cppFileNameBaseOpt: Option[String] = None
   ): CppDoc.Class.Member.Function =
     CppDoc.Class.Member.Function(
       CppDoc.Function(
@@ -315,20 +316,20 @@ trait CppWriterUtils extends LineUtils {
         body,
         svQualifier,
         constQualifier,
-        cppFile
+        cppFileNameBaseOpt
       )
     )
 
   def linesClassMember(
     content: List[Line],
     output: CppDoc.Lines.Output = CppDoc.Lines.Hpp,
-    cppFile: Option[String] = None
+    cppFileNameBaseOpt: Option[String] = None
   ): CppDoc.Class.Member.Lines =
     CppDoc.Class.Member.Lines(
       CppDoc.Lines(
         content,
         output,
-        cppFile
+        cppFileNameBaseOpt
       )
     )
 

--- a/compiler/lib/test/codegen/CppWriter/Main.scala
+++ b/compiler/lib/test/codegen/CppWriter/Main.scala
@@ -22,7 +22,7 @@ object Program extends LineUtils {
         lines = Lines(
           content = includeHeader,
           output = Lines.Cpp,
-          cppFile = Some("Other")
+          cppFileNameBaseOpt = Some("Other")
         )
       ),
       Member.Namespace(
@@ -89,7 +89,7 @@ object Program extends LineUtils {
                             ),
                             retType = Type("void"),
                             body = Nil,
-                            cppFile = Some("Other")
+                            cppFileNameBaseOpt = Some("Other")
                           )
                         ),
                       )


### PR DESCRIPTION
- Update CppWriter utilities to account for changes in #295
- Fix the name of the output file in `CppWriter.writeCppFile`