### PR TITLE
Merge updates from the data-products branch

### DIFF
--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCppWriter.scala
@@ -93,7 +93,7 @@ case class ComponentCppWriter (
       if hasInternalPorts then List("Fw/Types/InternalInterfaceString.hpp")
       else Nil
 
-    val standardHeaders = List(
+    val standardHeaders = List.concat(
       List(
         "FpConfig.hpp",
         "Fw/Port/InputSerializePort.hpp",
@@ -106,7 +106,7 @@ case class ComponentCppWriter (
       prmStrHeader,
       logStrHeader,
       internalStrHeader
-    ).flatten.map(CppWriter.headerString)
+    ).map(CppWriter.headerString)
     val symbolHeaders = writeIncludeDirectives
     val headers = standardHeaders ++ symbolHeaders
     linesMember(addBlankPrefix(headers.sorted.flatMap({
@@ -277,8 +277,8 @@ case class ComponentCppWriter (
         )
         else Nil,
         List(
-          typedAsyncInputPorts.map(generalPortCppConstantName),
-          serialAsyncInputPorts.map(generalPortCppConstantName),
+          typedAsyncInputPorts.map(portCppConstantName),
+          serialAsyncInputPorts.map(portCppConstantName),
           asyncCmds.map((_, cmd) => commandCppConstantName(cmd)),
           internalPorts.map(internalPortCppConstantName),
         ).flatten.map(s => line(s"$s,"))
@@ -530,7 +530,7 @@ case class ComponentCppWriter (
   }
 
   private def getDispatchFunctionMember: List[CppDoc.Class.Member] = {
-    def writeGeneralAsyncPortDispatch(p: PortInstance.General) = {
+    def writeAsyncPortDispatch(p: PortInstance) = {
       val body = p.getType.get match {
         case PortInstance.Type.DefPort(_) =>
           List(
@@ -574,7 +574,7 @@ case class ComponentCppWriter (
 
       line(s"// Handle async input port ${p.getUnqualifiedName}") ::
         wrapInScope(
-          s"case ${generalPortCppConstantName(p)}: {",
+          s"case ${portCppConstantName(p)}: {",
           body,
           "}"
         )
@@ -791,8 +791,8 @@ case class ComponentCppWriter (
                 "msgType",
                 intersperseBlankLines(
                   List(
-                    intersperseBlankLines(typedAsyncInputPorts.map(writeGeneralAsyncPortDispatch)),
-                    intersperseBlankLines(serialAsyncInputPorts.map(writeGeneralAsyncPortDispatch)),
+                    intersperseBlankLines(typedAsyncInputPorts.map(writeAsyncPortDispatch)),
+                    intersperseBlankLines(serialAsyncInputPorts.map(writeAsyncPortDispatch)),
                     intersperseBlankLines(asyncCmds.map(writeAsyncCommandDispatch)),
                     intersperseBlankLines(internalPorts.map(writeInternalPortDispatch)),
                     lines(

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCppWriterUtils.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCppWriterUtils.scala
@@ -561,7 +561,7 @@ abstract class ComponentCppWriterUtils(
     TypeCppWriter.getName(s, t, Some("Fw::ParamString"))
 
   /** Get the name for a general port enumerated constant in cpp file */
-  def generalPortCppConstantName(p: PortInstance.General) =
+  def portCppConstantName(p: PortInstance) =
     s"${p.getUnqualifiedName}_${getPortTypeBaseName(p)}".toUpperCase
 
   /** Get the name for an internal port enumerated constant in cpp file */

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentInputPorts.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentInputPorts.scala
@@ -130,7 +130,7 @@ case class ComponentInputPorts(
           lines(
             s"""|// Serialize message ID
                 |_status = $bufferName.serialize(
-                |  static_cast<NATIVE_INT_TYPE>(${generalPortCppConstantName(p)})
+                |  static_cast<NATIVE_INT_TYPE>(${portCppConstantName(p)})
                 |);
                 |FW_ASSERT(
                 |  _status == Fw::FW_SERIALIZE_OK,

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentOutputPorts.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentOutputPorts.scala
@@ -64,10 +64,14 @@ case class ComponentOutputPorts(
   /** Get connectors for a list of typed ports */
   def getTypedConnectors(ports: List[PortInstance]): List[CppDoc.Class.Member] = {
     val typeStr = getPortListTypeString(ports)
-
+    val comment =
+      if (typeStr == "special")
+        s"Connect input ports to $typeStr output ports"
+      else
+        s"Connect $typeStr input ports to $typeStr output ports"
     generateConnectors(
       ports,
-      s"Connect $typeStr input ports to $typeStr output ports",
+      comment,
       outputPortConnectorName,
       portNumGetterName,
       portVariableName

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveCommandsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveCommandsComponentAc.ref.cpp
@@ -842,7 +842,7 @@ InputTypedPort* ActiveCommandsComponentBase ::
 }
 
 // ----------------------------------------------------------------------
-// Connect special input ports to special output ports
+// Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
 void ActiveCommandsComponentBase ::

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveCommandsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveCommandsComponentAc.ref.hpp
@@ -239,7 +239,7 @@ class ActiveCommandsComponentBase :
   public:
 
     // ----------------------------------------------------------------------
-    // Connect special input ports to special output ports
+    // Connect input ports to special output ports
     // ----------------------------------------------------------------------
 
     //! Connect port to cmdRegOut[portNum]

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveEventsComponentAc.ref.cpp
@@ -837,7 +837,7 @@ InputTypedPort* ActiveEventsComponentBase ::
 }
 
 // ----------------------------------------------------------------------
-// Connect special input ports to special output ports
+// Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
 void ActiveEventsComponentBase ::

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveEventsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveEventsComponentAc.ref.hpp
@@ -236,7 +236,7 @@ class ActiveEventsComponentBase :
   public:
 
     // ----------------------------------------------------------------------
-    // Connect special input ports to special output ports
+    // Connect input ports to special output ports
     // ----------------------------------------------------------------------
 
     //! Connect port to cmdRegOut[portNum]

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveParamsComponentAc.ref.cpp
@@ -837,7 +837,7 @@ InputTypedPort* ActiveParamsComponentBase ::
 }
 
 // ----------------------------------------------------------------------
-// Connect special input ports to special output ports
+// Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
 void ActiveParamsComponentBase ::

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveParamsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveParamsComponentAc.ref.hpp
@@ -246,7 +246,7 @@ class ActiveParamsComponentBase :
   public:
 
     // ----------------------------------------------------------------------
-    // Connect special input ports to special output ports
+    // Connect input ports to special output ports
     // ----------------------------------------------------------------------
 
     //! Connect port to cmdRegOut[portNum]

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.cpp
@@ -1131,7 +1131,7 @@ Fw::InputSerializePort* ActiveSerialComponentBase ::
 }
 
 // ----------------------------------------------------------------------
-// Connect special input ports to special output ports
+// Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
 void ActiveSerialComponentBase ::

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.hpp
@@ -368,7 +368,7 @@ class ActiveSerialComponentBase :
   public:
 
     // ----------------------------------------------------------------------
-    // Connect special input ports to special output ports
+    // Connect input ports to special output ports
     // ----------------------------------------------------------------------
 
     //! Connect port to cmdRegOut[portNum]

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTelemetryComponentAc.ref.cpp
@@ -837,7 +837,7 @@ InputTypedPort* ActiveTelemetryComponentBase ::
 }
 
 // ----------------------------------------------------------------------
-// Connect special input ports to special output ports
+// Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
 void ActiveTelemetryComponentBase ::

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTelemetryComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTelemetryComponentAc.ref.hpp
@@ -233,7 +233,7 @@ class ActiveTelemetryComponentBase :
   public:
 
     // ----------------------------------------------------------------------
-    // Connect special input ports to special output ports
+    // Connect input ports to special output ports
     // ----------------------------------------------------------------------
 
     //! Connect port to cmdRegOut[portNum]

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
@@ -875,7 +875,7 @@ namespace M {
   }
 
   // ----------------------------------------------------------------------
-  // Connect special input ports to special output ports
+  // Connect input ports to special output ports
   // ----------------------------------------------------------------------
 
   void ActiveTestComponentBase ::

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.hpp
@@ -301,7 +301,7 @@ namespace M {
     public:
 
       // ----------------------------------------------------------------------
-      // Connect special input ports to special output ports
+      // Connect input ports to special output ports
       // ----------------------------------------------------------------------
 
       //! Connect port to cmdRegOut[portNum]

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveCommandsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveCommandsComponentAc.ref.cpp
@@ -626,7 +626,7 @@ InputTypedPort* PassiveCommandsComponentBase ::
 }
 
 // ----------------------------------------------------------------------
-// Connect special input ports to special output ports
+// Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
 void PassiveCommandsComponentBase ::

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveCommandsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveCommandsComponentAc.ref.hpp
@@ -193,7 +193,7 @@ class PassiveCommandsComponentBase :
   public:
 
     // ----------------------------------------------------------------------
-    // Connect special input ports to special output ports
+    // Connect input ports to special output ports
     // ----------------------------------------------------------------------
 
     //! Connect port to cmdRegOut[portNum]

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveEventsComponentAc.ref.cpp
@@ -626,7 +626,7 @@ InputTypedPort* PassiveEventsComponentBase ::
 }
 
 // ----------------------------------------------------------------------
-// Connect special input ports to special output ports
+// Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
 void PassiveEventsComponentBase ::

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveEventsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveEventsComponentAc.ref.hpp
@@ -195,7 +195,7 @@ class PassiveEventsComponentBase :
   public:
 
     // ----------------------------------------------------------------------
-    // Connect special input ports to special output ports
+    // Connect input ports to special output ports
     // ----------------------------------------------------------------------
 
     //! Connect port to cmdRegOut[portNum]

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveParamsComponentAc.ref.cpp
@@ -626,7 +626,7 @@ InputTypedPort* PassiveParamsComponentBase ::
 }
 
 // ----------------------------------------------------------------------
-// Connect special input ports to special output ports
+// Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
 void PassiveParamsComponentBase ::

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveParamsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveParamsComponentAc.ref.hpp
@@ -205,7 +205,7 @@ class PassiveParamsComponentBase :
   public:
 
     // ----------------------------------------------------------------------
-    // Connect special input ports to special output ports
+    // Connect input ports to special output ports
     // ----------------------------------------------------------------------
 
     //! Connect port to cmdRegOut[portNum]

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.cpp
@@ -725,7 +725,7 @@ Fw::InputSerializePort* PassiveSerialComponentBase ::
 }
 
 // ----------------------------------------------------------------------
-// Connect special input ports to special output ports
+// Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
 void PassiveSerialComponentBase ::

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.hpp
@@ -288,7 +288,7 @@ class PassiveSerialComponentBase :
   public:
 
     // ----------------------------------------------------------------------
-    // Connect special input ports to special output ports
+    // Connect input ports to special output ports
     // ----------------------------------------------------------------------
 
     //! Connect port to cmdRegOut[portNum]

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTelemetryComponentAc.ref.cpp
@@ -626,7 +626,7 @@ InputTypedPort* PassiveTelemetryComponentBase ::
 }
 
 // ----------------------------------------------------------------------
-// Connect special input ports to special output ports
+// Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
 void PassiveTelemetryComponentBase ::

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTelemetryComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTelemetryComponentAc.ref.hpp
@@ -192,7 +192,7 @@ class PassiveTelemetryComponentBase :
   public:
 
     // ----------------------------------------------------------------------
-    // Connect special input ports to special output ports
+    // Connect input ports to special output ports
     // ----------------------------------------------------------------------
 
     //! Connect port to cmdRegOut[portNum]

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.cpp
@@ -626,7 +626,7 @@ InputTypedPort* PassiveTestComponentBase ::
 }
 
 // ----------------------------------------------------------------------
-// Connect special input ports to special output ports
+// Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
 void PassiveTestComponentBase ::

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.hpp
@@ -252,7 +252,7 @@ class PassiveTestComponentBase :
   public:
 
     // ----------------------------------------------------------------------
-    // Connect special input ports to special output ports
+    // Connect input ports to special output ports
     // ----------------------------------------------------------------------
 
     //! Connect port to cmdRegOut[portNum]

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedCommandsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedCommandsComponentAc.ref.cpp
@@ -842,7 +842,7 @@ InputTypedPort* QueuedCommandsComponentBase ::
 }
 
 // ----------------------------------------------------------------------
-// Connect special input ports to special output ports
+// Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
 void QueuedCommandsComponentBase ::

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedCommandsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedCommandsComponentAc.ref.hpp
@@ -239,7 +239,7 @@ class QueuedCommandsComponentBase :
   public:
 
     // ----------------------------------------------------------------------
-    // Connect special input ports to special output ports
+    // Connect input ports to special output ports
     // ----------------------------------------------------------------------
 
     //! Connect port to cmdRegOut[portNum]

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedEventsComponentAc.ref.cpp
@@ -837,7 +837,7 @@ InputTypedPort* QueuedEventsComponentBase ::
 }
 
 // ----------------------------------------------------------------------
-// Connect special input ports to special output ports
+// Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
 void QueuedEventsComponentBase ::

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedEventsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedEventsComponentAc.ref.hpp
@@ -236,7 +236,7 @@ class QueuedEventsComponentBase :
   public:
 
     // ----------------------------------------------------------------------
-    // Connect special input ports to special output ports
+    // Connect input ports to special output ports
     // ----------------------------------------------------------------------
 
     //! Connect port to cmdRegOut[portNum]

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedParamsComponentAc.ref.cpp
@@ -837,7 +837,7 @@ InputTypedPort* QueuedParamsComponentBase ::
 }
 
 // ----------------------------------------------------------------------
-// Connect special input ports to special output ports
+// Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
 void QueuedParamsComponentBase ::

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedParamsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedParamsComponentAc.ref.hpp
@@ -246,7 +246,7 @@ class QueuedParamsComponentBase :
   public:
 
     // ----------------------------------------------------------------------
-    // Connect special input ports to special output ports
+    // Connect input ports to special output ports
     // ----------------------------------------------------------------------
 
     //! Connect port to cmdRegOut[portNum]

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.cpp
@@ -1131,7 +1131,7 @@ Fw::InputSerializePort* QueuedSerialComponentBase ::
 }
 
 // ----------------------------------------------------------------------
-// Connect special input ports to special output ports
+// Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
 void QueuedSerialComponentBase ::

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.hpp
@@ -368,7 +368,7 @@ class QueuedSerialComponentBase :
   public:
 
     // ----------------------------------------------------------------------
-    // Connect special input ports to special output ports
+    // Connect input ports to special output ports
     // ----------------------------------------------------------------------
 
     //! Connect port to cmdRegOut[portNum]

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTelemetryComponentAc.ref.cpp
@@ -837,7 +837,7 @@ InputTypedPort* QueuedTelemetryComponentBase ::
 }
 
 // ----------------------------------------------------------------------
-// Connect special input ports to special output ports
+// Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
 void QueuedTelemetryComponentBase ::

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTelemetryComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTelemetryComponentAc.ref.hpp
@@ -233,7 +233,7 @@ class QueuedTelemetryComponentBase :
   public:
 
     // ----------------------------------------------------------------------
-    // Connect special input ports to special output ports
+    // Connect input ports to special output ports
     // ----------------------------------------------------------------------
 
     //! Connect port to cmdRegOut[portNum]

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
@@ -873,7 +873,7 @@ InputTypedPort* QueuedTestComponentBase ::
 }
 
 // ----------------------------------------------------------------------
-// Connect special input ports to special output ports
+// Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
 void QueuedTestComponentBase ::

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.hpp
@@ -299,7 +299,7 @@ class QueuedTestComponentBase :
   public:
 
     // ----------------------------------------------------------------------
-    // Connect special input ports to special output ports
+    // Connect input ports to special output ports
     // ----------------------------------------------------------------------
 
     //! Connect port to cmdRegOut[portNum]

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveCommandsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveCommandsComponentAc.ref.cpp
@@ -842,7 +842,7 @@ InputTypedPort* ActiveCommandsComponentBase ::
 }
 
 // ----------------------------------------------------------------------
-// Connect special input ports to special output ports
+// Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
 void ActiveCommandsComponentBase ::

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveCommandsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveCommandsComponentAc.ref.hpp
@@ -239,7 +239,7 @@ class ActiveCommandsComponentBase :
   public:
 
     // ----------------------------------------------------------------------
-    // Connect special input ports to special output ports
+    // Connect input ports to special output ports
     // ----------------------------------------------------------------------
 
     //! Connect port to cmdRegOut[portNum]

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveEventsComponentAc.ref.cpp
@@ -837,7 +837,7 @@ InputTypedPort* ActiveEventsComponentBase ::
 }
 
 // ----------------------------------------------------------------------
-// Connect special input ports to special output ports
+// Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
 void ActiveEventsComponentBase ::

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveEventsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveEventsComponentAc.ref.hpp
@@ -236,7 +236,7 @@ class ActiveEventsComponentBase :
   public:
 
     // ----------------------------------------------------------------------
-    // Connect special input ports to special output ports
+    // Connect input ports to special output ports
     // ----------------------------------------------------------------------
 
     //! Connect port to cmdRegOut[portNum]

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveParamsComponentAc.ref.cpp
@@ -837,7 +837,7 @@ InputTypedPort* ActiveParamsComponentBase ::
 }
 
 // ----------------------------------------------------------------------
-// Connect special input ports to special output ports
+// Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
 void ActiveParamsComponentBase ::

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveParamsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveParamsComponentAc.ref.hpp
@@ -246,7 +246,7 @@ class ActiveParamsComponentBase :
   public:
 
     // ----------------------------------------------------------------------
-    // Connect special input ports to special output ports
+    // Connect input ports to special output ports
     // ----------------------------------------------------------------------
 
     //! Connect port to cmdRegOut[portNum]

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialComponentAc.ref.cpp
@@ -1131,7 +1131,7 @@ Fw::InputSerializePort* ActiveSerialComponentBase ::
 }
 
 // ----------------------------------------------------------------------
-// Connect special input ports to special output ports
+// Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
 void ActiveSerialComponentBase ::

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialComponentAc.ref.hpp
@@ -368,7 +368,7 @@ class ActiveSerialComponentBase :
   public:
 
     // ----------------------------------------------------------------------
-    // Connect special input ports to special output ports
+    // Connect input ports to special output ports
     // ----------------------------------------------------------------------
 
     //! Connect port to cmdRegOut[portNum]

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTelemetryComponentAc.ref.cpp
@@ -837,7 +837,7 @@ InputTypedPort* ActiveTelemetryComponentBase ::
 }
 
 // ----------------------------------------------------------------------
-// Connect special input ports to special output ports
+// Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
 void ActiveTelemetryComponentBase ::

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTelemetryComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTelemetryComponentAc.ref.hpp
@@ -233,7 +233,7 @@ class ActiveTelemetryComponentBase :
   public:
 
     // ----------------------------------------------------------------------
-    // Connect special input ports to special output ports
+    // Connect input ports to special output ports
     // ----------------------------------------------------------------------
 
     //! Connect port to cmdRegOut[portNum]

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestComponentAc.ref.cpp
@@ -875,7 +875,7 @@ namespace M {
   }
 
   // ----------------------------------------------------------------------
-  // Connect special input ports to special output ports
+  // Connect input ports to special output ports
   // ----------------------------------------------------------------------
 
   void ActiveTestComponentBase ::

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestComponentAc.ref.hpp
@@ -301,7 +301,7 @@ namespace M {
     public:
 
       // ----------------------------------------------------------------------
-      // Connect special input ports to special output ports
+      // Connect input ports to special output ports
       // ----------------------------------------------------------------------
 
       //! Connect port to cmdRegOut[portNum]

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveCommandsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveCommandsComponentAc.ref.cpp
@@ -626,7 +626,7 @@ InputTypedPort* PassiveCommandsComponentBase ::
 }
 
 // ----------------------------------------------------------------------
-// Connect special input ports to special output ports
+// Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
 void PassiveCommandsComponentBase ::

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveCommandsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveCommandsComponentAc.ref.hpp
@@ -193,7 +193,7 @@ class PassiveCommandsComponentBase :
   public:
 
     // ----------------------------------------------------------------------
-    // Connect special input ports to special output ports
+    // Connect input ports to special output ports
     // ----------------------------------------------------------------------
 
     //! Connect port to cmdRegOut[portNum]

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveEventsComponentAc.ref.cpp
@@ -626,7 +626,7 @@ InputTypedPort* PassiveEventsComponentBase ::
 }
 
 // ----------------------------------------------------------------------
-// Connect special input ports to special output ports
+// Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
 void PassiveEventsComponentBase ::

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveEventsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveEventsComponentAc.ref.hpp
@@ -195,7 +195,7 @@ class PassiveEventsComponentBase :
   public:
 
     // ----------------------------------------------------------------------
-    // Connect special input ports to special output ports
+    // Connect input ports to special output ports
     // ----------------------------------------------------------------------
 
     //! Connect port to cmdRegOut[portNum]

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveParamsComponentAc.ref.cpp
@@ -626,7 +626,7 @@ InputTypedPort* PassiveParamsComponentBase ::
 }
 
 // ----------------------------------------------------------------------
-// Connect special input ports to special output ports
+// Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
 void PassiveParamsComponentBase ::

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveParamsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveParamsComponentAc.ref.hpp
@@ -205,7 +205,7 @@ class PassiveParamsComponentBase :
   public:
 
     // ----------------------------------------------------------------------
-    // Connect special input ports to special output ports
+    // Connect input ports to special output ports
     // ----------------------------------------------------------------------
 
     //! Connect port to cmdRegOut[portNum]

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialComponentAc.ref.cpp
@@ -725,7 +725,7 @@ Fw::InputSerializePort* PassiveSerialComponentBase ::
 }
 
 // ----------------------------------------------------------------------
-// Connect special input ports to special output ports
+// Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
 void PassiveSerialComponentBase ::

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialComponentAc.ref.hpp
@@ -288,7 +288,7 @@ class PassiveSerialComponentBase :
   public:
 
     // ----------------------------------------------------------------------
-    // Connect special input ports to special output ports
+    // Connect input ports to special output ports
     // ----------------------------------------------------------------------
 
     //! Connect port to cmdRegOut[portNum]

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTelemetryComponentAc.ref.cpp
@@ -626,7 +626,7 @@ InputTypedPort* PassiveTelemetryComponentBase ::
 }
 
 // ----------------------------------------------------------------------
-// Connect special input ports to special output ports
+// Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
 void PassiveTelemetryComponentBase ::

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTelemetryComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTelemetryComponentAc.ref.hpp
@@ -192,7 +192,7 @@ class PassiveTelemetryComponentBase :
   public:
 
     // ----------------------------------------------------------------------
-    // Connect special input ports to special output ports
+    // Connect input ports to special output ports
     // ----------------------------------------------------------------------
 
     //! Connect port to cmdRegOut[portNum]

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestComponentAc.ref.cpp
@@ -626,7 +626,7 @@ InputTypedPort* PassiveTestComponentBase ::
 }
 
 // ----------------------------------------------------------------------
-// Connect special input ports to special output ports
+// Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
 void PassiveTestComponentBase ::

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestComponentAc.ref.hpp
@@ -252,7 +252,7 @@ class PassiveTestComponentBase :
   public:
 
     // ----------------------------------------------------------------------
-    // Connect special input ports to special output ports
+    // Connect input ports to special output ports
     // ----------------------------------------------------------------------
 
     //! Connect port to cmdRegOut[portNum]

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedCommandsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedCommandsComponentAc.ref.cpp
@@ -842,7 +842,7 @@ InputTypedPort* QueuedCommandsComponentBase ::
 }
 
 // ----------------------------------------------------------------------
-// Connect special input ports to special output ports
+// Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
 void QueuedCommandsComponentBase ::

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedCommandsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedCommandsComponentAc.ref.hpp
@@ -239,7 +239,7 @@ class QueuedCommandsComponentBase :
   public:
 
     // ----------------------------------------------------------------------
-    // Connect special input ports to special output ports
+    // Connect input ports to special output ports
     // ----------------------------------------------------------------------
 
     //! Connect port to cmdRegOut[portNum]

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedEventsComponentAc.ref.cpp
@@ -837,7 +837,7 @@ InputTypedPort* QueuedEventsComponentBase ::
 }
 
 // ----------------------------------------------------------------------
-// Connect special input ports to special output ports
+// Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
 void QueuedEventsComponentBase ::

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedEventsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedEventsComponentAc.ref.hpp
@@ -236,7 +236,7 @@ class QueuedEventsComponentBase :
   public:
 
     // ----------------------------------------------------------------------
-    // Connect special input ports to special output ports
+    // Connect input ports to special output ports
     // ----------------------------------------------------------------------
 
     //! Connect port to cmdRegOut[portNum]

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedParamsComponentAc.ref.cpp
@@ -837,7 +837,7 @@ InputTypedPort* QueuedParamsComponentBase ::
 }
 
 // ----------------------------------------------------------------------
-// Connect special input ports to special output ports
+// Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
 void QueuedParamsComponentBase ::

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedParamsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedParamsComponentAc.ref.hpp
@@ -246,7 +246,7 @@ class QueuedParamsComponentBase :
   public:
 
     // ----------------------------------------------------------------------
-    // Connect special input ports to special output ports
+    // Connect input ports to special output ports
     // ----------------------------------------------------------------------
 
     //! Connect port to cmdRegOut[portNum]

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialComponentAc.ref.cpp
@@ -1131,7 +1131,7 @@ Fw::InputSerializePort* QueuedSerialComponentBase ::
 }
 
 // ----------------------------------------------------------------------
-// Connect special input ports to special output ports
+// Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
 void QueuedSerialComponentBase ::

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialComponentAc.ref.hpp
@@ -368,7 +368,7 @@ class QueuedSerialComponentBase :
   public:
 
     // ----------------------------------------------------------------------
-    // Connect special input ports to special output ports
+    // Connect input ports to special output ports
     // ----------------------------------------------------------------------
 
     //! Connect port to cmdRegOut[portNum]

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTelemetryComponentAc.ref.cpp
@@ -837,7 +837,7 @@ InputTypedPort* QueuedTelemetryComponentBase ::
 }
 
 // ----------------------------------------------------------------------
-// Connect special input ports to special output ports
+// Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
 void QueuedTelemetryComponentBase ::

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTelemetryComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTelemetryComponentAc.ref.hpp
@@ -233,7 +233,7 @@ class QueuedTelemetryComponentBase :
   public:
 
     // ----------------------------------------------------------------------
-    // Connect special input ports to special output ports
+    // Connect input ports to special output ports
     // ----------------------------------------------------------------------
 
     //! Connect port to cmdRegOut[portNum]

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestComponentAc.ref.cpp
@@ -873,7 +873,7 @@ InputTypedPort* QueuedTestComponentBase ::
 }
 
 // ----------------------------------------------------------------------
-// Connect special input ports to special output ports
+// Connect input ports to special output ports
 // ----------------------------------------------------------------------
 
 void QueuedTestComponentBase ::

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestComponentAc.ref.hpp
@@ -299,7 +299,7 @@ class QueuedTestComponentBase :
   public:
 
     // ----------------------------------------------------------------------
-    // Connect special input ports to special output ports
+    // Connect input ports to special output ports
     // ----------------------------------------------------------------------
 
     //! Connect port to cmdRegOut[portNum]

--- a/compiler/tools/fpp-to-cpp/test/update-ref
+++ b/compiler/tools/fpp-to-cpp/test/update-ref
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 
-for file in `find . -mindepth 2 -name update-ref`
+for file in `find . -mindepth 2 -maxdepth 2 -name update-ref`
 do
   dir=`dirname $file`
   echo "[ $dir ]"


### PR DESCRIPTION
The changes are minor, but they will help keep `main` and `data-products` in sync until we can merge the branches.
* There is an improvement to a comment in the generated C++ code.
* Some unnecessarily restrictive types have been generalized. The corresponding function names have been updated to match.
* There is an improvement to a testing script.

Closes #312.