### PR TITLE
remove odroid from pull_request builds

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -9,10 +9,10 @@ jobs:
     strategy:
       matrix:
         os: ["rhel-8.7", "macos-11", "odroid"]
-    if: (${{ github.event_name == 'pull_request' }} && ${{ matrix.os != 'odroid' }}) || ${{ github.event_name == 'release' }}
     runs-on: ${{ matrix.os }}
     steps:
     - name: "Checkout FPP Repository"
+      if: (${{ github.event_name == 'pull_request' }} && ${{ matrix.os != 'odroid' }}) || ${{ github.event_name == 'release' }}
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
@@ -23,6 +23,7 @@ jobs:
       if: ${{ matrix.os != 'odroid' }}
       run: echo "architecture=amd64" >> "$GITHUB_ENV"
     - name: Image Build Step
+      if: (${{ github.event_name == 'pull_request' }} && ${{ matrix.os != 'odroid' }}) || ${{ github.event_name == 'release' }}
       working-directory: ./compiler
       run: |
         . ${GITHUB_WORKSPACE}/.github/workflows/env-setup ${{ env.architecture }}

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -9,7 +9,8 @@ jobs:
     strategy:
       matrix:
         os: ["rhel-8.7", "macos-11", "odroid"]
-        is_pull_request: ${{ github.event_name == 'pull_request' }}
+        is_pull_request:
+          - ${{ github.event_name == 'pull_request' }}
         exclude:
           - is_pull_request: true
             os: odroid

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -9,10 +9,13 @@ jobs:
     strategy:
       matrix:
         os: ["rhel-8.7", "macos-11", "odroid"]
+        is_pull_request: ${{ github.event_name == 'pull_request' }}
+      exclude:
+        - is_pull_request: true
+          os: odroid
     runs-on: ${{ matrix.os }}
     steps:
     - name: "Checkout FPP Repository"
-      if: (${{ github.event_name == 'pull_request' }} && ${{ matrix.os != 'odroid' }}) || ${{ github.event_name == 'release' }}
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
@@ -23,7 +26,6 @@ jobs:
       if: ${{ matrix.os != 'odroid' }}
       run: echo "architecture=amd64" >> "$GITHUB_ENV"
     - name: Image Build Step
-      if: (${{ github.event_name == 'pull_request' }} && ${{ matrix.os != 'odroid' }}) || ${{ github.event_name == 'release' }}
       working-directory: ./compiler
       run: |
         . ${GITHUB_WORKSPACE}/.github/workflows/env-setup ${{ env.architecture }}

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -10,9 +10,9 @@ jobs:
       matrix:
         os: ["rhel-8.7", "macos-11", "odroid"]
         is_pull_request: ${{ github.event_name == 'pull_request' }}
-      exclude:
-        - is_pull_request: true
-          os: odroid
+        exclude:
+          - is_pull_request: true
+            os: odroid
     runs-on: ${{ matrix.os }}
     steps:
     - name: "Checkout FPP Repository"

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -9,6 +9,7 @@ jobs:
     strategy:
       matrix:
         os: ["rhel-8.7", "macos-11", "odroid"]
+    if: (${{ github.event_name == 'pull_request' }} && ${{ matrix.os != 'odroid' }}) || ${{ github.event_name == 'release' }}
     runs-on: ${{ matrix.os }}
     steps:
     - name: "Checkout FPP Repository"


### PR DESCRIPTION
This PR removes the odroid runner from builds that are triggered by pull requests. From what I've [read](https://github.com/orgs/community/discussions/26253), this seemed like the cleanest solution, let me know if anyone has any feedback or suggestions!