### PR TITLE
Fix issue with namespace prefixes in C++ string types

### DIFF
--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCppWriterUtils.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCppWriterUtils.scala
@@ -309,7 +309,7 @@ abstract class ComponentCppWriterUtils(
           p.getUnqualifiedName,
           formalParamsCppWriter.write(
             symbol.node._2.data.params,
-            PortCppWriter.getPortNamespaces(symbol.node._2.data.name)
+            PortCppWriter.getPortNamespaces(s, symbol)
           )
         ))
         case None => p match {
@@ -412,7 +412,7 @@ abstract class ComponentCppWriterUtils(
               s,
               s.a.typeMap(typeName.id),
               None,
-              PortCppWriter.getPortNamespaces(symbol.getUnqualifiedName)
+              PortCppWriter.getPortNamespaces(s, symbol)
             )
           )
           case _ => None
@@ -695,7 +695,7 @@ abstract class ComponentCppWriterUtils(
       s,
       s.a.typeMap(param.typeName.id),
       None,
-      PortCppWriter.getPortNamespaces(symbol.getUnqualifiedName)
+      PortCppWriter.getPortNamespaces(s, symbol)
     )
 
   /** Write a command param as a C++ type */

--- a/compiler/lib/src/main/scala/codegen/CppWriter/PortCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/PortCppWriter.scala
@@ -577,9 +577,14 @@ object PortCppWriter {
     }
 
   /** Get the name of the port string class namespace */
-  def getPortStringNamespace(name: String): String = s"${name}PortStrings"
+  def getPortStringNamespace(s: CppWriterState, symbol: Symbol.Port): String = {
+    val fppName = s.a.getQualifiedName(symbol)
+    val cppName = CppWriter.writeQualifiedName(fppName)
+    s"${cppName}PortStrings"
+  }
 
   /** Get the names of port namespaces as a list */
-  def getPortNamespaces(name: String): List[String] = List(getPortStringNamespace(name))
+  def getPortNamespaces(s: CppWriterState, symbol: Symbol.Port): List[String] =
+    List(getPortStringNamespace(s, symbol))
 
 }

--- a/compiler/tools/fpp-to-cpp/test/check-cpp
+++ b/compiler/tools/fpp-to-cpp/test/check-cpp
@@ -2,7 +2,7 @@
 
 . ../../../scripts/utils.sh
 
-for target in `find . -mindepth 2 -name check-cpp`
+for target in `find . -mindepth 2 -maxdepth 2 -name check-cpp`
 do
   dir=`dirname $target`
   echo "[ $dir ]"

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveCommandsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveCommandsComponentAc.ref.cpp
@@ -29,19 +29,19 @@ namespace {
 
   // Get the max size by doing a union of the input and internal port serialization sizes
   union BuffUnion {
-    BYTE noArgsAsyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsGuardedPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnGuardedPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnSyncPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsSyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE typedAsyncPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncAssertPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncBlockPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncDropPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedGuardedPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedReturnGuardedPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedReturnSyncPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedSyncPortSize[InputTypedPort::SERIALIZED_SIZE];
+    BYTE noArgsAsyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsGuardedPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE typedAsyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncAssertPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncBlockPriorityPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncDropPriorityPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedGuardedPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedReturnGuardedPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedReturnSyncPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedSyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
     BYTE cmdPortSize[Fw::InputCmdPort::SERIALIZED_SIZE];
   };
 
@@ -698,7 +698,7 @@ Fw::InputCmdPort* ActiveCommandsComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-InputNoArgsPort* ActiveCommandsComponentBase ::
+Ports::InputNoArgsPort* ActiveCommandsComponentBase ::
   get_noArgsAsync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -709,7 +709,7 @@ InputNoArgsPort* ActiveCommandsComponentBase ::
   return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-InputNoArgsPort* ActiveCommandsComponentBase ::
+Ports::InputNoArgsPort* ActiveCommandsComponentBase ::
   get_noArgsGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -720,7 +720,7 @@ InputNoArgsPort* ActiveCommandsComponentBase ::
   return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* ActiveCommandsComponentBase ::
+Ports::InputNoArgsReturnPort* ActiveCommandsComponentBase ::
   get_noArgsReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -731,7 +731,7 @@ InputNoArgsReturnPort* ActiveCommandsComponentBase ::
   return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* ActiveCommandsComponentBase ::
+Ports::InputNoArgsReturnPort* ActiveCommandsComponentBase ::
   get_noArgsReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -742,7 +742,7 @@ InputNoArgsReturnPort* ActiveCommandsComponentBase ::
   return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-InputNoArgsPort* ActiveCommandsComponentBase ::
+Ports::InputNoArgsPort* ActiveCommandsComponentBase ::
   get_noArgsSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -753,7 +753,7 @@ InputNoArgsPort* ActiveCommandsComponentBase ::
   return &this->m_noArgsSync_InputPort[portNum];
 }
 
-InputTypedPort* ActiveCommandsComponentBase ::
+Ports::InputTypedPort* ActiveCommandsComponentBase ::
   get_typedAsync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -764,7 +764,7 @@ InputTypedPort* ActiveCommandsComponentBase ::
   return &this->m_typedAsync_InputPort[portNum];
 }
 
-InputTypedPort* ActiveCommandsComponentBase ::
+Ports::InputTypedPort* ActiveCommandsComponentBase ::
   get_typedAsyncAssert_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -775,7 +775,7 @@ InputTypedPort* ActiveCommandsComponentBase ::
   return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-InputTypedPort* ActiveCommandsComponentBase ::
+Ports::InputTypedPort* ActiveCommandsComponentBase ::
   get_typedAsyncBlockPriority_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -786,7 +786,7 @@ InputTypedPort* ActiveCommandsComponentBase ::
   return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-InputTypedPort* ActiveCommandsComponentBase ::
+Ports::InputTypedPort* ActiveCommandsComponentBase ::
   get_typedAsyncDropPriority_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -797,7 +797,7 @@ InputTypedPort* ActiveCommandsComponentBase ::
   return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-InputTypedPort* ActiveCommandsComponentBase ::
+Ports::InputTypedPort* ActiveCommandsComponentBase ::
   get_typedGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -808,7 +808,7 @@ InputTypedPort* ActiveCommandsComponentBase ::
   return &this->m_typedGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* ActiveCommandsComponentBase ::
+Ports::InputTypedReturnPort* ActiveCommandsComponentBase ::
   get_typedReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -819,7 +819,7 @@ InputTypedReturnPort* ActiveCommandsComponentBase ::
   return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* ActiveCommandsComponentBase ::
+Ports::InputTypedReturnPort* ActiveCommandsComponentBase ::
   get_typedReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -830,7 +830,7 @@ InputTypedReturnPort* ActiveCommandsComponentBase ::
   return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-InputTypedPort* ActiveCommandsComponentBase ::
+Ports::InputTypedPort* ActiveCommandsComponentBase ::
   get_typedSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -968,7 +968,7 @@ void ActiveCommandsComponentBase ::
 void ActiveCommandsComponentBase ::
   set_typedOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -982,7 +982,7 @@ void ActiveCommandsComponentBase ::
 void ActiveCommandsComponentBase ::
   set_typedReturnOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -1630,7 +1630,7 @@ void ActiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1737,7 +1737,7 @@ void ActiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1844,7 +1844,7 @@ void ActiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1951,7 +1951,7 @@ void ActiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2063,7 +2063,7 @@ void ActiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2100,7 +2100,7 @@ F32 ActiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2141,7 +2141,7 @@ F32 ActiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2176,7 +2176,7 @@ void ActiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2221,7 +2221,7 @@ void ActiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2236,7 +2236,7 @@ void ActiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2251,7 +2251,7 @@ void ActiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2266,7 +2266,7 @@ void ActiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2285,7 +2285,7 @@ void ActiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2312,7 +2312,7 @@ F32 ActiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -3455,7 +3455,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -3527,7 +3527,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -3599,7 +3599,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -3671,7 +3671,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -4236,7 +4236,7 @@ void ActiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -4263,7 +4263,7 @@ void ActiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -4290,7 +4290,7 @@ void ActiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -4317,7 +4317,7 @@ void ActiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -4344,7 +4344,7 @@ void ActiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -4371,7 +4371,7 @@ F32 ActiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -4398,7 +4398,7 @@ F32 ActiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -4425,7 +4425,7 @@ void ActiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveCommandsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveCommandsComponentAc.ref.hpp
@@ -148,91 +148,91 @@ class ActiveCommandsComponentBase :
     //! Get typed input port at index
     //!
     //! \return noArgsAsync[portNum]
-    InputNoArgsPort* get_noArgsAsync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsAsync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsGuarded[portNum]
-    InputNoArgsPort* get_noArgsGuarded_InputPort(
+    Ports::InputNoArgsPort* get_noArgsGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnGuarded[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnSync[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsSync[portNum]
-    InputNoArgsPort* get_noArgsSync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsync[portNum]
-    InputTypedPort* get_typedAsync_InputPort(
+    Ports::InputTypedPort* get_typedAsync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncAssert[portNum]
-    InputTypedPort* get_typedAsyncAssert_InputPort(
+    Ports::InputTypedPort* get_typedAsyncAssert_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncBlockPriority[portNum]
-    InputTypedPort* get_typedAsyncBlockPriority_InputPort(
+    Ports::InputTypedPort* get_typedAsyncBlockPriority_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncDropPriority[portNum]
-    InputTypedPort* get_typedAsyncDropPriority_InputPort(
+    Ports::InputTypedPort* get_typedAsyncDropPriority_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedGuarded[portNum]
-    InputTypedPort* get_typedGuarded_InputPort(
+    Ports::InputTypedPort* get_typedGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnGuarded[portNum]
-    InputTypedReturnPort* get_typedReturnGuarded_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnSync[portNum]
-    InputTypedReturnPort* get_typedReturnSync_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedSync[portNum]
-    InputTypedPort* get_typedSync_InputPort(
+    Ports::InputTypedPort* get_typedSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -303,13 +303,13 @@ class ActiveCommandsComponentBase :
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnOut[portNum]
     void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
 #if FW_PORT_SERIALIZATION
@@ -680,7 +680,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -692,7 +692,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -704,7 +704,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -716,7 +716,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -728,7 +728,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -740,7 +740,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -752,7 +752,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -764,7 +764,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -809,7 +809,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -821,7 +821,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -833,7 +833,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -845,7 +845,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -857,7 +857,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -869,7 +869,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -881,7 +881,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -893,7 +893,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -920,7 +920,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -932,7 +932,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -944,7 +944,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -956,7 +956,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -974,7 +974,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -986,7 +986,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1459,7 +1459,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1472,7 +1472,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1485,7 +1485,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1498,7 +1498,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1511,7 +1511,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1524,7 +1524,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1537,7 +1537,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1550,7 +1550,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1572,43 +1572,43 @@ class ActiveCommandsComponentBase :
     // ----------------------------------------------------------------------
 
     //! Input port noArgsAsync
-    InputNoArgsPort m_noArgsAsync_InputPort[NUM_NOARGSASYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsAsync_InputPort[NUM_NOARGSASYNC_INPUT_PORTS];
 
     //! Input port noArgsGuarded
-    InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnGuarded
-    InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnSync
-    InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
 
     //! Input port noArgsSync
-    InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedAsync
-    InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];
 
     //! Input port typedAsyncAssert
-    InputTypedPort m_typedAsyncAssert_InputPort[NUM_TYPEDASYNCASSERT_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncAssert_InputPort[NUM_TYPEDASYNCASSERT_INPUT_PORTS];
 
     //! Input port typedAsyncBlockPriority
-    InputTypedPort m_typedAsyncBlockPriority_InputPort[NUM_TYPEDASYNCBLOCKPRIORITY_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncBlockPriority_InputPort[NUM_TYPEDASYNCBLOCKPRIORITY_INPUT_PORTS];
 
     //! Input port typedAsyncDropPriority
-    InputTypedPort m_typedAsyncDropPriority_InputPort[NUM_TYPEDASYNCDROPPRIORITY_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncDropPriority_InputPort[NUM_TYPEDASYNCDROPPRIORITY_INPUT_PORTS];
 
     //! Input port typedGuarded
-    InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
+    Ports::InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnGuarded
-    InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnSync
-    InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
 
     //! Input port typedSync
-    InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
 
   PRIVATE:
 
@@ -1651,10 +1651,10 @@ class ActiveCommandsComponentBase :
     // ----------------------------------------------------------------------
 
     //! Output port typedOut
-    OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
+    Ports::OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
 
     //! Output port typedReturnOut
-    OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
+    Ports::OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
 
   PRIVATE:
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveEventsComponentAc.ref.cpp
@@ -24,19 +24,19 @@ namespace {
 
   // Get the max size by doing a union of the input and internal port serialization sizes
   union BuffUnion {
-    BYTE noArgsAsyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsGuardedPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnGuardedPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnSyncPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsSyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE typedAsyncPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncAssertPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncBlockPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncDropPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedGuardedPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedReturnGuardedPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedReturnSyncPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedSyncPortSize[InputTypedPort::SERIALIZED_SIZE];
+    BYTE noArgsAsyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsGuardedPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE typedAsyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncAssertPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncBlockPriorityPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncDropPriorityPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedGuardedPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedReturnGuardedPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedReturnSyncPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedSyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
     BYTE cmdPortSize[Fw::InputCmdPort::SERIALIZED_SIZE];
   };
 
@@ -693,7 +693,7 @@ Fw::InputCmdPort* ActiveEventsComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-InputNoArgsPort* ActiveEventsComponentBase ::
+Ports::InputNoArgsPort* ActiveEventsComponentBase ::
   get_noArgsAsync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -704,7 +704,7 @@ InputNoArgsPort* ActiveEventsComponentBase ::
   return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-InputNoArgsPort* ActiveEventsComponentBase ::
+Ports::InputNoArgsPort* ActiveEventsComponentBase ::
   get_noArgsGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -715,7 +715,7 @@ InputNoArgsPort* ActiveEventsComponentBase ::
   return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* ActiveEventsComponentBase ::
+Ports::InputNoArgsReturnPort* ActiveEventsComponentBase ::
   get_noArgsReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -726,7 +726,7 @@ InputNoArgsReturnPort* ActiveEventsComponentBase ::
   return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* ActiveEventsComponentBase ::
+Ports::InputNoArgsReturnPort* ActiveEventsComponentBase ::
   get_noArgsReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -737,7 +737,7 @@ InputNoArgsReturnPort* ActiveEventsComponentBase ::
   return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-InputNoArgsPort* ActiveEventsComponentBase ::
+Ports::InputNoArgsPort* ActiveEventsComponentBase ::
   get_noArgsSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -748,7 +748,7 @@ InputNoArgsPort* ActiveEventsComponentBase ::
   return &this->m_noArgsSync_InputPort[portNum];
 }
 
-InputTypedPort* ActiveEventsComponentBase ::
+Ports::InputTypedPort* ActiveEventsComponentBase ::
   get_typedAsync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -759,7 +759,7 @@ InputTypedPort* ActiveEventsComponentBase ::
   return &this->m_typedAsync_InputPort[portNum];
 }
 
-InputTypedPort* ActiveEventsComponentBase ::
+Ports::InputTypedPort* ActiveEventsComponentBase ::
   get_typedAsyncAssert_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -770,7 +770,7 @@ InputTypedPort* ActiveEventsComponentBase ::
   return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-InputTypedPort* ActiveEventsComponentBase ::
+Ports::InputTypedPort* ActiveEventsComponentBase ::
   get_typedAsyncBlockPriority_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -781,7 +781,7 @@ InputTypedPort* ActiveEventsComponentBase ::
   return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-InputTypedPort* ActiveEventsComponentBase ::
+Ports::InputTypedPort* ActiveEventsComponentBase ::
   get_typedAsyncDropPriority_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -792,7 +792,7 @@ InputTypedPort* ActiveEventsComponentBase ::
   return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-InputTypedPort* ActiveEventsComponentBase ::
+Ports::InputTypedPort* ActiveEventsComponentBase ::
   get_typedGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -803,7 +803,7 @@ InputTypedPort* ActiveEventsComponentBase ::
   return &this->m_typedGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* ActiveEventsComponentBase ::
+Ports::InputTypedReturnPort* ActiveEventsComponentBase ::
   get_typedReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -814,7 +814,7 @@ InputTypedReturnPort* ActiveEventsComponentBase ::
   return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* ActiveEventsComponentBase ::
+Ports::InputTypedReturnPort* ActiveEventsComponentBase ::
   get_typedReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -825,7 +825,7 @@ InputTypedReturnPort* ActiveEventsComponentBase ::
   return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-InputTypedPort* ActiveEventsComponentBase ::
+Ports::InputTypedPort* ActiveEventsComponentBase ::
   get_typedSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -963,7 +963,7 @@ void ActiveEventsComponentBase ::
 void ActiveEventsComponentBase ::
   set_typedOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -977,7 +977,7 @@ void ActiveEventsComponentBase ::
 void ActiveEventsComponentBase ::
   set_typedReturnOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -1549,7 +1549,7 @@ void ActiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1656,7 +1656,7 @@ void ActiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1763,7 +1763,7 @@ void ActiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1870,7 +1870,7 @@ void ActiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1982,7 +1982,7 @@ void ActiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2019,7 +2019,7 @@ F32 ActiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2060,7 +2060,7 @@ F32 ActiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2095,7 +2095,7 @@ void ActiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2140,7 +2140,7 @@ void ActiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2155,7 +2155,7 @@ void ActiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2170,7 +2170,7 @@ void ActiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2185,7 +2185,7 @@ void ActiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2204,7 +2204,7 @@ void ActiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2231,7 +2231,7 @@ F32 ActiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -3062,7 +3062,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -3134,7 +3134,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -3206,7 +3206,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -3278,7 +3278,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -3415,7 +3415,7 @@ void ActiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3442,7 +3442,7 @@ void ActiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3469,7 +3469,7 @@ void ActiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3496,7 +3496,7 @@ void ActiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3523,7 +3523,7 @@ void ActiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3550,7 +3550,7 @@ F32 ActiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -3577,7 +3577,7 @@ F32 ActiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -3604,7 +3604,7 @@ void ActiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveEventsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveEventsComponentAc.ref.hpp
@@ -145,91 +145,91 @@ class ActiveEventsComponentBase :
     //! Get typed input port at index
     //!
     //! \return noArgsAsync[portNum]
-    InputNoArgsPort* get_noArgsAsync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsAsync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsGuarded[portNum]
-    InputNoArgsPort* get_noArgsGuarded_InputPort(
+    Ports::InputNoArgsPort* get_noArgsGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnGuarded[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnSync[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsSync[portNum]
-    InputNoArgsPort* get_noArgsSync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsync[portNum]
-    InputTypedPort* get_typedAsync_InputPort(
+    Ports::InputTypedPort* get_typedAsync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncAssert[portNum]
-    InputTypedPort* get_typedAsyncAssert_InputPort(
+    Ports::InputTypedPort* get_typedAsyncAssert_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncBlockPriority[portNum]
-    InputTypedPort* get_typedAsyncBlockPriority_InputPort(
+    Ports::InputTypedPort* get_typedAsyncBlockPriority_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncDropPriority[portNum]
-    InputTypedPort* get_typedAsyncDropPriority_InputPort(
+    Ports::InputTypedPort* get_typedAsyncDropPriority_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedGuarded[portNum]
-    InputTypedPort* get_typedGuarded_InputPort(
+    Ports::InputTypedPort* get_typedGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnGuarded[portNum]
-    InputTypedReturnPort* get_typedReturnGuarded_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnSync[portNum]
-    InputTypedReturnPort* get_typedReturnSync_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedSync[portNum]
-    InputTypedPort* get_typedSync_InputPort(
+    Ports::InputTypedPort* get_typedSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -300,13 +300,13 @@ class ActiveEventsComponentBase :
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnOut[portNum]
     void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
 #if FW_PORT_SERIALIZATION
@@ -666,7 +666,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -678,7 +678,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -690,7 +690,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -702,7 +702,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -714,7 +714,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -726,7 +726,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -738,7 +738,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -750,7 +750,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -795,7 +795,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -807,7 +807,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -819,7 +819,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -831,7 +831,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -843,7 +843,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -855,7 +855,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -867,7 +867,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -879,7 +879,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -906,7 +906,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -918,7 +918,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -930,7 +930,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -942,7 +942,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -960,7 +960,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -972,7 +972,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1140,7 +1140,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1153,7 +1153,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1166,7 +1166,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1179,7 +1179,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1192,7 +1192,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1205,7 +1205,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1218,7 +1218,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1231,7 +1231,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1253,43 +1253,43 @@ class ActiveEventsComponentBase :
     // ----------------------------------------------------------------------
 
     //! Input port noArgsAsync
-    InputNoArgsPort m_noArgsAsync_InputPort[NUM_NOARGSASYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsAsync_InputPort[NUM_NOARGSASYNC_INPUT_PORTS];
 
     //! Input port noArgsGuarded
-    InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnGuarded
-    InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnSync
-    InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
 
     //! Input port noArgsSync
-    InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedAsync
-    InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];
 
     //! Input port typedAsyncAssert
-    InputTypedPort m_typedAsyncAssert_InputPort[NUM_TYPEDASYNCASSERT_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncAssert_InputPort[NUM_TYPEDASYNCASSERT_INPUT_PORTS];
 
     //! Input port typedAsyncBlockPriority
-    InputTypedPort m_typedAsyncBlockPriority_InputPort[NUM_TYPEDASYNCBLOCKPRIORITY_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncBlockPriority_InputPort[NUM_TYPEDASYNCBLOCKPRIORITY_INPUT_PORTS];
 
     //! Input port typedAsyncDropPriority
-    InputTypedPort m_typedAsyncDropPriority_InputPort[NUM_TYPEDASYNCDROPPRIORITY_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncDropPriority_InputPort[NUM_TYPEDASYNCDROPPRIORITY_INPUT_PORTS];
 
     //! Input port typedGuarded
-    InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
+    Ports::InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnGuarded
-    InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnSync
-    InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
 
     //! Input port typedSync
-    InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
 
   PRIVATE:
 
@@ -1332,10 +1332,10 @@ class ActiveEventsComponentBase :
     // ----------------------------------------------------------------------
 
     //! Output port typedOut
-    OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
+    Ports::OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
 
     //! Output port typedReturnOut
-    OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
+    Ports::OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
 
   PRIVATE:
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveParamsComponentAc.ref.cpp
@@ -24,19 +24,19 @@ namespace {
 
   // Get the max size by doing a union of the input and internal port serialization sizes
   union BuffUnion {
-    BYTE noArgsAsyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsGuardedPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnGuardedPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnSyncPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsSyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE typedAsyncPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncAssertPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncBlockPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncDropPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedGuardedPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedReturnGuardedPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedReturnSyncPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedSyncPortSize[InputTypedPort::SERIALIZED_SIZE];
+    BYTE noArgsAsyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsGuardedPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE typedAsyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncAssertPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncBlockPriorityPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncDropPriorityPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedGuardedPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedReturnGuardedPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedReturnSyncPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedSyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
     BYTE cmdPortSize[Fw::InputCmdPort::SERIALIZED_SIZE];
   };
 
@@ -693,7 +693,7 @@ Fw::InputCmdPort* ActiveParamsComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-InputNoArgsPort* ActiveParamsComponentBase ::
+Ports::InputNoArgsPort* ActiveParamsComponentBase ::
   get_noArgsAsync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -704,7 +704,7 @@ InputNoArgsPort* ActiveParamsComponentBase ::
   return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-InputNoArgsPort* ActiveParamsComponentBase ::
+Ports::InputNoArgsPort* ActiveParamsComponentBase ::
   get_noArgsGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -715,7 +715,7 @@ InputNoArgsPort* ActiveParamsComponentBase ::
   return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* ActiveParamsComponentBase ::
+Ports::InputNoArgsReturnPort* ActiveParamsComponentBase ::
   get_noArgsReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -726,7 +726,7 @@ InputNoArgsReturnPort* ActiveParamsComponentBase ::
   return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* ActiveParamsComponentBase ::
+Ports::InputNoArgsReturnPort* ActiveParamsComponentBase ::
   get_noArgsReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -737,7 +737,7 @@ InputNoArgsReturnPort* ActiveParamsComponentBase ::
   return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-InputNoArgsPort* ActiveParamsComponentBase ::
+Ports::InputNoArgsPort* ActiveParamsComponentBase ::
   get_noArgsSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -748,7 +748,7 @@ InputNoArgsPort* ActiveParamsComponentBase ::
   return &this->m_noArgsSync_InputPort[portNum];
 }
 
-InputTypedPort* ActiveParamsComponentBase ::
+Ports::InputTypedPort* ActiveParamsComponentBase ::
   get_typedAsync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -759,7 +759,7 @@ InputTypedPort* ActiveParamsComponentBase ::
   return &this->m_typedAsync_InputPort[portNum];
 }
 
-InputTypedPort* ActiveParamsComponentBase ::
+Ports::InputTypedPort* ActiveParamsComponentBase ::
   get_typedAsyncAssert_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -770,7 +770,7 @@ InputTypedPort* ActiveParamsComponentBase ::
   return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-InputTypedPort* ActiveParamsComponentBase ::
+Ports::InputTypedPort* ActiveParamsComponentBase ::
   get_typedAsyncBlockPriority_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -781,7 +781,7 @@ InputTypedPort* ActiveParamsComponentBase ::
   return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-InputTypedPort* ActiveParamsComponentBase ::
+Ports::InputTypedPort* ActiveParamsComponentBase ::
   get_typedAsyncDropPriority_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -792,7 +792,7 @@ InputTypedPort* ActiveParamsComponentBase ::
   return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-InputTypedPort* ActiveParamsComponentBase ::
+Ports::InputTypedPort* ActiveParamsComponentBase ::
   get_typedGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -803,7 +803,7 @@ InputTypedPort* ActiveParamsComponentBase ::
   return &this->m_typedGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* ActiveParamsComponentBase ::
+Ports::InputTypedReturnPort* ActiveParamsComponentBase ::
   get_typedReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -814,7 +814,7 @@ InputTypedReturnPort* ActiveParamsComponentBase ::
   return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* ActiveParamsComponentBase ::
+Ports::InputTypedReturnPort* ActiveParamsComponentBase ::
   get_typedReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -825,7 +825,7 @@ InputTypedReturnPort* ActiveParamsComponentBase ::
   return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-InputTypedPort* ActiveParamsComponentBase ::
+Ports::InputTypedPort* ActiveParamsComponentBase ::
   get_typedSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -963,7 +963,7 @@ void ActiveParamsComponentBase ::
 void ActiveParamsComponentBase ::
   set_typedOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -977,7 +977,7 @@ void ActiveParamsComponentBase ::
 void ActiveParamsComponentBase ::
   set_typedReturnOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -1785,7 +1785,7 @@ void ActiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1892,7 +1892,7 @@ void ActiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1999,7 +1999,7 @@ void ActiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2106,7 +2106,7 @@ void ActiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2218,7 +2218,7 @@ void ActiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2255,7 +2255,7 @@ F32 ActiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2296,7 +2296,7 @@ F32 ActiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2331,7 +2331,7 @@ void ActiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2376,7 +2376,7 @@ void ActiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2391,7 +2391,7 @@ void ActiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2406,7 +2406,7 @@ void ActiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2421,7 +2421,7 @@ void ActiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2440,7 +2440,7 @@ void ActiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2467,7 +2467,7 @@ F32 ActiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2704,7 +2704,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -2776,7 +2776,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -2848,7 +2848,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -2920,7 +2920,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -3181,7 +3181,7 @@ void ActiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3208,7 +3208,7 @@ void ActiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3235,7 +3235,7 @@ void ActiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3262,7 +3262,7 @@ void ActiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3289,7 +3289,7 @@ void ActiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3316,7 +3316,7 @@ F32 ActiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -3343,7 +3343,7 @@ F32 ActiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -3370,7 +3370,7 @@ void ActiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveParamsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveParamsComponentAc.ref.hpp
@@ -155,91 +155,91 @@ class ActiveParamsComponentBase :
     //! Get typed input port at index
     //!
     //! \return noArgsAsync[portNum]
-    InputNoArgsPort* get_noArgsAsync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsAsync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsGuarded[portNum]
-    InputNoArgsPort* get_noArgsGuarded_InputPort(
+    Ports::InputNoArgsPort* get_noArgsGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnGuarded[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnSync[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsSync[portNum]
-    InputNoArgsPort* get_noArgsSync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsync[portNum]
-    InputTypedPort* get_typedAsync_InputPort(
+    Ports::InputTypedPort* get_typedAsync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncAssert[portNum]
-    InputTypedPort* get_typedAsyncAssert_InputPort(
+    Ports::InputTypedPort* get_typedAsyncAssert_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncBlockPriority[portNum]
-    InputTypedPort* get_typedAsyncBlockPriority_InputPort(
+    Ports::InputTypedPort* get_typedAsyncBlockPriority_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncDropPriority[portNum]
-    InputTypedPort* get_typedAsyncDropPriority_InputPort(
+    Ports::InputTypedPort* get_typedAsyncDropPriority_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedGuarded[portNum]
-    InputTypedPort* get_typedGuarded_InputPort(
+    Ports::InputTypedPort* get_typedGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnGuarded[portNum]
-    InputTypedReturnPort* get_typedReturnGuarded_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnSync[portNum]
-    InputTypedReturnPort* get_typedReturnSync_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedSync[portNum]
-    InputTypedPort* get_typedSync_InputPort(
+    Ports::InputTypedPort* get_typedSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -310,13 +310,13 @@ class ActiveParamsComponentBase :
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnOut[portNum]
     void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
 #if FW_PORT_SERIALIZATION
@@ -698,7 +698,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -710,7 +710,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -722,7 +722,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -734,7 +734,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -746,7 +746,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -758,7 +758,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -770,7 +770,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -782,7 +782,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -827,7 +827,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -839,7 +839,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -851,7 +851,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -863,7 +863,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -875,7 +875,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -887,7 +887,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -899,7 +899,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -911,7 +911,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -938,7 +938,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -950,7 +950,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -962,7 +962,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -974,7 +974,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -992,7 +992,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1004,7 +1004,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1199,7 +1199,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1212,7 +1212,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1225,7 +1225,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1238,7 +1238,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1251,7 +1251,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1264,7 +1264,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1277,7 +1277,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1290,7 +1290,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1396,43 +1396,43 @@ class ActiveParamsComponentBase :
     // ----------------------------------------------------------------------
 
     //! Input port noArgsAsync
-    InputNoArgsPort m_noArgsAsync_InputPort[NUM_NOARGSASYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsAsync_InputPort[NUM_NOARGSASYNC_INPUT_PORTS];
 
     //! Input port noArgsGuarded
-    InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnGuarded
-    InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnSync
-    InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
 
     //! Input port noArgsSync
-    InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedAsync
-    InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];
 
     //! Input port typedAsyncAssert
-    InputTypedPort m_typedAsyncAssert_InputPort[NUM_TYPEDASYNCASSERT_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncAssert_InputPort[NUM_TYPEDASYNCASSERT_INPUT_PORTS];
 
     //! Input port typedAsyncBlockPriority
-    InputTypedPort m_typedAsyncBlockPriority_InputPort[NUM_TYPEDASYNCBLOCKPRIORITY_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncBlockPriority_InputPort[NUM_TYPEDASYNCBLOCKPRIORITY_INPUT_PORTS];
 
     //! Input port typedAsyncDropPriority
-    InputTypedPort m_typedAsyncDropPriority_InputPort[NUM_TYPEDASYNCDROPPRIORITY_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncDropPriority_InputPort[NUM_TYPEDASYNCDROPPRIORITY_INPUT_PORTS];
 
     //! Input port typedGuarded
-    InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
+    Ports::InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnGuarded
-    InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnSync
-    InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
 
     //! Input port typedSync
-    InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
 
   PRIVATE:
 
@@ -1475,10 +1475,10 @@ class ActiveParamsComponentBase :
     // ----------------------------------------------------------------------
 
     //! Output port typedOut
-    OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
+    Ports::OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
 
     //! Output port typedReturnOut
-    OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
+    Ports::OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
 
   PRIVATE:
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.cpp
@@ -39,19 +39,19 @@ namespace {
 
   // Get the max size by doing a union of the input and internal port serialization sizes
   union BuffUnion {
-    BYTE noArgsAsyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsGuardedPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnGuardedPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnSyncPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsSyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE typedAsyncPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncAssertPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncBlockPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncDropPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedGuardedPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedReturnGuardedPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedReturnSyncPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedSyncPortSize[InputTypedPort::SERIALIZED_SIZE];
+    BYTE noArgsAsyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsGuardedPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE typedAsyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncAssertPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncBlockPriorityPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncDropPriorityPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedGuardedPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedReturnGuardedPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedReturnSyncPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedSyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
     BYTE cmdPortSize[Fw::InputCmdPort::SERIALIZED_SIZE];
     // Size of internalArray argument list
     BYTE internalArrayIntIfSize[
@@ -917,7 +917,7 @@ Fw::InputCmdPort* ActiveSerialComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-InputNoArgsPort* ActiveSerialComponentBase ::
+Ports::InputNoArgsPort* ActiveSerialComponentBase ::
   get_noArgsAsync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -928,7 +928,7 @@ InputNoArgsPort* ActiveSerialComponentBase ::
   return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-InputNoArgsPort* ActiveSerialComponentBase ::
+Ports::InputNoArgsPort* ActiveSerialComponentBase ::
   get_noArgsGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -939,7 +939,7 @@ InputNoArgsPort* ActiveSerialComponentBase ::
   return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* ActiveSerialComponentBase ::
+Ports::InputNoArgsReturnPort* ActiveSerialComponentBase ::
   get_noArgsReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -950,7 +950,7 @@ InputNoArgsReturnPort* ActiveSerialComponentBase ::
   return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* ActiveSerialComponentBase ::
+Ports::InputNoArgsReturnPort* ActiveSerialComponentBase ::
   get_noArgsReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -961,7 +961,7 @@ InputNoArgsReturnPort* ActiveSerialComponentBase ::
   return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-InputNoArgsPort* ActiveSerialComponentBase ::
+Ports::InputNoArgsPort* ActiveSerialComponentBase ::
   get_noArgsSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -972,7 +972,7 @@ InputNoArgsPort* ActiveSerialComponentBase ::
   return &this->m_noArgsSync_InputPort[portNum];
 }
 
-InputTypedPort* ActiveSerialComponentBase ::
+Ports::InputTypedPort* ActiveSerialComponentBase ::
   get_typedAsync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -983,7 +983,7 @@ InputTypedPort* ActiveSerialComponentBase ::
   return &this->m_typedAsync_InputPort[portNum];
 }
 
-InputTypedPort* ActiveSerialComponentBase ::
+Ports::InputTypedPort* ActiveSerialComponentBase ::
   get_typedAsyncAssert_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -994,7 +994,7 @@ InputTypedPort* ActiveSerialComponentBase ::
   return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-InputTypedPort* ActiveSerialComponentBase ::
+Ports::InputTypedPort* ActiveSerialComponentBase ::
   get_typedAsyncBlockPriority_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -1005,7 +1005,7 @@ InputTypedPort* ActiveSerialComponentBase ::
   return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-InputTypedPort* ActiveSerialComponentBase ::
+Ports::InputTypedPort* ActiveSerialComponentBase ::
   get_typedAsyncDropPriority_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -1016,7 +1016,7 @@ InputTypedPort* ActiveSerialComponentBase ::
   return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-InputTypedPort* ActiveSerialComponentBase ::
+Ports::InputTypedPort* ActiveSerialComponentBase ::
   get_typedGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -1027,7 +1027,7 @@ InputTypedPort* ActiveSerialComponentBase ::
   return &this->m_typedGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* ActiveSerialComponentBase ::
+Ports::InputTypedReturnPort* ActiveSerialComponentBase ::
   get_typedReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -1038,7 +1038,7 @@ InputTypedReturnPort* ActiveSerialComponentBase ::
   return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* ActiveSerialComponentBase ::
+Ports::InputTypedReturnPort* ActiveSerialComponentBase ::
   get_typedReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -1049,7 +1049,7 @@ InputTypedReturnPort* ActiveSerialComponentBase ::
   return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-InputTypedPort* ActiveSerialComponentBase ::
+Ports::InputTypedPort* ActiveSerialComponentBase ::
   get_typedSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -1257,7 +1257,7 @@ void ActiveSerialComponentBase ::
 void ActiveSerialComponentBase ::
   set_typedOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -1271,7 +1271,7 @@ void ActiveSerialComponentBase ::
 void ActiveSerialComponentBase ::
   set_typedReturnOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -2245,7 +2245,7 @@ void ActiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2352,7 +2352,7 @@ void ActiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2459,7 +2459,7 @@ void ActiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2566,7 +2566,7 @@ void ActiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2678,7 +2678,7 @@ void ActiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2715,7 +2715,7 @@ F32 ActiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2756,7 +2756,7 @@ F32 ActiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2791,7 +2791,7 @@ void ActiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3091,7 +3091,7 @@ void ActiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3106,7 +3106,7 @@ void ActiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3121,7 +3121,7 @@ void ActiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3136,7 +3136,7 @@ void ActiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3199,7 +3199,7 @@ void ActiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3226,7 +3226,7 @@ F32 ActiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -5816,7 +5816,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -5888,7 +5888,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -5960,7 +5960,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -6032,7 +6032,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -6952,7 +6952,7 @@ void ActiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -6979,7 +6979,7 @@ void ActiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -7006,7 +7006,7 @@ void ActiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -7033,7 +7033,7 @@ void ActiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -7060,7 +7060,7 @@ void ActiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -7087,7 +7087,7 @@ F32 ActiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -7114,7 +7114,7 @@ F32 ActiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -7141,7 +7141,7 @@ void ActiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.hpp
@@ -229,91 +229,91 @@ class ActiveSerialComponentBase :
     //! Get typed input port at index
     //!
     //! \return noArgsAsync[portNum]
-    InputNoArgsPort* get_noArgsAsync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsAsync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsGuarded[portNum]
-    InputNoArgsPort* get_noArgsGuarded_InputPort(
+    Ports::InputNoArgsPort* get_noArgsGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnGuarded[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnSync[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsSync[portNum]
-    InputNoArgsPort* get_noArgsSync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsync[portNum]
-    InputTypedPort* get_typedAsync_InputPort(
+    Ports::InputTypedPort* get_typedAsync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncAssert[portNum]
-    InputTypedPort* get_typedAsyncAssert_InputPort(
+    Ports::InputTypedPort* get_typedAsyncAssert_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncBlockPriority[portNum]
-    InputTypedPort* get_typedAsyncBlockPriority_InputPort(
+    Ports::InputTypedPort* get_typedAsyncBlockPriority_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncDropPriority[portNum]
-    InputTypedPort* get_typedAsyncDropPriority_InputPort(
+    Ports::InputTypedPort* get_typedAsyncDropPriority_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedGuarded[portNum]
-    InputTypedPort* get_typedGuarded_InputPort(
+    Ports::InputTypedPort* get_typedGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnGuarded[portNum]
-    InputTypedReturnPort* get_typedReturnGuarded_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnSync[portNum]
-    InputTypedReturnPort* get_typedReturnSync_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedSync[portNum]
-    InputTypedPort* get_typedSync_InputPort(
+    Ports::InputTypedPort* get_typedSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -432,13 +432,13 @@ class ActiveSerialComponentBase :
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnOut[portNum]
     void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
 #if FW_PORT_SERIALIZATION
@@ -896,7 +896,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -908,7 +908,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -920,7 +920,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -932,7 +932,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -944,7 +944,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -956,7 +956,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -968,7 +968,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -980,7 +980,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1025,7 +1025,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1037,7 +1037,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1049,7 +1049,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1061,7 +1061,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1073,7 +1073,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1085,7 +1085,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1097,7 +1097,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1109,7 +1109,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1222,7 +1222,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1234,7 +1234,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1246,7 +1246,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1258,7 +1258,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1310,7 +1310,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1322,7 +1322,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -2127,7 +2127,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -2140,7 +2140,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -2153,7 +2153,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -2166,7 +2166,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -2179,7 +2179,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -2192,7 +2192,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -2205,7 +2205,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -2218,7 +2218,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -2376,43 +2376,43 @@ class ActiveSerialComponentBase :
     // ----------------------------------------------------------------------
 
     //! Input port noArgsAsync
-    InputNoArgsPort m_noArgsAsync_InputPort[NUM_NOARGSASYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsAsync_InputPort[NUM_NOARGSASYNC_INPUT_PORTS];
 
     //! Input port noArgsGuarded
-    InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnGuarded
-    InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnSync
-    InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
 
     //! Input port noArgsSync
-    InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedAsync
-    InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];
 
     //! Input port typedAsyncAssert
-    InputTypedPort m_typedAsyncAssert_InputPort[NUM_TYPEDASYNCASSERT_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncAssert_InputPort[NUM_TYPEDASYNCASSERT_INPUT_PORTS];
 
     //! Input port typedAsyncBlockPriority
-    InputTypedPort m_typedAsyncBlockPriority_InputPort[NUM_TYPEDASYNCBLOCKPRIORITY_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncBlockPriority_InputPort[NUM_TYPEDASYNCBLOCKPRIORITY_INPUT_PORTS];
 
     //! Input port typedAsyncDropPriority
-    InputTypedPort m_typedAsyncDropPriority_InputPort[NUM_TYPEDASYNCDROPPRIORITY_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncDropPriority_InputPort[NUM_TYPEDASYNCDROPPRIORITY_INPUT_PORTS];
 
     //! Input port typedGuarded
-    InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
+    Ports::InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnGuarded
-    InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnSync
-    InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
 
     //! Input port typedSync
-    InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
 
   PRIVATE:
 
@@ -2479,10 +2479,10 @@ class ActiveSerialComponentBase :
     // ----------------------------------------------------------------------
 
     //! Output port typedOut
-    OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
+    Ports::OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
 
     //! Output port typedReturnOut
-    OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
+    Ports::OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
 
   PRIVATE:
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTelemetryComponentAc.ref.cpp
@@ -24,19 +24,19 @@ namespace {
 
   // Get the max size by doing a union of the input and internal port serialization sizes
   union BuffUnion {
-    BYTE noArgsAsyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsGuardedPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnGuardedPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnSyncPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsSyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE typedAsyncPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncAssertPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncBlockPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncDropPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedGuardedPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedReturnGuardedPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedReturnSyncPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedSyncPortSize[InputTypedPort::SERIALIZED_SIZE];
+    BYTE noArgsAsyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsGuardedPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE typedAsyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncAssertPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncBlockPriorityPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncDropPriorityPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedGuardedPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedReturnGuardedPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedReturnSyncPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedSyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
     BYTE cmdPortSize[Fw::InputCmdPort::SERIALIZED_SIZE];
   };
 
@@ -693,7 +693,7 @@ Fw::InputCmdPort* ActiveTelemetryComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-InputNoArgsPort* ActiveTelemetryComponentBase ::
+Ports::InputNoArgsPort* ActiveTelemetryComponentBase ::
   get_noArgsAsync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -704,7 +704,7 @@ InputNoArgsPort* ActiveTelemetryComponentBase ::
   return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-InputNoArgsPort* ActiveTelemetryComponentBase ::
+Ports::InputNoArgsPort* ActiveTelemetryComponentBase ::
   get_noArgsGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -715,7 +715,7 @@ InputNoArgsPort* ActiveTelemetryComponentBase ::
   return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* ActiveTelemetryComponentBase ::
+Ports::InputNoArgsReturnPort* ActiveTelemetryComponentBase ::
   get_noArgsReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -726,7 +726,7 @@ InputNoArgsReturnPort* ActiveTelemetryComponentBase ::
   return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* ActiveTelemetryComponentBase ::
+Ports::InputNoArgsReturnPort* ActiveTelemetryComponentBase ::
   get_noArgsReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -737,7 +737,7 @@ InputNoArgsReturnPort* ActiveTelemetryComponentBase ::
   return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-InputNoArgsPort* ActiveTelemetryComponentBase ::
+Ports::InputNoArgsPort* ActiveTelemetryComponentBase ::
   get_noArgsSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -748,7 +748,7 @@ InputNoArgsPort* ActiveTelemetryComponentBase ::
   return &this->m_noArgsSync_InputPort[portNum];
 }
 
-InputTypedPort* ActiveTelemetryComponentBase ::
+Ports::InputTypedPort* ActiveTelemetryComponentBase ::
   get_typedAsync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -759,7 +759,7 @@ InputTypedPort* ActiveTelemetryComponentBase ::
   return &this->m_typedAsync_InputPort[portNum];
 }
 
-InputTypedPort* ActiveTelemetryComponentBase ::
+Ports::InputTypedPort* ActiveTelemetryComponentBase ::
   get_typedAsyncAssert_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -770,7 +770,7 @@ InputTypedPort* ActiveTelemetryComponentBase ::
   return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-InputTypedPort* ActiveTelemetryComponentBase ::
+Ports::InputTypedPort* ActiveTelemetryComponentBase ::
   get_typedAsyncBlockPriority_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -781,7 +781,7 @@ InputTypedPort* ActiveTelemetryComponentBase ::
   return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-InputTypedPort* ActiveTelemetryComponentBase ::
+Ports::InputTypedPort* ActiveTelemetryComponentBase ::
   get_typedAsyncDropPriority_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -792,7 +792,7 @@ InputTypedPort* ActiveTelemetryComponentBase ::
   return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-InputTypedPort* ActiveTelemetryComponentBase ::
+Ports::InputTypedPort* ActiveTelemetryComponentBase ::
   get_typedGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -803,7 +803,7 @@ InputTypedPort* ActiveTelemetryComponentBase ::
   return &this->m_typedGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* ActiveTelemetryComponentBase ::
+Ports::InputTypedReturnPort* ActiveTelemetryComponentBase ::
   get_typedReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -814,7 +814,7 @@ InputTypedReturnPort* ActiveTelemetryComponentBase ::
   return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* ActiveTelemetryComponentBase ::
+Ports::InputTypedReturnPort* ActiveTelemetryComponentBase ::
   get_typedReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -825,7 +825,7 @@ InputTypedReturnPort* ActiveTelemetryComponentBase ::
   return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-InputTypedPort* ActiveTelemetryComponentBase ::
+Ports::InputTypedPort* ActiveTelemetryComponentBase ::
   get_typedSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -963,7 +963,7 @@ void ActiveTelemetryComponentBase ::
 void ActiveTelemetryComponentBase ::
   set_typedOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -977,7 +977,7 @@ void ActiveTelemetryComponentBase ::
 void ActiveTelemetryComponentBase ::
   set_typedReturnOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -1552,7 +1552,7 @@ void ActiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1659,7 +1659,7 @@ void ActiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1766,7 +1766,7 @@ void ActiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1873,7 +1873,7 @@ void ActiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1985,7 +1985,7 @@ void ActiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2022,7 +2022,7 @@ F32 ActiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2063,7 +2063,7 @@ F32 ActiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2098,7 +2098,7 @@ void ActiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2143,7 +2143,7 @@ void ActiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2158,7 +2158,7 @@ void ActiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2173,7 +2173,7 @@ void ActiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2188,7 +2188,7 @@ void ActiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2207,7 +2207,7 @@ void ActiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2234,7 +2234,7 @@ F32 ActiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2767,7 +2767,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -2839,7 +2839,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -2911,7 +2911,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -2983,7 +2983,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -3120,7 +3120,7 @@ void ActiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3147,7 +3147,7 @@ void ActiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3174,7 +3174,7 @@ void ActiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3201,7 +3201,7 @@ void ActiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3228,7 +3228,7 @@ void ActiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3255,7 +3255,7 @@ F32 ActiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -3282,7 +3282,7 @@ F32 ActiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -3309,7 +3309,7 @@ void ActiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTelemetryComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTelemetryComponentAc.ref.hpp
@@ -142,91 +142,91 @@ class ActiveTelemetryComponentBase :
     //! Get typed input port at index
     //!
     //! \return noArgsAsync[portNum]
-    InputNoArgsPort* get_noArgsAsync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsAsync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsGuarded[portNum]
-    InputNoArgsPort* get_noArgsGuarded_InputPort(
+    Ports::InputNoArgsPort* get_noArgsGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnGuarded[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnSync[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsSync[portNum]
-    InputNoArgsPort* get_noArgsSync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsync[portNum]
-    InputTypedPort* get_typedAsync_InputPort(
+    Ports::InputTypedPort* get_typedAsync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncAssert[portNum]
-    InputTypedPort* get_typedAsyncAssert_InputPort(
+    Ports::InputTypedPort* get_typedAsyncAssert_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncBlockPriority[portNum]
-    InputTypedPort* get_typedAsyncBlockPriority_InputPort(
+    Ports::InputTypedPort* get_typedAsyncBlockPriority_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncDropPriority[portNum]
-    InputTypedPort* get_typedAsyncDropPriority_InputPort(
+    Ports::InputTypedPort* get_typedAsyncDropPriority_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedGuarded[portNum]
-    InputTypedPort* get_typedGuarded_InputPort(
+    Ports::InputTypedPort* get_typedGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnGuarded[portNum]
-    InputTypedReturnPort* get_typedReturnGuarded_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnSync[portNum]
-    InputTypedReturnPort* get_typedReturnSync_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedSync[portNum]
-    InputTypedPort* get_typedSync_InputPort(
+    Ports::InputTypedPort* get_typedSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -297,13 +297,13 @@ class ActiveTelemetryComponentBase :
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnOut[portNum]
     void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
 #if FW_PORT_SERIALIZATION
@@ -663,7 +663,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -675,7 +675,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -687,7 +687,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -699,7 +699,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -711,7 +711,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -723,7 +723,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -735,7 +735,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -747,7 +747,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -792,7 +792,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -804,7 +804,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -816,7 +816,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -828,7 +828,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -840,7 +840,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -852,7 +852,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -864,7 +864,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -876,7 +876,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -903,7 +903,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -915,7 +915,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -927,7 +927,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -939,7 +939,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -957,7 +957,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -969,7 +969,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1162,7 +1162,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1175,7 +1175,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1188,7 +1188,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1201,7 +1201,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1214,7 +1214,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1227,7 +1227,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1240,7 +1240,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1253,7 +1253,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1275,43 +1275,43 @@ class ActiveTelemetryComponentBase :
     // ----------------------------------------------------------------------
 
     //! Input port noArgsAsync
-    InputNoArgsPort m_noArgsAsync_InputPort[NUM_NOARGSASYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsAsync_InputPort[NUM_NOARGSASYNC_INPUT_PORTS];
 
     //! Input port noArgsGuarded
-    InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnGuarded
-    InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnSync
-    InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
 
     //! Input port noArgsSync
-    InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedAsync
-    InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];
 
     //! Input port typedAsyncAssert
-    InputTypedPort m_typedAsyncAssert_InputPort[NUM_TYPEDASYNCASSERT_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncAssert_InputPort[NUM_TYPEDASYNCASSERT_INPUT_PORTS];
 
     //! Input port typedAsyncBlockPriority
-    InputTypedPort m_typedAsyncBlockPriority_InputPort[NUM_TYPEDASYNCBLOCKPRIORITY_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncBlockPriority_InputPort[NUM_TYPEDASYNCBLOCKPRIORITY_INPUT_PORTS];
 
     //! Input port typedAsyncDropPriority
-    InputTypedPort m_typedAsyncDropPriority_InputPort[NUM_TYPEDASYNCDROPPRIORITY_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncDropPriority_InputPort[NUM_TYPEDASYNCDROPPRIORITY_INPUT_PORTS];
 
     //! Input port typedGuarded
-    InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
+    Ports::InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnGuarded
-    InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnSync
-    InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
 
     //! Input port typedSync
-    InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
 
   PRIVATE:
 
@@ -1354,10 +1354,10 @@ class ActiveTelemetryComponentBase :
     // ----------------------------------------------------------------------
 
     //! Output port typedOut
-    OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
+    Ports::OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
 
     //! Output port typedReturnOut
-    OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
+    Ports::OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
 
   PRIVATE:
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
@@ -37,19 +37,19 @@ namespace M {
 
     // Get the max size by doing a union of the input and internal port serialization sizes
     union BuffUnion {
-      BYTE noArgsAsyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-      BYTE noArgsGuardedPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-      BYTE noArgsReturnGuardedPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-      BYTE noArgsReturnSyncPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-      BYTE noArgsSyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-      BYTE typedAsyncPortSize[InputTypedPort::SERIALIZED_SIZE];
-      BYTE typedAsyncAssertPortSize[InputTypedPort::SERIALIZED_SIZE];
-      BYTE typedAsyncBlockPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
-      BYTE typedAsyncDropPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
-      BYTE typedGuardedPortSize[InputTypedPort::SERIALIZED_SIZE];
-      BYTE typedReturnGuardedPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-      BYTE typedReturnSyncPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-      BYTE typedSyncPortSize[InputTypedPort::SERIALIZED_SIZE];
+      BYTE noArgsAsyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+      BYTE noArgsGuardedPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+      BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+      BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+      BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+      BYTE typedAsyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+      BYTE typedAsyncAssertPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+      BYTE typedAsyncBlockPriorityPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+      BYTE typedAsyncDropPriorityPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+      BYTE typedGuardedPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+      BYTE typedReturnGuardedPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+      BYTE typedReturnSyncPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+      BYTE typedSyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
       BYTE cmdPortSize[Fw::InputCmdPort::SERIALIZED_SIZE];
       // Size of internalArray argument list
       BYTE internalArrayIntIfSize[
@@ -731,7 +731,7 @@ namespace M {
   // Getters for typed input ports
   // ----------------------------------------------------------------------
 
-  InputNoArgsPort* ActiveTestComponentBase ::
+  Ports::InputNoArgsPort* ActiveTestComponentBase ::
     get_noArgsAsync_InputPort(NATIVE_INT_TYPE portNum)
   {
     FW_ASSERT(
@@ -742,7 +742,7 @@ namespace M {
     return &this->m_noArgsAsync_InputPort[portNum];
   }
 
-  InputNoArgsPort* ActiveTestComponentBase ::
+  Ports::InputNoArgsPort* ActiveTestComponentBase ::
     get_noArgsGuarded_InputPort(NATIVE_INT_TYPE portNum)
   {
     FW_ASSERT(
@@ -753,7 +753,7 @@ namespace M {
     return &this->m_noArgsGuarded_InputPort[portNum];
   }
 
-  InputNoArgsReturnPort* ActiveTestComponentBase ::
+  Ports::InputNoArgsReturnPort* ActiveTestComponentBase ::
     get_noArgsReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
   {
     FW_ASSERT(
@@ -764,7 +764,7 @@ namespace M {
     return &this->m_noArgsReturnGuarded_InputPort[portNum];
   }
 
-  InputNoArgsReturnPort* ActiveTestComponentBase ::
+  Ports::InputNoArgsReturnPort* ActiveTestComponentBase ::
     get_noArgsReturnSync_InputPort(NATIVE_INT_TYPE portNum)
   {
     FW_ASSERT(
@@ -775,7 +775,7 @@ namespace M {
     return &this->m_noArgsReturnSync_InputPort[portNum];
   }
 
-  InputNoArgsPort* ActiveTestComponentBase ::
+  Ports::InputNoArgsPort* ActiveTestComponentBase ::
     get_noArgsSync_InputPort(NATIVE_INT_TYPE portNum)
   {
     FW_ASSERT(
@@ -786,7 +786,7 @@ namespace M {
     return &this->m_noArgsSync_InputPort[portNum];
   }
 
-  InputTypedPort* ActiveTestComponentBase ::
+  Ports::InputTypedPort* ActiveTestComponentBase ::
     get_typedAsync_InputPort(NATIVE_INT_TYPE portNum)
   {
     FW_ASSERT(
@@ -797,7 +797,7 @@ namespace M {
     return &this->m_typedAsync_InputPort[portNum];
   }
 
-  InputTypedPort* ActiveTestComponentBase ::
+  Ports::InputTypedPort* ActiveTestComponentBase ::
     get_typedAsyncAssert_InputPort(NATIVE_INT_TYPE portNum)
   {
     FW_ASSERT(
@@ -808,7 +808,7 @@ namespace M {
     return &this->m_typedAsyncAssert_InputPort[portNum];
   }
 
-  InputTypedPort* ActiveTestComponentBase ::
+  Ports::InputTypedPort* ActiveTestComponentBase ::
     get_typedAsyncBlockPriority_InputPort(NATIVE_INT_TYPE portNum)
   {
     FW_ASSERT(
@@ -819,7 +819,7 @@ namespace M {
     return &this->m_typedAsyncBlockPriority_InputPort[portNum];
   }
 
-  InputTypedPort* ActiveTestComponentBase ::
+  Ports::InputTypedPort* ActiveTestComponentBase ::
     get_typedAsyncDropPriority_InputPort(NATIVE_INT_TYPE portNum)
   {
     FW_ASSERT(
@@ -830,7 +830,7 @@ namespace M {
     return &this->m_typedAsyncDropPriority_InputPort[portNum];
   }
 
-  InputTypedPort* ActiveTestComponentBase ::
+  Ports::InputTypedPort* ActiveTestComponentBase ::
     get_typedGuarded_InputPort(NATIVE_INT_TYPE portNum)
   {
     FW_ASSERT(
@@ -841,7 +841,7 @@ namespace M {
     return &this->m_typedGuarded_InputPort[portNum];
   }
 
-  InputTypedReturnPort* ActiveTestComponentBase ::
+  Ports::InputTypedReturnPort* ActiveTestComponentBase ::
     get_typedReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
   {
     FW_ASSERT(
@@ -852,7 +852,7 @@ namespace M {
     return &this->m_typedReturnGuarded_InputPort[portNum];
   }
 
-  InputTypedReturnPort* ActiveTestComponentBase ::
+  Ports::InputTypedReturnPort* ActiveTestComponentBase ::
     get_typedReturnSync_InputPort(NATIVE_INT_TYPE portNum)
   {
     FW_ASSERT(
@@ -863,7 +863,7 @@ namespace M {
     return &this->m_typedReturnSync_InputPort[portNum];
   }
 
-  InputTypedPort* ActiveTestComponentBase ::
+  Ports::InputTypedPort* ActiveTestComponentBase ::
     get_typedSync_InputPort(NATIVE_INT_TYPE portNum)
   {
     FW_ASSERT(
@@ -1001,7 +1001,7 @@ namespace M {
   void ActiveTestComponentBase ::
     set_typedOut_OutputPort(
         NATIVE_INT_TYPE portNum,
-        InputTypedPort* port
+        Ports::InputTypedPort* port
     )
   {
     FW_ASSERT(
@@ -1015,7 +1015,7 @@ namespace M {
   void ActiveTestComponentBase ::
     set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum,
-        InputTypedReturnPort* port
+        Ports::InputTypedReturnPort* port
     )
   {
     FW_ASSERT(
@@ -1902,7 +1902,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s
@@ -2009,7 +2009,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s
@@ -2116,7 +2116,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s
@@ -2223,7 +2223,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s
@@ -2335,7 +2335,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s
@@ -2372,7 +2372,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedReturnPortStrings::StringSize80& str2,
+        const Ports::TypedReturnPortStrings::StringSize80& str2,
         const E& e,
         const A& a,
         const S& s
@@ -2413,7 +2413,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedReturnPortStrings::StringSize80& str2,
+        const Ports::TypedReturnPortStrings::StringSize80& str2,
         const E& e,
         const A& a,
         const S& s
@@ -2448,7 +2448,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s
@@ -2493,7 +2493,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s
@@ -2508,7 +2508,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s
@@ -2523,7 +2523,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s
@@ -2538,7 +2538,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s
@@ -2557,7 +2557,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s
@@ -2584,7 +2584,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedReturnPortStrings::StringSize80& str2,
+        const Ports::TypedReturnPortStrings::StringSize80& str2,
         const E& e,
         const A& a,
         const S& s
@@ -5154,7 +5154,7 @@ namespace M {
         );
 
         // Deserialize argument str1
-        TypedPortStrings::StringSize80 str1;
+        Ports::TypedPortStrings::StringSize80 str1;
         deserStatus = msg.deserialize(str1);
         FW_ASSERT(
           deserStatus == Fw::FW_SERIALIZE_OK,
@@ -5226,7 +5226,7 @@ namespace M {
         );
 
         // Deserialize argument str1
-        TypedPortStrings::StringSize80 str1;
+        Ports::TypedPortStrings::StringSize80 str1;
         deserStatus = msg.deserialize(str1);
         FW_ASSERT(
           deserStatus == Fw::FW_SERIALIZE_OK,
@@ -5298,7 +5298,7 @@ namespace M {
         );
 
         // Deserialize argument str1
-        TypedPortStrings::StringSize80 str1;
+        Ports::TypedPortStrings::StringSize80 str1;
         deserStatus = msg.deserialize(str1);
         FW_ASSERT(
           deserStatus == Fw::FW_SERIALIZE_OK,
@@ -5370,7 +5370,7 @@ namespace M {
         );
 
         // Deserialize argument str1
-        TypedPortStrings::StringSize80 str1;
+        Ports::TypedPortStrings::StringSize80 str1;
         deserStatus = msg.deserialize(str1);
         FW_ASSERT(
           deserStatus == Fw::FW_SERIALIZE_OK,
@@ -6230,7 +6230,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s
@@ -6257,7 +6257,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s
@@ -6284,7 +6284,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s
@@ -6311,7 +6311,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s
@@ -6338,7 +6338,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s
@@ -6365,7 +6365,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedReturnPortStrings::StringSize80& str2,
+        const Ports::TypedReturnPortStrings::StringSize80& str2,
         const E& e,
         const A& a,
         const S& s
@@ -6392,7 +6392,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedReturnPortStrings::StringSize80& str2,
+        const Ports::TypedReturnPortStrings::StringSize80& str2,
         const E& e,
         const A& a,
         const S& s
@@ -6419,7 +6419,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.hpp
@@ -210,91 +210,91 @@ namespace M {
       //! Get typed input port at index
       //!
       //! \return noArgsAsync[portNum]
-      InputNoArgsPort* get_noArgsAsync_InputPort(
+      Ports::InputNoArgsPort* get_noArgsAsync_InputPort(
           NATIVE_INT_TYPE portNum //!< The port number
       );
 
       //! Get typed input port at index
       //!
       //! \return noArgsGuarded[portNum]
-      InputNoArgsPort* get_noArgsGuarded_InputPort(
+      Ports::InputNoArgsPort* get_noArgsGuarded_InputPort(
           NATIVE_INT_TYPE portNum //!< The port number
       );
 
       //! Get typed input port at index
       //!
       //! \return noArgsReturnGuarded[portNum]
-      InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
+      Ports::InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
           NATIVE_INT_TYPE portNum //!< The port number
       );
 
       //! Get typed input port at index
       //!
       //! \return noArgsReturnSync[portNum]
-      InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
+      Ports::InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
           NATIVE_INT_TYPE portNum //!< The port number
       );
 
       //! Get typed input port at index
       //!
       //! \return noArgsSync[portNum]
-      InputNoArgsPort* get_noArgsSync_InputPort(
+      Ports::InputNoArgsPort* get_noArgsSync_InputPort(
           NATIVE_INT_TYPE portNum //!< The port number
       );
 
       //! Get typed input port at index
       //!
       //! \return typedAsync[portNum]
-      InputTypedPort* get_typedAsync_InputPort(
+      Ports::InputTypedPort* get_typedAsync_InputPort(
           NATIVE_INT_TYPE portNum //!< The port number
       );
 
       //! Get typed input port at index
       //!
       //! \return typedAsyncAssert[portNum]
-      InputTypedPort* get_typedAsyncAssert_InputPort(
+      Ports::InputTypedPort* get_typedAsyncAssert_InputPort(
           NATIVE_INT_TYPE portNum //!< The port number
       );
 
       //! Get typed input port at index
       //!
       //! \return typedAsyncBlockPriority[portNum]
-      InputTypedPort* get_typedAsyncBlockPriority_InputPort(
+      Ports::InputTypedPort* get_typedAsyncBlockPriority_InputPort(
           NATIVE_INT_TYPE portNum //!< The port number
       );
 
       //! Get typed input port at index
       //!
       //! \return typedAsyncDropPriority[portNum]
-      InputTypedPort* get_typedAsyncDropPriority_InputPort(
+      Ports::InputTypedPort* get_typedAsyncDropPriority_InputPort(
           NATIVE_INT_TYPE portNum //!< The port number
       );
 
       //! Get typed input port at index
       //!
       //! \return typedGuarded[portNum]
-      InputTypedPort* get_typedGuarded_InputPort(
+      Ports::InputTypedPort* get_typedGuarded_InputPort(
           NATIVE_INT_TYPE portNum //!< The port number
       );
 
       //! Get typed input port at index
       //!
       //! \return typedReturnGuarded[portNum]
-      InputTypedReturnPort* get_typedReturnGuarded_InputPort(
+      Ports::InputTypedReturnPort* get_typedReturnGuarded_InputPort(
           NATIVE_INT_TYPE portNum //!< The port number
       );
 
       //! Get typed input port at index
       //!
       //! \return typedReturnSync[portNum]
-      InputTypedReturnPort* get_typedReturnSync_InputPort(
+      Ports::InputTypedReturnPort* get_typedReturnSync_InputPort(
           NATIVE_INT_TYPE portNum //!< The port number
       );
 
       //! Get typed input port at index
       //!
       //! \return typedSync[portNum]
-      InputTypedPort* get_typedSync_InputPort(
+      Ports::InputTypedPort* get_typedSync_InputPort(
           NATIVE_INT_TYPE portNum //!< The port number
       );
 
@@ -365,13 +365,13 @@ namespace M {
       //! Connect port to typedOut[portNum]
       void set_typedOut_OutputPort(
           NATIVE_INT_TYPE portNum, //!< The port number
-          InputTypedPort* port //!< The input port
+          Ports::InputTypedPort* port //!< The input port
       );
 
       //! Connect port to typedReturnOut[portNum]
       void set_typedReturnOut_OutputPort(
           NATIVE_INT_TYPE portNum, //!< The port number
-          InputTypedReturnPort* port //!< The input port
+          Ports::InputTypedReturnPort* port //!< The input port
       );
 
 #if FW_PORT_SERIALIZATION
@@ -753,7 +753,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -765,7 +765,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -777,7 +777,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -789,7 +789,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -801,7 +801,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -813,7 +813,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedReturnPortStrings::StringSize80& str2, //!< A string
+          const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -825,7 +825,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedReturnPortStrings::StringSize80& str2, //!< A string
+          const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -837,7 +837,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -882,7 +882,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -894,7 +894,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -906,7 +906,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -918,7 +918,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -930,7 +930,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -942,7 +942,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedReturnPortStrings::StringSize80& str2, //!< A string
+          const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -954,7 +954,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedReturnPortStrings::StringSize80& str2, //!< A string
+          const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -966,7 +966,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -993,7 +993,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -1005,7 +1005,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -1017,7 +1017,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -1029,7 +1029,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -1047,7 +1047,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -1059,7 +1059,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedReturnPortStrings::StringSize80& str2, //!< A string
+          const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -1852,7 +1852,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -1865,7 +1865,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -1878,7 +1878,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -1891,7 +1891,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -1904,7 +1904,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -1917,7 +1917,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedReturnPortStrings::StringSize80& str2, //!< A string
+          const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -1930,7 +1930,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedReturnPortStrings::StringSize80& str2, //!< A string
+          const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -1943,7 +1943,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -2049,43 +2049,43 @@ namespace M {
       // ----------------------------------------------------------------------
 
       //! Input port noArgsAsync
-      InputNoArgsPort m_noArgsAsync_InputPort[NUM_NOARGSASYNC_INPUT_PORTS];
+      Ports::InputNoArgsPort m_noArgsAsync_InputPort[NUM_NOARGSASYNC_INPUT_PORTS];
 
       //! Input port noArgsGuarded
-      InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
+      Ports::InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
 
       //! Input port noArgsReturnGuarded
-      InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
+      Ports::InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
 
       //! Input port noArgsReturnSync
-      InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
+      Ports::InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
 
       //! Input port noArgsSync
-      InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
+      Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
       //! Input port typedAsync
-      InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];
+      Ports::InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];
 
       //! Input port typedAsyncAssert
-      InputTypedPort m_typedAsyncAssert_InputPort[NUM_TYPEDASYNCASSERT_INPUT_PORTS];
+      Ports::InputTypedPort m_typedAsyncAssert_InputPort[NUM_TYPEDASYNCASSERT_INPUT_PORTS];
 
       //! Input port typedAsyncBlockPriority
-      InputTypedPort m_typedAsyncBlockPriority_InputPort[NUM_TYPEDASYNCBLOCKPRIORITY_INPUT_PORTS];
+      Ports::InputTypedPort m_typedAsyncBlockPriority_InputPort[NUM_TYPEDASYNCBLOCKPRIORITY_INPUT_PORTS];
 
       //! Input port typedAsyncDropPriority
-      InputTypedPort m_typedAsyncDropPriority_InputPort[NUM_TYPEDASYNCDROPPRIORITY_INPUT_PORTS];
+      Ports::InputTypedPort m_typedAsyncDropPriority_InputPort[NUM_TYPEDASYNCDROPPRIORITY_INPUT_PORTS];
 
       //! Input port typedGuarded
-      InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
+      Ports::InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
 
       //! Input port typedReturnGuarded
-      InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
+      Ports::InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
 
       //! Input port typedReturnSync
-      InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
+      Ports::InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
 
       //! Input port typedSync
-      InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
+      Ports::InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
 
     PRIVATE:
 
@@ -2128,10 +2128,10 @@ namespace M {
       // ----------------------------------------------------------------------
 
       //! Output port typedOut
-      OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
+      Ports::OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
 
       //! Output port typedReturnOut
-      OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
+      Ports::OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
 
     PRIVATE:
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/NoArgsPortAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/NoArgsPortAc.ref.cpp
@@ -8,151 +8,155 @@
 #include "Fw/Types/StringUtils.hpp"
 #include "base/NoArgsPortAc.hpp"
 
-namespace {
+namespace Ports {
+
+  namespace {
+
+    // ----------------------------------------------------------------------
+    // Port buffer class
+    // ----------------------------------------------------------------------
+
+    class NoArgsPortBuffer : public Fw::SerializeBufferBase {
+
+      public:
+
+        NATIVE_UINT_TYPE getBuffCapacity() const {
+          return InputNoArgsPort::SERIALIZED_SIZE;
+        }
+
+        U8* getBuffAddr() {
+          return nullptr;
+        }
+
+        const U8* getBuffAddr() const {
+          return nullptr;
+        }
+
+    };
+
+  }
 
   // ----------------------------------------------------------------------
-  // Port buffer class
+  // Input Port Member functions
   // ----------------------------------------------------------------------
 
-  class NoArgsPortBuffer : public Fw::SerializeBufferBase {
+  InputNoArgsPort ::
+    InputNoArgsPort() :
+      Fw::InputPortBase(),
+      m_func(nullptr)
+  {
 
-    public:
+  }
 
-      NATIVE_UINT_TYPE getBuffCapacity() const {
-        return InputNoArgsPort::SERIALIZED_SIZE;
-      }
+  void InputNoArgsPort ::
+    init()
+  {
+    Fw::InputPortBase::init();
+  }
 
-      U8* getBuffAddr() {
-        return nullptr;
-      }
+  void InputNoArgsPort ::
+    addCallComp(
+        Fw::PassiveComponentBase* callComp,
+        CompFuncPtr funcPtr
+    )
+  {
+    FW_ASSERT(callComp != nullptr);
+    FW_ASSERT(funcPtr != nullptr);
 
-      const U8* getBuffAddr() const {
-        return nullptr;
-      }
+    this->m_comp = callComp;
+    this->m_func = funcPtr;
+    this->m_connObj = callComp;
+  }
 
-  };
-
-}
-
-// ----------------------------------------------------------------------
-// Input Port Member functions
-// ----------------------------------------------------------------------
-
-InputNoArgsPort ::
-  InputNoArgsPort() :
-    Fw::InputPortBase(),
-    m_func(nullptr)
-{
-
-}
-
-void InputNoArgsPort ::
-  init()
-{
-  Fw::InputPortBase::init();
-}
-
-void InputNoArgsPort ::
-  addCallComp(
-      Fw::PassiveComponentBase* callComp,
-      CompFuncPtr funcPtr
-  )
-{
-  FW_ASSERT(callComp != nullptr);
-  FW_ASSERT(funcPtr != nullptr);
-
-  this->m_comp = callComp;
-  this->m_func = funcPtr;
-  this->m_connObj = callComp;
-}
-
-void InputNoArgsPort ::
-  invoke()
-{
+  void InputNoArgsPort ::
+    invoke()
+  {
 #if FW_PORT_TRACING == 1
-  this->trace();
+    this->trace();
 #endif
 
-  FW_ASSERT(this->m_comp != nullptr);
-  FW_ASSERT(this->m_func != nullptr);
+    FW_ASSERT(this->m_comp != nullptr);
+    FW_ASSERT(this->m_func != nullptr);
 
-  return this->m_func(this->m_comp, this->m_portNum);
-}
+    return this->m_func(this->m_comp, this->m_portNum);
+  }
 
 #if FW_PORT_SERIALIZATION == 1
 
-Fw::SerializeStatus InputNoArgsPort ::
-  invokeSerial(Fw::SerializeBufferBase& _buffer)
-{
-  (void) _buffer;
+  Fw::SerializeStatus InputNoArgsPort ::
+    invokeSerial(Fw::SerializeBufferBase& _buffer)
+  {
+    (void) _buffer;
 
 #if FW_PORT_TRACING == 1
-  this->trace();
+    this->trace();
 #endif
 
-  FW_ASSERT(this->m_comp != nullptr);
-  FW_ASSERT(this->m_func != nullptr);
+    FW_ASSERT(this->m_comp != nullptr);
+    FW_ASSERT(this->m_func != nullptr);
 
-  this->m_func(this->m_comp, this->m_portNum);
+    this->m_func(this->m_comp, this->m_portNum);
 
-  return Fw::FW_SERIALIZE_OK;
-}
+    return Fw::FW_SERIALIZE_OK;
+  }
 
 #endif
 
-// ----------------------------------------------------------------------
-// Output Port Member functions
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Output Port Member functions
+  // ----------------------------------------------------------------------
 
-OutputNoArgsPort ::
-  OutputNoArgsPort() :
-    Fw::OutputPortBase(),
-    m_port(nullptr)
-{
+  OutputNoArgsPort ::
+    OutputNoArgsPort() :
+      Fw::OutputPortBase(),
+      m_port(nullptr)
+  {
 
-}
+  }
 
-void OutputNoArgsPort ::
-  init()
-{
-  Fw::OutputPortBase::init();
-}
+  void OutputNoArgsPort ::
+    init()
+  {
+    Fw::OutputPortBase::init();
+  }
 
-void OutputNoArgsPort ::
-  addCallPort(InputNoArgsPort* callPort)
-{
-  FW_ASSERT(callPort != nullptr);
+  void OutputNoArgsPort ::
+    addCallPort(InputNoArgsPort* callPort)
+  {
+    FW_ASSERT(callPort != nullptr);
 
-  this->m_port = callPort;
-  this->m_connObj = callPort;
+    this->m_port = callPort;
+    this->m_connObj = callPort;
 
 #if FW_PORT_SERIALIZATION == 1
-  this->m_serPort = nullptr;
+    this->m_serPort = nullptr;
 #endif
-}
+  }
 
-void OutputNoArgsPort ::
-  invoke()
-{
+  void OutputNoArgsPort ::
+    invoke()
+  {
 #if FW_PORT_TRACING == 1
-  this->trace();
+    this->trace();
 #endif
 
 #if FW_PORT_SERIALIZATION
-  FW_ASSERT((this->m_port != nullptr) || (this->m_serPort != nullptr));
+    FW_ASSERT((this->m_port != nullptr) || (this->m_serPort != nullptr));
 
-  if (this->m_port != nullptr) {
-    this->m_port->invoke();
-  }
-  else {
-    Fw::SerializeStatus _status;
-    NoArgsPortBuffer _buffer;
+    if (this->m_port != nullptr) {
+      this->m_port->invoke();
+    }
+    else {
+      Fw::SerializeStatus _status;
+      NoArgsPortBuffer _buffer;
 
-    _status = this->m_serPort->invokeSerial(_buffer);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-  }
+      _status = this->m_serPort->invokeSerial(_buffer);
+      FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    }
 #else
-  FW_ASSERT(this->m_port != nullptr);
-  this->m_port->invoke();
+    FW_ASSERT(this->m_port != nullptr);
+    this->m_port->invoke();
 #endif
+  }
+
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/NoArgsPortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/NoArgsPortAc.ref.hpp
@@ -4,8 +4,8 @@
 // \brief  hpp file for NoArgs port
 // ======================================================================
 
-#ifndef NoArgsPortAc_HPP
-#define NoArgsPortAc_HPP
+#ifndef Ports_NoArgsPortAc_HPP
+#define Ports_NoArgsPortAc_HPP
 
 #include <cstdio>
 #include <cstring>
@@ -17,111 +17,115 @@
 #include "Fw/Types/Serializable.hpp"
 #include "Fw/Types/StringType.hpp"
 
-//! Input NoArgs port
-//! A typed port with no arguments
-class InputNoArgsPort :
-  public Fw::InputPortBase
-{
+namespace Ports {
 
-  public:
+  //! Input NoArgs port
+  //! A typed port with no arguments
+  class InputNoArgsPort :
+    public Fw::InputPortBase
+  {
 
-    // ----------------------------------------------------------------------
-    // Constants
-    // ----------------------------------------------------------------------
+    public:
 
-    enum {
-      //! The size of the serial representations of the port arguments
-      SERIALIZED_SIZE = 0
-    };
+      // ----------------------------------------------------------------------
+      // Constants
+      // ----------------------------------------------------------------------
 
-  public:
+      enum {
+        //! The size of the serial representations of the port arguments
+        SERIALIZED_SIZE = 0
+      };
 
-    // ----------------------------------------------------------------------
-    // Types
-    // ----------------------------------------------------------------------
+    public:
 
-    //! The port callback function type
-    typedef void (*CompFuncPtr)(
-      Fw::PassiveComponentBase* callComp,
-      NATIVE_INT_TYPE portNum
-    );
+      // ----------------------------------------------------------------------
+      // Types
+      // ----------------------------------------------------------------------
 
-  public:
+      //! The port callback function type
+      typedef void (*CompFuncPtr)(
+        Fw::PassiveComponentBase* callComp,
+        NATIVE_INT_TYPE portNum
+      );
 
-    // ----------------------------------------------------------------------
-    // Input Port Member functions
-    // ----------------------------------------------------------------------
+    public:
 
-    //! Constructor
-    InputNoArgsPort();
+      // ----------------------------------------------------------------------
+      // Input Port Member functions
+      // ----------------------------------------------------------------------
 
-    //! Initialization function
-    void init();
+      //! Constructor
+      InputNoArgsPort();
 
-    //! Register a component
-    void addCallComp(
-        Fw::PassiveComponentBase* callComp, //!< The containing component
-        CompFuncPtr funcPtr //!< The port callback function
-    );
+      //! Initialization function
+      void init();
 
-    //! Invoke a port interface
-    void invoke();
+      //! Register a component
+      void addCallComp(
+          Fw::PassiveComponentBase* callComp, //!< The containing component
+          CompFuncPtr funcPtr //!< The port callback function
+      );
 
-  private:
+      //! Invoke a port interface
+      void invoke();
+
+    private:
 
 #if FW_PORT_SERIALIZATION == 1
 
-    //! Invoke the port with serialized arguments
-    Fw::SerializeStatus invokeSerial(Fw::SerializeBufferBase& _buffer);
+      //! Invoke the port with serialized arguments
+      Fw::SerializeStatus invokeSerial(Fw::SerializeBufferBase& _buffer);
 
 #endif
 
-  private:
+    private:
 
-    // ----------------------------------------------------------------------
-    // Member variables
-    // ----------------------------------------------------------------------
+      // ----------------------------------------------------------------------
+      // Member variables
+      // ----------------------------------------------------------------------
 
-    //! The pointer to the port callback function
-    CompFuncPtr m_func;
+      //! The pointer to the port callback function
+      CompFuncPtr m_func;
 
-};
+  };
 
-//! Output NoArgs port
-//! A typed port with no arguments
-class OutputNoArgsPort :
-  public Fw::OutputPortBase
-{
+  //! Output NoArgs port
+  //! A typed port with no arguments
+  class OutputNoArgsPort :
+    public Fw::OutputPortBase
+  {
 
-  public:
+    public:
 
-    // ----------------------------------------------------------------------
-    // Output Port Member functions
-    // ----------------------------------------------------------------------
+      // ----------------------------------------------------------------------
+      // Output Port Member functions
+      // ----------------------------------------------------------------------
 
-    //! Constructor
-    OutputNoArgsPort();
+      //! Constructor
+      OutputNoArgsPort();
 
-    //! Initialization function
-    void init();
+      //! Initialization function
+      void init();
 
-    //! Register an input port
-    void addCallPort(
-        InputNoArgsPort* callPort //!< The input port
-    );
+      //! Register an input port
+      void addCallPort(
+          InputNoArgsPort* callPort //!< The input port
+      );
 
-    //! Invoke a port interface
-    void invoke();
+      //! Invoke a port interface
+      void invoke();
 
-  private:
+    private:
 
-    // ----------------------------------------------------------------------
-    // Member variables
-    // ----------------------------------------------------------------------
+      // ----------------------------------------------------------------------
+      // Member variables
+      // ----------------------------------------------------------------------
 
-    //! The pointer to the input port
-    InputNoArgsPort* m_port;
+      //! The pointer to the input port
+      InputNoArgsPort* m_port;
 
-};
+  };
+
+}
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/component/base/NoArgsReturnPortAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/NoArgsReturnPortAc.ref.cpp
@@ -8,103 +8,107 @@
 #include "Fw/Types/StringUtils.hpp"
 #include "base/NoArgsReturnPortAc.hpp"
 
-// ----------------------------------------------------------------------
-// Input Port Member functions
-// ----------------------------------------------------------------------
+namespace Ports {
 
-InputNoArgsReturnPort ::
-  InputNoArgsReturnPort() :
-    Fw::InputPortBase(),
-    m_func(nullptr)
-{
+  // ----------------------------------------------------------------------
+  // Input Port Member functions
+  // ----------------------------------------------------------------------
 
-}
+  InputNoArgsReturnPort ::
+    InputNoArgsReturnPort() :
+      Fw::InputPortBase(),
+      m_func(nullptr)
+  {
 
-void InputNoArgsReturnPort ::
-  init()
-{
-  Fw::InputPortBase::init();
-}
+  }
 
-void InputNoArgsReturnPort ::
-  addCallComp(
-      Fw::PassiveComponentBase* callComp,
-      CompFuncPtr funcPtr
-  )
-{
-  FW_ASSERT(callComp != nullptr);
-  FW_ASSERT(funcPtr != nullptr);
+  void InputNoArgsReturnPort ::
+    init()
+  {
+    Fw::InputPortBase::init();
+  }
 
-  this->m_comp = callComp;
-  this->m_func = funcPtr;
-  this->m_connObj = callComp;
-}
+  void InputNoArgsReturnPort ::
+    addCallComp(
+        Fw::PassiveComponentBase* callComp,
+        CompFuncPtr funcPtr
+    )
+  {
+    FW_ASSERT(callComp != nullptr);
+    FW_ASSERT(funcPtr != nullptr);
 
-U32 InputNoArgsReturnPort ::
-  invoke()
-{
+    this->m_comp = callComp;
+    this->m_func = funcPtr;
+    this->m_connObj = callComp;
+  }
+
+  U32 InputNoArgsReturnPort ::
+    invoke()
+  {
 #if FW_PORT_TRACING == 1
-  this->trace();
+    this->trace();
 #endif
 
-  FW_ASSERT(this->m_comp != nullptr);
-  FW_ASSERT(this->m_func != nullptr);
+    FW_ASSERT(this->m_comp != nullptr);
+    FW_ASSERT(this->m_func != nullptr);
 
-  return this->m_func(this->m_comp, this->m_portNum);
-}
+    return this->m_func(this->m_comp, this->m_portNum);
+  }
 
 #if FW_PORT_SERIALIZATION == 1
 
-Fw::SerializeStatus InputNoArgsReturnPort ::
-  invokeSerial(Fw::SerializeBufferBase& _buffer)
-{
-  // For ports with a return type, invokeSerial is not used
-  (void) _buffer;
+  Fw::SerializeStatus InputNoArgsReturnPort ::
+    invokeSerial(Fw::SerializeBufferBase& _buffer)
+  {
+    // For ports with a return type, invokeSerial is not used
+    (void) _buffer;
 
-  FW_ASSERT(0);
-  return Fw::FW_SERIALIZE_OK;
-}
+    FW_ASSERT(0);
+    return Fw::FW_SERIALIZE_OK;
+  }
 
 #endif
 
-// ----------------------------------------------------------------------
-// Output Port Member functions
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Output Port Member functions
+  // ----------------------------------------------------------------------
 
-OutputNoArgsReturnPort ::
-  OutputNoArgsReturnPort() :
-    Fw::OutputPortBase(),
-    m_port(nullptr)
-{
+  OutputNoArgsReturnPort ::
+    OutputNoArgsReturnPort() :
+      Fw::OutputPortBase(),
+      m_port(nullptr)
+  {
 
-}
+  }
 
-void OutputNoArgsReturnPort ::
-  init()
-{
-  Fw::OutputPortBase::init();
-}
+  void OutputNoArgsReturnPort ::
+    init()
+  {
+    Fw::OutputPortBase::init();
+  }
 
-void OutputNoArgsReturnPort ::
-  addCallPort(InputNoArgsReturnPort* callPort)
-{
-  FW_ASSERT(callPort != nullptr);
+  void OutputNoArgsReturnPort ::
+    addCallPort(InputNoArgsReturnPort* callPort)
+  {
+    FW_ASSERT(callPort != nullptr);
 
-  this->m_port = callPort;
-  this->m_connObj = callPort;
+    this->m_port = callPort;
+    this->m_connObj = callPort;
 
 #if FW_PORT_SERIALIZATION == 1
-  this->m_serPort = nullptr;
+    this->m_serPort = nullptr;
 #endif
-}
+  }
 
-U32 OutputNoArgsReturnPort ::
-  invoke()
-{
+  U32 OutputNoArgsReturnPort ::
+    invoke()
+  {
 #if FW_PORT_TRACING == 1
-  this->trace();
+    this->trace();
 #endif
 
-  FW_ASSERT(this->m_port != nullptr);
-  return this->m_port->invoke();
+    FW_ASSERT(this->m_port != nullptr);
+    return this->m_port->invoke();
+  }
+
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/NoArgsReturnPortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/NoArgsReturnPortAc.ref.hpp
@@ -4,8 +4,8 @@
 // \brief  hpp file for NoArgsReturn port
 // ======================================================================
 
-#ifndef NoArgsReturnPortAc_HPP
-#define NoArgsReturnPortAc_HPP
+#ifndef Ports_NoArgsReturnPortAc_HPP
+#define Ports_NoArgsReturnPortAc_HPP
 
 #include <cstdio>
 #include <cstring>
@@ -16,111 +16,115 @@
 #include "Fw/Port/OutputPortBase.hpp"
 #include "Fw/Types/StringType.hpp"
 
-//! Input NoArgsReturn port
-//! A type port with no arguments and a return type
-class InputNoArgsReturnPort :
-  public Fw::InputPortBase
-{
+namespace Ports {
 
-  public:
+  //! Input NoArgsReturn port
+  //! A type port with no arguments and a return type
+  class InputNoArgsReturnPort :
+    public Fw::InputPortBase
+  {
 
-    // ----------------------------------------------------------------------
-    // Constants
-    // ----------------------------------------------------------------------
+    public:
 
-    enum {
-      //! The size of the serial representations of the port arguments
-      SERIALIZED_SIZE = 0
-    };
+      // ----------------------------------------------------------------------
+      // Constants
+      // ----------------------------------------------------------------------
 
-  public:
+      enum {
+        //! The size of the serial representations of the port arguments
+        SERIALIZED_SIZE = 0
+      };
 
-    // ----------------------------------------------------------------------
-    // Types
-    // ----------------------------------------------------------------------
+    public:
 
-    //! The port callback function type
-    typedef U32 (*CompFuncPtr)(
-      Fw::PassiveComponentBase* callComp,
-      NATIVE_INT_TYPE portNum
-    );
+      // ----------------------------------------------------------------------
+      // Types
+      // ----------------------------------------------------------------------
 
-  public:
+      //! The port callback function type
+      typedef U32 (*CompFuncPtr)(
+        Fw::PassiveComponentBase* callComp,
+        NATIVE_INT_TYPE portNum
+      );
 
-    // ----------------------------------------------------------------------
-    // Input Port Member functions
-    // ----------------------------------------------------------------------
+    public:
 
-    //! Constructor
-    InputNoArgsReturnPort();
+      // ----------------------------------------------------------------------
+      // Input Port Member functions
+      // ----------------------------------------------------------------------
 
-    //! Initialization function
-    void init();
+      //! Constructor
+      InputNoArgsReturnPort();
 
-    //! Register a component
-    void addCallComp(
-        Fw::PassiveComponentBase* callComp, //!< The containing component
-        CompFuncPtr funcPtr //!< The port callback function
-    );
+      //! Initialization function
+      void init();
 
-    //! Invoke a port interface
-    U32 invoke();
+      //! Register a component
+      void addCallComp(
+          Fw::PassiveComponentBase* callComp, //!< The containing component
+          CompFuncPtr funcPtr //!< The port callback function
+      );
 
-  private:
+      //! Invoke a port interface
+      U32 invoke();
+
+    private:
 
 #if FW_PORT_SERIALIZATION == 1
 
-    //! Invoke the port with serialized arguments
-    Fw::SerializeStatus invokeSerial(Fw::SerializeBufferBase& _buffer);
+      //! Invoke the port with serialized arguments
+      Fw::SerializeStatus invokeSerial(Fw::SerializeBufferBase& _buffer);
 
 #endif
 
-  private:
+    private:
 
-    // ----------------------------------------------------------------------
-    // Member variables
-    // ----------------------------------------------------------------------
+      // ----------------------------------------------------------------------
+      // Member variables
+      // ----------------------------------------------------------------------
 
-    //! The pointer to the port callback function
-    CompFuncPtr m_func;
+      //! The pointer to the port callback function
+      CompFuncPtr m_func;
 
-};
+  };
 
-//! Output NoArgsReturn port
-//! A type port with no arguments and a return type
-class OutputNoArgsReturnPort :
-  public Fw::OutputPortBase
-{
+  //! Output NoArgsReturn port
+  //! A type port with no arguments and a return type
+  class OutputNoArgsReturnPort :
+    public Fw::OutputPortBase
+  {
 
-  public:
+    public:
 
-    // ----------------------------------------------------------------------
-    // Output Port Member functions
-    // ----------------------------------------------------------------------
+      // ----------------------------------------------------------------------
+      // Output Port Member functions
+      // ----------------------------------------------------------------------
 
-    //! Constructor
-    OutputNoArgsReturnPort();
+      //! Constructor
+      OutputNoArgsReturnPort();
 
-    //! Initialization function
-    void init();
+      //! Initialization function
+      void init();
 
-    //! Register an input port
-    void addCallPort(
-        InputNoArgsReturnPort* callPort //!< The input port
-    );
+      //! Register an input port
+      void addCallPort(
+          InputNoArgsReturnPort* callPort //!< The input port
+      );
 
-    //! Invoke a port interface
-    U32 invoke();
+      //! Invoke a port interface
+      U32 invoke();
 
-  private:
+    private:
 
-    // ----------------------------------------------------------------------
-    // Member variables
-    // ----------------------------------------------------------------------
+      // ----------------------------------------------------------------------
+      // Member variables
+      // ----------------------------------------------------------------------
 
-    //! The pointer to the input port
-    InputNoArgsReturnPort* m_port;
+      //! The pointer to the input port
+      InputNoArgsReturnPort* m_port;
 
-};
+  };
+
+}
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveCommandsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveCommandsComponentAc.ref.cpp
@@ -15,14 +15,14 @@
 namespace {
   // Get the max size by doing a union of the input and internal port serialization sizes
   union BuffUnion {
-    BYTE noArgsGuardedPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnGuardedPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnSyncPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsSyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE typedGuardedPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedReturnGuardedPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedReturnSyncPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedSyncPortSize[InputTypedPort::SERIALIZED_SIZE];
+    BYTE noArgsGuardedPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE typedGuardedPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedReturnGuardedPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedReturnSyncPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedSyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
     BYTE cmdPortSize[Fw::InputCmdPort::SERIALIZED_SIZE];
   };
 
@@ -537,7 +537,7 @@ Fw::InputCmdPort* PassiveCommandsComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-InputNoArgsPort* PassiveCommandsComponentBase ::
+Ports::InputNoArgsPort* PassiveCommandsComponentBase ::
   get_noArgsGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -548,7 +548,7 @@ InputNoArgsPort* PassiveCommandsComponentBase ::
   return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* PassiveCommandsComponentBase ::
+Ports::InputNoArgsReturnPort* PassiveCommandsComponentBase ::
   get_noArgsReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -559,7 +559,7 @@ InputNoArgsReturnPort* PassiveCommandsComponentBase ::
   return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* PassiveCommandsComponentBase ::
+Ports::InputNoArgsReturnPort* PassiveCommandsComponentBase ::
   get_noArgsReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -570,7 +570,7 @@ InputNoArgsReturnPort* PassiveCommandsComponentBase ::
   return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-InputNoArgsPort* PassiveCommandsComponentBase ::
+Ports::InputNoArgsPort* PassiveCommandsComponentBase ::
   get_noArgsSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -581,7 +581,7 @@ InputNoArgsPort* PassiveCommandsComponentBase ::
   return &this->m_noArgsSync_InputPort[portNum];
 }
 
-InputTypedPort* PassiveCommandsComponentBase ::
+Ports::InputTypedPort* PassiveCommandsComponentBase ::
   get_typedGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -592,7 +592,7 @@ InputTypedPort* PassiveCommandsComponentBase ::
   return &this->m_typedGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* PassiveCommandsComponentBase ::
+Ports::InputTypedReturnPort* PassiveCommandsComponentBase ::
   get_typedReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -603,7 +603,7 @@ InputTypedReturnPort* PassiveCommandsComponentBase ::
   return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* PassiveCommandsComponentBase ::
+Ports::InputTypedReturnPort* PassiveCommandsComponentBase ::
   get_typedReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -614,7 +614,7 @@ InputTypedReturnPort* PassiveCommandsComponentBase ::
   return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-InputTypedPort* PassiveCommandsComponentBase ::
+Ports::InputTypedPort* PassiveCommandsComponentBase ::
   get_typedSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -752,7 +752,7 @@ void PassiveCommandsComponentBase ::
 void PassiveCommandsComponentBase ::
   set_typedOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -766,7 +766,7 @@ void PassiveCommandsComponentBase ::
 void PassiveCommandsComponentBase ::
   set_typedReturnOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -1324,7 +1324,7 @@ void PassiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1361,7 +1361,7 @@ F32 PassiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1402,7 +1402,7 @@ F32 PassiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1437,7 +1437,7 @@ void PassiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1472,7 +1472,7 @@ void PassiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1499,7 +1499,7 @@ F32 PassiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2391,7 +2391,7 @@ void PassiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2418,7 +2418,7 @@ F32 PassiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2445,7 +2445,7 @@ F32 PassiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2472,7 +2472,7 @@ void PassiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveCommandsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveCommandsComponentAc.ref.hpp
@@ -137,56 +137,56 @@ class PassiveCommandsComponentBase :
     //! Get typed input port at index
     //!
     //! \return noArgsGuarded[portNum]
-    InputNoArgsPort* get_noArgsGuarded_InputPort(
+    Ports::InputNoArgsPort* get_noArgsGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnGuarded[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnSync[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsSync[portNum]
-    InputNoArgsPort* get_noArgsSync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedGuarded[portNum]
-    InputTypedPort* get_typedGuarded_InputPort(
+    Ports::InputTypedPort* get_typedGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnGuarded[portNum]
-    InputTypedReturnPort* get_typedReturnGuarded_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnSync[portNum]
-    InputTypedReturnPort* get_typedReturnSync_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedSync[portNum]
-    InputTypedPort* get_typedSync_InputPort(
+    Ports::InputTypedPort* get_typedSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -257,13 +257,13 @@ class PassiveCommandsComponentBase :
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnOut[portNum]
     void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
 #if FW_PORT_SERIALIZATION
@@ -604,7 +604,7 @@ class PassiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -616,7 +616,7 @@ class PassiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -628,7 +628,7 @@ class PassiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -640,7 +640,7 @@ class PassiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -680,7 +680,7 @@ class PassiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -692,7 +692,7 @@ class PassiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -704,7 +704,7 @@ class PassiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -716,7 +716,7 @@ class PassiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -734,7 +734,7 @@ class PassiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -746,7 +746,7 @@ class PassiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1077,7 +1077,7 @@ class PassiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1090,7 +1090,7 @@ class PassiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1103,7 +1103,7 @@ class PassiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1116,7 +1116,7 @@ class PassiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1138,28 +1138,28 @@ class PassiveCommandsComponentBase :
     // ----------------------------------------------------------------------
 
     //! Input port noArgsGuarded
-    InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnGuarded
-    InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnSync
-    InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
 
     //! Input port noArgsSync
-    InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedGuarded
-    InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
+    Ports::InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnGuarded
-    InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnSync
-    InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
 
     //! Input port typedSync
-    InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
 
   PRIVATE:
 
@@ -1202,10 +1202,10 @@ class PassiveCommandsComponentBase :
     // ----------------------------------------------------------------------
 
     //! Output port typedOut
-    OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
+    Ports::OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
 
     //! Output port typedReturnOut
-    OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
+    Ports::OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
 
   PRIVATE:
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveEventsComponentAc.ref.cpp
@@ -15,14 +15,14 @@
 namespace {
   // Get the max size by doing a union of the input and internal port serialization sizes
   union BuffUnion {
-    BYTE noArgsGuardedPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnGuardedPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnSyncPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsSyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE typedGuardedPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedReturnGuardedPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedReturnSyncPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedSyncPortSize[InputTypedPort::SERIALIZED_SIZE];
+    BYTE noArgsGuardedPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE typedGuardedPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedReturnGuardedPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedReturnSyncPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedSyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
     BYTE cmdPortSize[Fw::InputCmdPort::SERIALIZED_SIZE];
   };
 
@@ -537,7 +537,7 @@ Fw::InputCmdPort* PassiveEventsComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-InputNoArgsPort* PassiveEventsComponentBase ::
+Ports::InputNoArgsPort* PassiveEventsComponentBase ::
   get_noArgsGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -548,7 +548,7 @@ InputNoArgsPort* PassiveEventsComponentBase ::
   return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* PassiveEventsComponentBase ::
+Ports::InputNoArgsReturnPort* PassiveEventsComponentBase ::
   get_noArgsReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -559,7 +559,7 @@ InputNoArgsReturnPort* PassiveEventsComponentBase ::
   return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* PassiveEventsComponentBase ::
+Ports::InputNoArgsReturnPort* PassiveEventsComponentBase ::
   get_noArgsReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -570,7 +570,7 @@ InputNoArgsReturnPort* PassiveEventsComponentBase ::
   return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-InputNoArgsPort* PassiveEventsComponentBase ::
+Ports::InputNoArgsPort* PassiveEventsComponentBase ::
   get_noArgsSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -581,7 +581,7 @@ InputNoArgsPort* PassiveEventsComponentBase ::
   return &this->m_noArgsSync_InputPort[portNum];
 }
 
-InputTypedPort* PassiveEventsComponentBase ::
+Ports::InputTypedPort* PassiveEventsComponentBase ::
   get_typedGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -592,7 +592,7 @@ InputTypedPort* PassiveEventsComponentBase ::
   return &this->m_typedGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* PassiveEventsComponentBase ::
+Ports::InputTypedReturnPort* PassiveEventsComponentBase ::
   get_typedReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -603,7 +603,7 @@ InputTypedReturnPort* PassiveEventsComponentBase ::
   return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* PassiveEventsComponentBase ::
+Ports::InputTypedReturnPort* PassiveEventsComponentBase ::
   get_typedReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -614,7 +614,7 @@ InputTypedReturnPort* PassiveEventsComponentBase ::
   return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-InputTypedPort* PassiveEventsComponentBase ::
+Ports::InputTypedPort* PassiveEventsComponentBase ::
   get_typedSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -752,7 +752,7 @@ void PassiveEventsComponentBase ::
 void PassiveEventsComponentBase ::
   set_typedOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -766,7 +766,7 @@ void PassiveEventsComponentBase ::
 void PassiveEventsComponentBase ::
   set_typedReturnOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -1268,7 +1268,7 @@ void PassiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1305,7 +1305,7 @@ F32 PassiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1346,7 +1346,7 @@ F32 PassiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1381,7 +1381,7 @@ void PassiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1416,7 +1416,7 @@ void PassiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1443,7 +1443,7 @@ F32 PassiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2269,7 +2269,7 @@ void PassiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2296,7 +2296,7 @@ F32 PassiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2323,7 +2323,7 @@ F32 PassiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2350,7 +2350,7 @@ void PassiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveEventsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveEventsComponentAc.ref.hpp
@@ -139,56 +139,56 @@ class PassiveEventsComponentBase :
     //! Get typed input port at index
     //!
     //! \return noArgsGuarded[portNum]
-    InputNoArgsPort* get_noArgsGuarded_InputPort(
+    Ports::InputNoArgsPort* get_noArgsGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnGuarded[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnSync[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsSync[portNum]
-    InputNoArgsPort* get_noArgsSync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedGuarded[portNum]
-    InputTypedPort* get_typedGuarded_InputPort(
+    Ports::InputTypedPort* get_typedGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnGuarded[portNum]
-    InputTypedReturnPort* get_typedReturnGuarded_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnSync[portNum]
-    InputTypedReturnPort* get_typedReturnSync_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedSync[portNum]
-    InputTypedPort* get_typedSync_InputPort(
+    Ports::InputTypedPort* get_typedSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -259,13 +259,13 @@ class PassiveEventsComponentBase :
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnOut[portNum]
     void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
 #if FW_PORT_SERIALIZATION
@@ -595,7 +595,7 @@ class PassiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -607,7 +607,7 @@ class PassiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -619,7 +619,7 @@ class PassiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -631,7 +631,7 @@ class PassiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -671,7 +671,7 @@ class PassiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -683,7 +683,7 @@ class PassiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -695,7 +695,7 @@ class PassiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -707,7 +707,7 @@ class PassiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -725,7 +725,7 @@ class PassiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -737,7 +737,7 @@ class PassiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -890,7 +890,7 @@ class PassiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -903,7 +903,7 @@ class PassiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -916,7 +916,7 @@ class PassiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -929,7 +929,7 @@ class PassiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -951,28 +951,28 @@ class PassiveEventsComponentBase :
     // ----------------------------------------------------------------------
 
     //! Input port noArgsGuarded
-    InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnGuarded
-    InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnSync
-    InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
 
     //! Input port noArgsSync
-    InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedGuarded
-    InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
+    Ports::InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnGuarded
-    InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnSync
-    InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
 
     //! Input port typedSync
-    InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
 
   PRIVATE:
 
@@ -1015,10 +1015,10 @@ class PassiveEventsComponentBase :
     // ----------------------------------------------------------------------
 
     //! Output port typedOut
-    OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
+    Ports::OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
 
     //! Output port typedReturnOut
-    OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
+    Ports::OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
 
   PRIVATE:
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveParamsComponentAc.ref.cpp
@@ -15,14 +15,14 @@
 namespace {
   // Get the max size by doing a union of the input and internal port serialization sizes
   union BuffUnion {
-    BYTE noArgsGuardedPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnGuardedPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnSyncPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsSyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE typedGuardedPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedReturnGuardedPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedReturnSyncPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedSyncPortSize[InputTypedPort::SERIALIZED_SIZE];
+    BYTE noArgsGuardedPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE typedGuardedPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedReturnGuardedPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedReturnSyncPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedSyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
     BYTE cmdPortSize[Fw::InputCmdPort::SERIALIZED_SIZE];
   };
 
@@ -537,7 +537,7 @@ Fw::InputCmdPort* PassiveParamsComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-InputNoArgsPort* PassiveParamsComponentBase ::
+Ports::InputNoArgsPort* PassiveParamsComponentBase ::
   get_noArgsGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -548,7 +548,7 @@ InputNoArgsPort* PassiveParamsComponentBase ::
   return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* PassiveParamsComponentBase ::
+Ports::InputNoArgsReturnPort* PassiveParamsComponentBase ::
   get_noArgsReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -559,7 +559,7 @@ InputNoArgsReturnPort* PassiveParamsComponentBase ::
   return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* PassiveParamsComponentBase ::
+Ports::InputNoArgsReturnPort* PassiveParamsComponentBase ::
   get_noArgsReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -570,7 +570,7 @@ InputNoArgsReturnPort* PassiveParamsComponentBase ::
   return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-InputNoArgsPort* PassiveParamsComponentBase ::
+Ports::InputNoArgsPort* PassiveParamsComponentBase ::
   get_noArgsSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -581,7 +581,7 @@ InputNoArgsPort* PassiveParamsComponentBase ::
   return &this->m_noArgsSync_InputPort[portNum];
 }
 
-InputTypedPort* PassiveParamsComponentBase ::
+Ports::InputTypedPort* PassiveParamsComponentBase ::
   get_typedGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -592,7 +592,7 @@ InputTypedPort* PassiveParamsComponentBase ::
   return &this->m_typedGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* PassiveParamsComponentBase ::
+Ports::InputTypedReturnPort* PassiveParamsComponentBase ::
   get_typedReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -603,7 +603,7 @@ InputTypedReturnPort* PassiveParamsComponentBase ::
   return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* PassiveParamsComponentBase ::
+Ports::InputTypedReturnPort* PassiveParamsComponentBase ::
   get_typedReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -614,7 +614,7 @@ InputTypedReturnPort* PassiveParamsComponentBase ::
   return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-InputTypedPort* PassiveParamsComponentBase ::
+Ports::InputTypedPort* PassiveParamsComponentBase ::
   get_typedSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -752,7 +752,7 @@ void PassiveParamsComponentBase ::
 void PassiveParamsComponentBase ::
   set_typedOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -766,7 +766,7 @@ void PassiveParamsComponentBase ::
 void PassiveParamsComponentBase ::
   set_typedReturnOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -1504,7 +1504,7 @@ void PassiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1541,7 +1541,7 @@ F32 PassiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1582,7 +1582,7 @@ F32 PassiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1617,7 +1617,7 @@ void PassiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1652,7 +1652,7 @@ void PassiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1679,7 +1679,7 @@ F32 PassiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2035,7 +2035,7 @@ void PassiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2062,7 +2062,7 @@ F32 PassiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2089,7 +2089,7 @@ F32 PassiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2116,7 +2116,7 @@ void PassiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveParamsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveParamsComponentAc.ref.hpp
@@ -149,56 +149,56 @@ class PassiveParamsComponentBase :
     //! Get typed input port at index
     //!
     //! \return noArgsGuarded[portNum]
-    InputNoArgsPort* get_noArgsGuarded_InputPort(
+    Ports::InputNoArgsPort* get_noArgsGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnGuarded[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnSync[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsSync[portNum]
-    InputNoArgsPort* get_noArgsSync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedGuarded[portNum]
-    InputTypedPort* get_typedGuarded_InputPort(
+    Ports::InputTypedPort* get_typedGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnGuarded[portNum]
-    InputTypedReturnPort* get_typedReturnGuarded_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnSync[portNum]
-    InputTypedReturnPort* get_typedReturnSync_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedSync[portNum]
-    InputTypedPort* get_typedSync_InputPort(
+    Ports::InputTypedPort* get_typedSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -269,13 +269,13 @@ class PassiveParamsComponentBase :
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnOut[portNum]
     void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
 #if FW_PORT_SERIALIZATION
@@ -627,7 +627,7 @@ class PassiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -639,7 +639,7 @@ class PassiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -651,7 +651,7 @@ class PassiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -663,7 +663,7 @@ class PassiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -703,7 +703,7 @@ class PassiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -715,7 +715,7 @@ class PassiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -727,7 +727,7 @@ class PassiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -739,7 +739,7 @@ class PassiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -757,7 +757,7 @@ class PassiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -769,7 +769,7 @@ class PassiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -949,7 +949,7 @@ class PassiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -962,7 +962,7 @@ class PassiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -975,7 +975,7 @@ class PassiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -988,7 +988,7 @@ class PassiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1094,28 +1094,28 @@ class PassiveParamsComponentBase :
     // ----------------------------------------------------------------------
 
     //! Input port noArgsGuarded
-    InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnGuarded
-    InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnSync
-    InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
 
     //! Input port noArgsSync
-    InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedGuarded
-    InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
+    Ports::InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnGuarded
-    InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnSync
-    InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
 
     //! Input port typedSync
-    InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
 
   PRIVATE:
 
@@ -1158,10 +1158,10 @@ class PassiveParamsComponentBase :
     // ----------------------------------------------------------------------
 
     //! Output port typedOut
-    OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
+    Ports::OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
 
     //! Output port typedReturnOut
-    OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
+    Ports::OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
 
   PRIVATE:
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.cpp
@@ -15,14 +15,14 @@
 namespace {
   // Get the max size by doing a union of the input and internal port serialization sizes
   union BuffUnion {
-    BYTE noArgsGuardedPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnGuardedPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnSyncPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsSyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE typedGuardedPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedReturnGuardedPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedReturnSyncPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedSyncPortSize[InputTypedPort::SERIALIZED_SIZE];
+    BYTE noArgsGuardedPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE typedGuardedPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedReturnGuardedPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedReturnSyncPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedSyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
     BYTE cmdPortSize[Fw::InputCmdPort::SERIALIZED_SIZE];
   };
 
@@ -610,7 +610,7 @@ Fw::InputCmdPort* PassiveSerialComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-InputNoArgsPort* PassiveSerialComponentBase ::
+Ports::InputNoArgsPort* PassiveSerialComponentBase ::
   get_noArgsGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -621,7 +621,7 @@ InputNoArgsPort* PassiveSerialComponentBase ::
   return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* PassiveSerialComponentBase ::
+Ports::InputNoArgsReturnPort* PassiveSerialComponentBase ::
   get_noArgsReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -632,7 +632,7 @@ InputNoArgsReturnPort* PassiveSerialComponentBase ::
   return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* PassiveSerialComponentBase ::
+Ports::InputNoArgsReturnPort* PassiveSerialComponentBase ::
   get_noArgsReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -643,7 +643,7 @@ InputNoArgsReturnPort* PassiveSerialComponentBase ::
   return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-InputNoArgsPort* PassiveSerialComponentBase ::
+Ports::InputNoArgsPort* PassiveSerialComponentBase ::
   get_noArgsSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -654,7 +654,7 @@ InputNoArgsPort* PassiveSerialComponentBase ::
   return &this->m_noArgsSync_InputPort[portNum];
 }
 
-InputTypedPort* PassiveSerialComponentBase ::
+Ports::InputTypedPort* PassiveSerialComponentBase ::
   get_typedGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -665,7 +665,7 @@ InputTypedPort* PassiveSerialComponentBase ::
   return &this->m_typedGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* PassiveSerialComponentBase ::
+Ports::InputTypedReturnPort* PassiveSerialComponentBase ::
   get_typedReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -676,7 +676,7 @@ InputTypedReturnPort* PassiveSerialComponentBase ::
   return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* PassiveSerialComponentBase ::
+Ports::InputTypedReturnPort* PassiveSerialComponentBase ::
   get_typedReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -687,7 +687,7 @@ InputTypedReturnPort* PassiveSerialComponentBase ::
   return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-InputTypedPort* PassiveSerialComponentBase ::
+Ports::InputTypedPort* PassiveSerialComponentBase ::
   get_typedSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -851,7 +851,7 @@ void PassiveSerialComponentBase ::
 void PassiveSerialComponentBase ::
   set_typedOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -865,7 +865,7 @@ void PassiveSerialComponentBase ::
 void PassiveSerialComponentBase ::
   set_typedReturnOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -1725,7 +1725,7 @@ void PassiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1762,7 +1762,7 @@ F32 PassiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1803,7 +1803,7 @@ F32 PassiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1838,7 +1838,7 @@ void PassiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1923,7 +1923,7 @@ void PassiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1950,7 +1950,7 @@ F32 PassiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -4159,7 +4159,7 @@ void PassiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -4186,7 +4186,7 @@ F32 PassiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -4213,7 +4213,7 @@ F32 PassiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -4240,7 +4240,7 @@ void PassiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.hpp
@@ -212,56 +212,56 @@ class PassiveSerialComponentBase :
     //! Get typed input port at index
     //!
     //! \return noArgsGuarded[portNum]
-    InputNoArgsPort* get_noArgsGuarded_InputPort(
+    Ports::InputNoArgsPort* get_noArgsGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnGuarded[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnSync[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsSync[portNum]
-    InputNoArgsPort* get_noArgsSync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedGuarded[portNum]
-    InputTypedPort* get_typedGuarded_InputPort(
+    Ports::InputTypedPort* get_typedGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnGuarded[portNum]
-    InputTypedReturnPort* get_typedReturnGuarded_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnSync[portNum]
-    InputTypedReturnPort* get_typedReturnSync_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedSync[portNum]
-    InputTypedPort* get_typedSync_InputPort(
+    Ports::InputTypedPort* get_typedSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -352,13 +352,13 @@ class PassiveSerialComponentBase :
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnOut[portNum]
     void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
 #if FW_PORT_SERIALIZATION
@@ -766,7 +766,7 @@ class PassiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -778,7 +778,7 @@ class PassiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -790,7 +790,7 @@ class PassiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -802,7 +802,7 @@ class PassiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -842,7 +842,7 @@ class PassiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -854,7 +854,7 @@ class PassiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -866,7 +866,7 @@ class PassiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -878,7 +878,7 @@ class PassiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -934,7 +934,7 @@ class PassiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -946,7 +946,7 @@ class PassiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1535,7 +1535,7 @@ class PassiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1548,7 +1548,7 @@ class PassiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1561,7 +1561,7 @@ class PassiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1574,7 +1574,7 @@ class PassiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1704,28 +1704,28 @@ class PassiveSerialComponentBase :
     // ----------------------------------------------------------------------
 
     //! Input port noArgsGuarded
-    InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnGuarded
-    InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnSync
-    InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
 
     //! Input port noArgsSync
-    InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedGuarded
-    InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
+    Ports::InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnGuarded
-    InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnSync
-    InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
 
     //! Input port typedSync
-    InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
 
   PRIVATE:
 
@@ -1780,10 +1780,10 @@ class PassiveSerialComponentBase :
     // ----------------------------------------------------------------------
 
     //! Output port typedOut
-    OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
+    Ports::OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
 
     //! Output port typedReturnOut
-    OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
+    Ports::OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
 
   PRIVATE:
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTelemetryComponentAc.ref.cpp
@@ -15,14 +15,14 @@
 namespace {
   // Get the max size by doing a union of the input and internal port serialization sizes
   union BuffUnion {
-    BYTE noArgsGuardedPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnGuardedPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnSyncPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsSyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE typedGuardedPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedReturnGuardedPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedReturnSyncPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedSyncPortSize[InputTypedPort::SERIALIZED_SIZE];
+    BYTE noArgsGuardedPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE typedGuardedPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedReturnGuardedPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedReturnSyncPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedSyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
     BYTE cmdPortSize[Fw::InputCmdPort::SERIALIZED_SIZE];
   };
 
@@ -537,7 +537,7 @@ Fw::InputCmdPort* PassiveTelemetryComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-InputNoArgsPort* PassiveTelemetryComponentBase ::
+Ports::InputNoArgsPort* PassiveTelemetryComponentBase ::
   get_noArgsGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -548,7 +548,7 @@ InputNoArgsPort* PassiveTelemetryComponentBase ::
   return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* PassiveTelemetryComponentBase ::
+Ports::InputNoArgsReturnPort* PassiveTelemetryComponentBase ::
   get_noArgsReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -559,7 +559,7 @@ InputNoArgsReturnPort* PassiveTelemetryComponentBase ::
   return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* PassiveTelemetryComponentBase ::
+Ports::InputNoArgsReturnPort* PassiveTelemetryComponentBase ::
   get_noArgsReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -570,7 +570,7 @@ InputNoArgsReturnPort* PassiveTelemetryComponentBase ::
   return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-InputNoArgsPort* PassiveTelemetryComponentBase ::
+Ports::InputNoArgsPort* PassiveTelemetryComponentBase ::
   get_noArgsSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -581,7 +581,7 @@ InputNoArgsPort* PassiveTelemetryComponentBase ::
   return &this->m_noArgsSync_InputPort[portNum];
 }
 
-InputTypedPort* PassiveTelemetryComponentBase ::
+Ports::InputTypedPort* PassiveTelemetryComponentBase ::
   get_typedGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -592,7 +592,7 @@ InputTypedPort* PassiveTelemetryComponentBase ::
   return &this->m_typedGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* PassiveTelemetryComponentBase ::
+Ports::InputTypedReturnPort* PassiveTelemetryComponentBase ::
   get_typedReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -603,7 +603,7 @@ InputTypedReturnPort* PassiveTelemetryComponentBase ::
   return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* PassiveTelemetryComponentBase ::
+Ports::InputTypedReturnPort* PassiveTelemetryComponentBase ::
   get_typedReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -614,7 +614,7 @@ InputTypedReturnPort* PassiveTelemetryComponentBase ::
   return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-InputTypedPort* PassiveTelemetryComponentBase ::
+Ports::InputTypedPort* PassiveTelemetryComponentBase ::
   get_typedSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -752,7 +752,7 @@ void PassiveTelemetryComponentBase ::
 void PassiveTelemetryComponentBase ::
   set_typedOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -766,7 +766,7 @@ void PassiveTelemetryComponentBase ::
 void PassiveTelemetryComponentBase ::
   set_typedReturnOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -1271,7 +1271,7 @@ void PassiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1308,7 +1308,7 @@ F32 PassiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1349,7 +1349,7 @@ F32 PassiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1384,7 +1384,7 @@ void PassiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1419,7 +1419,7 @@ void PassiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1446,7 +1446,7 @@ F32 PassiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1974,7 +1974,7 @@ void PassiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2001,7 +2001,7 @@ F32 PassiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2028,7 +2028,7 @@ F32 PassiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2055,7 +2055,7 @@ void PassiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTelemetryComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTelemetryComponentAc.ref.hpp
@@ -136,56 +136,56 @@ class PassiveTelemetryComponentBase :
     //! Get typed input port at index
     //!
     //! \return noArgsGuarded[portNum]
-    InputNoArgsPort* get_noArgsGuarded_InputPort(
+    Ports::InputNoArgsPort* get_noArgsGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnGuarded[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnSync[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsSync[portNum]
-    InputNoArgsPort* get_noArgsSync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedGuarded[portNum]
-    InputTypedPort* get_typedGuarded_InputPort(
+    Ports::InputTypedPort* get_typedGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnGuarded[portNum]
-    InputTypedReturnPort* get_typedReturnGuarded_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnSync[portNum]
-    InputTypedReturnPort* get_typedReturnSync_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedSync[portNum]
-    InputTypedPort* get_typedSync_InputPort(
+    Ports::InputTypedPort* get_typedSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -256,13 +256,13 @@ class PassiveTelemetryComponentBase :
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnOut[portNum]
     void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
 #if FW_PORT_SERIALIZATION
@@ -592,7 +592,7 @@ class PassiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -604,7 +604,7 @@ class PassiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -616,7 +616,7 @@ class PassiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -628,7 +628,7 @@ class PassiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -668,7 +668,7 @@ class PassiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -680,7 +680,7 @@ class PassiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -692,7 +692,7 @@ class PassiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -704,7 +704,7 @@ class PassiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -722,7 +722,7 @@ class PassiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -734,7 +734,7 @@ class PassiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -912,7 +912,7 @@ class PassiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -925,7 +925,7 @@ class PassiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -938,7 +938,7 @@ class PassiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -951,7 +951,7 @@ class PassiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -973,28 +973,28 @@ class PassiveTelemetryComponentBase :
     // ----------------------------------------------------------------------
 
     //! Input port noArgsGuarded
-    InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnGuarded
-    InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnSync
-    InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
 
     //! Input port noArgsSync
-    InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedGuarded
-    InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
+    Ports::InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnGuarded
-    InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnSync
-    InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
 
     //! Input port typedSync
-    InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
 
   PRIVATE:
 
@@ -1037,10 +1037,10 @@ class PassiveTelemetryComponentBase :
     // ----------------------------------------------------------------------
 
     //! Output port typedOut
-    OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
+    Ports::OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
 
     //! Output port typedReturnOut
-    OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
+    Ports::OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
 
   PRIVATE:
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.cpp
@@ -15,14 +15,14 @@
 namespace {
   // Get the max size by doing a union of the input and internal port serialization sizes
   union BuffUnion {
-    BYTE noArgsGuardedPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnGuardedPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnSyncPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsSyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE typedGuardedPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedReturnGuardedPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedReturnSyncPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedSyncPortSize[InputTypedPort::SERIALIZED_SIZE];
+    BYTE noArgsGuardedPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE typedGuardedPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedReturnGuardedPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedReturnSyncPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedSyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
     BYTE cmdPortSize[Fw::InputCmdPort::SERIALIZED_SIZE];
   };
 
@@ -537,7 +537,7 @@ Fw::InputCmdPort* PassiveTestComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-InputNoArgsPort* PassiveTestComponentBase ::
+Ports::InputNoArgsPort* PassiveTestComponentBase ::
   get_noArgsGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -548,7 +548,7 @@ InputNoArgsPort* PassiveTestComponentBase ::
   return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* PassiveTestComponentBase ::
+Ports::InputNoArgsReturnPort* PassiveTestComponentBase ::
   get_noArgsReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -559,7 +559,7 @@ InputNoArgsReturnPort* PassiveTestComponentBase ::
   return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* PassiveTestComponentBase ::
+Ports::InputNoArgsReturnPort* PassiveTestComponentBase ::
   get_noArgsReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -570,7 +570,7 @@ InputNoArgsReturnPort* PassiveTestComponentBase ::
   return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-InputNoArgsPort* PassiveTestComponentBase ::
+Ports::InputNoArgsPort* PassiveTestComponentBase ::
   get_noArgsSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -581,7 +581,7 @@ InputNoArgsPort* PassiveTestComponentBase ::
   return &this->m_noArgsSync_InputPort[portNum];
 }
 
-InputTypedPort* PassiveTestComponentBase ::
+Ports::InputTypedPort* PassiveTestComponentBase ::
   get_typedGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -592,7 +592,7 @@ InputTypedPort* PassiveTestComponentBase ::
   return &this->m_typedGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* PassiveTestComponentBase ::
+Ports::InputTypedReturnPort* PassiveTestComponentBase ::
   get_typedReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -603,7 +603,7 @@ InputTypedReturnPort* PassiveTestComponentBase ::
   return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* PassiveTestComponentBase ::
+Ports::InputTypedReturnPort* PassiveTestComponentBase ::
   get_typedReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -614,7 +614,7 @@ InputTypedReturnPort* PassiveTestComponentBase ::
   return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-InputTypedPort* PassiveTestComponentBase ::
+Ports::InputTypedPort* PassiveTestComponentBase ::
   get_typedSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -752,7 +752,7 @@ void PassiveTestComponentBase ::
 void PassiveTestComponentBase ::
   set_typedOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -766,7 +766,7 @@ void PassiveTestComponentBase ::
 void PassiveTestComponentBase ::
   set_typedReturnOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -1563,7 +1563,7 @@ void PassiveTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1600,7 +1600,7 @@ F32 PassiveTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1641,7 +1641,7 @@ F32 PassiveTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1676,7 +1676,7 @@ void PassiveTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1711,7 +1711,7 @@ void PassiveTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1738,7 +1738,7 @@ F32 PassiveTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -3928,7 +3928,7 @@ void PassiveTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3955,7 +3955,7 @@ F32 PassiveTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -3982,7 +3982,7 @@ F32 PassiveTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -4009,7 +4009,7 @@ void PassiveTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.hpp
@@ -196,56 +196,56 @@ class PassiveTestComponentBase :
     //! Get typed input port at index
     //!
     //! \return noArgsGuarded[portNum]
-    InputNoArgsPort* get_noArgsGuarded_InputPort(
+    Ports::InputNoArgsPort* get_noArgsGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnGuarded[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnSync[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsSync[portNum]
-    InputNoArgsPort* get_noArgsSync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedGuarded[portNum]
-    InputTypedPort* get_typedGuarded_InputPort(
+    Ports::InputTypedPort* get_typedGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnGuarded[portNum]
-    InputTypedReturnPort* get_typedReturnGuarded_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnSync[portNum]
-    InputTypedReturnPort* get_typedReturnSync_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedSync[portNum]
-    InputTypedPort* get_typedSync_InputPort(
+    Ports::InputTypedPort* get_typedSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -316,13 +316,13 @@ class PassiveTestComponentBase :
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnOut[portNum]
     void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
 #if FW_PORT_SERIALIZATION
@@ -674,7 +674,7 @@ class PassiveTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -686,7 +686,7 @@ class PassiveTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -698,7 +698,7 @@ class PassiveTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -710,7 +710,7 @@ class PassiveTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -750,7 +750,7 @@ class PassiveTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -762,7 +762,7 @@ class PassiveTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -774,7 +774,7 @@ class PassiveTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -786,7 +786,7 @@ class PassiveTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -804,7 +804,7 @@ class PassiveTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -816,7 +816,7 @@ class PassiveTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1393,7 +1393,7 @@ class PassiveTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1406,7 +1406,7 @@ class PassiveTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1419,7 +1419,7 @@ class PassiveTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1432,7 +1432,7 @@ class PassiveTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1538,28 +1538,28 @@ class PassiveTestComponentBase :
     // ----------------------------------------------------------------------
 
     //! Input port noArgsGuarded
-    InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnGuarded
-    InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnSync
-    InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
 
     //! Input port noArgsSync
-    InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedGuarded
-    InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
+    Ports::InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnGuarded
-    InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnSync
-    InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
 
     //! Input port typedSync
-    InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
 
   PRIVATE:
 
@@ -1602,10 +1602,10 @@ class PassiveTestComponentBase :
     // ----------------------------------------------------------------------
 
     //! Output port typedOut
-    OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
+    Ports::OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
 
     //! Output port typedReturnOut
-    OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
+    Ports::OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
 
   PRIVATE:
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedCommandsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedCommandsComponentAc.ref.cpp
@@ -29,19 +29,19 @@ namespace {
 
   // Get the max size by doing a union of the input and internal port serialization sizes
   union BuffUnion {
-    BYTE noArgsAsyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsGuardedPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnGuardedPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnSyncPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsSyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE typedAsyncPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncAssertPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncBlockPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncDropPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedGuardedPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedReturnGuardedPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedReturnSyncPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedSyncPortSize[InputTypedPort::SERIALIZED_SIZE];
+    BYTE noArgsAsyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsGuardedPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE typedAsyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncAssertPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncBlockPriorityPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncDropPriorityPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedGuardedPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedReturnGuardedPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedReturnSyncPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedSyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
     BYTE cmdPortSize[Fw::InputCmdPort::SERIALIZED_SIZE];
   };
 
@@ -698,7 +698,7 @@ Fw::InputCmdPort* QueuedCommandsComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-InputNoArgsPort* QueuedCommandsComponentBase ::
+Ports::InputNoArgsPort* QueuedCommandsComponentBase ::
   get_noArgsAsync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -709,7 +709,7 @@ InputNoArgsPort* QueuedCommandsComponentBase ::
   return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-InputNoArgsPort* QueuedCommandsComponentBase ::
+Ports::InputNoArgsPort* QueuedCommandsComponentBase ::
   get_noArgsGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -720,7 +720,7 @@ InputNoArgsPort* QueuedCommandsComponentBase ::
   return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* QueuedCommandsComponentBase ::
+Ports::InputNoArgsReturnPort* QueuedCommandsComponentBase ::
   get_noArgsReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -731,7 +731,7 @@ InputNoArgsReturnPort* QueuedCommandsComponentBase ::
   return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* QueuedCommandsComponentBase ::
+Ports::InputNoArgsReturnPort* QueuedCommandsComponentBase ::
   get_noArgsReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -742,7 +742,7 @@ InputNoArgsReturnPort* QueuedCommandsComponentBase ::
   return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-InputNoArgsPort* QueuedCommandsComponentBase ::
+Ports::InputNoArgsPort* QueuedCommandsComponentBase ::
   get_noArgsSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -753,7 +753,7 @@ InputNoArgsPort* QueuedCommandsComponentBase ::
   return &this->m_noArgsSync_InputPort[portNum];
 }
 
-InputTypedPort* QueuedCommandsComponentBase ::
+Ports::InputTypedPort* QueuedCommandsComponentBase ::
   get_typedAsync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -764,7 +764,7 @@ InputTypedPort* QueuedCommandsComponentBase ::
   return &this->m_typedAsync_InputPort[portNum];
 }
 
-InputTypedPort* QueuedCommandsComponentBase ::
+Ports::InputTypedPort* QueuedCommandsComponentBase ::
   get_typedAsyncAssert_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -775,7 +775,7 @@ InputTypedPort* QueuedCommandsComponentBase ::
   return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-InputTypedPort* QueuedCommandsComponentBase ::
+Ports::InputTypedPort* QueuedCommandsComponentBase ::
   get_typedAsyncBlockPriority_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -786,7 +786,7 @@ InputTypedPort* QueuedCommandsComponentBase ::
   return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-InputTypedPort* QueuedCommandsComponentBase ::
+Ports::InputTypedPort* QueuedCommandsComponentBase ::
   get_typedAsyncDropPriority_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -797,7 +797,7 @@ InputTypedPort* QueuedCommandsComponentBase ::
   return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-InputTypedPort* QueuedCommandsComponentBase ::
+Ports::InputTypedPort* QueuedCommandsComponentBase ::
   get_typedGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -808,7 +808,7 @@ InputTypedPort* QueuedCommandsComponentBase ::
   return &this->m_typedGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* QueuedCommandsComponentBase ::
+Ports::InputTypedReturnPort* QueuedCommandsComponentBase ::
   get_typedReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -819,7 +819,7 @@ InputTypedReturnPort* QueuedCommandsComponentBase ::
   return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* QueuedCommandsComponentBase ::
+Ports::InputTypedReturnPort* QueuedCommandsComponentBase ::
   get_typedReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -830,7 +830,7 @@ InputTypedReturnPort* QueuedCommandsComponentBase ::
   return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-InputTypedPort* QueuedCommandsComponentBase ::
+Ports::InputTypedPort* QueuedCommandsComponentBase ::
   get_typedSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -968,7 +968,7 @@ void QueuedCommandsComponentBase ::
 void QueuedCommandsComponentBase ::
   set_typedOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -982,7 +982,7 @@ void QueuedCommandsComponentBase ::
 void QueuedCommandsComponentBase ::
   set_typedReturnOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -1630,7 +1630,7 @@ void QueuedCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1737,7 +1737,7 @@ void QueuedCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1844,7 +1844,7 @@ void QueuedCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1951,7 +1951,7 @@ void QueuedCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2063,7 +2063,7 @@ void QueuedCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2100,7 +2100,7 @@ F32 QueuedCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2141,7 +2141,7 @@ F32 QueuedCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2176,7 +2176,7 @@ void QueuedCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2221,7 +2221,7 @@ void QueuedCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2236,7 +2236,7 @@ void QueuedCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2251,7 +2251,7 @@ void QueuedCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2266,7 +2266,7 @@ void QueuedCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2285,7 +2285,7 @@ void QueuedCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2312,7 +2312,7 @@ F32 QueuedCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -3460,7 +3460,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -3532,7 +3532,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -3604,7 +3604,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -3676,7 +3676,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -4241,7 +4241,7 @@ void QueuedCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -4268,7 +4268,7 @@ void QueuedCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -4295,7 +4295,7 @@ void QueuedCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -4322,7 +4322,7 @@ void QueuedCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -4349,7 +4349,7 @@ void QueuedCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -4376,7 +4376,7 @@ F32 QueuedCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -4403,7 +4403,7 @@ F32 QueuedCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -4430,7 +4430,7 @@ void QueuedCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedCommandsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedCommandsComponentAc.ref.hpp
@@ -148,91 +148,91 @@ class QueuedCommandsComponentBase :
     //! Get typed input port at index
     //!
     //! \return noArgsAsync[portNum]
-    InputNoArgsPort* get_noArgsAsync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsAsync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsGuarded[portNum]
-    InputNoArgsPort* get_noArgsGuarded_InputPort(
+    Ports::InputNoArgsPort* get_noArgsGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnGuarded[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnSync[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsSync[portNum]
-    InputNoArgsPort* get_noArgsSync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsync[portNum]
-    InputTypedPort* get_typedAsync_InputPort(
+    Ports::InputTypedPort* get_typedAsync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncAssert[portNum]
-    InputTypedPort* get_typedAsyncAssert_InputPort(
+    Ports::InputTypedPort* get_typedAsyncAssert_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncBlockPriority[portNum]
-    InputTypedPort* get_typedAsyncBlockPriority_InputPort(
+    Ports::InputTypedPort* get_typedAsyncBlockPriority_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncDropPriority[portNum]
-    InputTypedPort* get_typedAsyncDropPriority_InputPort(
+    Ports::InputTypedPort* get_typedAsyncDropPriority_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedGuarded[portNum]
-    InputTypedPort* get_typedGuarded_InputPort(
+    Ports::InputTypedPort* get_typedGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnGuarded[portNum]
-    InputTypedReturnPort* get_typedReturnGuarded_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnSync[portNum]
-    InputTypedReturnPort* get_typedReturnSync_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedSync[portNum]
-    InputTypedPort* get_typedSync_InputPort(
+    Ports::InputTypedPort* get_typedSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -303,13 +303,13 @@ class QueuedCommandsComponentBase :
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnOut[portNum]
     void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
 #if FW_PORT_SERIALIZATION
@@ -680,7 +680,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -692,7 +692,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -704,7 +704,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -716,7 +716,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -728,7 +728,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -740,7 +740,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -752,7 +752,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -764,7 +764,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -809,7 +809,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -821,7 +821,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -833,7 +833,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -845,7 +845,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -857,7 +857,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -869,7 +869,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -881,7 +881,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -893,7 +893,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -920,7 +920,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -932,7 +932,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -944,7 +944,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -956,7 +956,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -974,7 +974,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -986,7 +986,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1459,7 +1459,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1472,7 +1472,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1485,7 +1485,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1498,7 +1498,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1511,7 +1511,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1524,7 +1524,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1537,7 +1537,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1550,7 +1550,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1572,43 +1572,43 @@ class QueuedCommandsComponentBase :
     // ----------------------------------------------------------------------
 
     //! Input port noArgsAsync
-    InputNoArgsPort m_noArgsAsync_InputPort[NUM_NOARGSASYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsAsync_InputPort[NUM_NOARGSASYNC_INPUT_PORTS];
 
     //! Input port noArgsGuarded
-    InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnGuarded
-    InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnSync
-    InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
 
     //! Input port noArgsSync
-    InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedAsync
-    InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];
 
     //! Input port typedAsyncAssert
-    InputTypedPort m_typedAsyncAssert_InputPort[NUM_TYPEDASYNCASSERT_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncAssert_InputPort[NUM_TYPEDASYNCASSERT_INPUT_PORTS];
 
     //! Input port typedAsyncBlockPriority
-    InputTypedPort m_typedAsyncBlockPriority_InputPort[NUM_TYPEDASYNCBLOCKPRIORITY_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncBlockPriority_InputPort[NUM_TYPEDASYNCBLOCKPRIORITY_INPUT_PORTS];
 
     //! Input port typedAsyncDropPriority
-    InputTypedPort m_typedAsyncDropPriority_InputPort[NUM_TYPEDASYNCDROPPRIORITY_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncDropPriority_InputPort[NUM_TYPEDASYNCDROPPRIORITY_INPUT_PORTS];
 
     //! Input port typedGuarded
-    InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
+    Ports::InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnGuarded
-    InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnSync
-    InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
 
     //! Input port typedSync
-    InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
 
   PRIVATE:
 
@@ -1651,10 +1651,10 @@ class QueuedCommandsComponentBase :
     // ----------------------------------------------------------------------
 
     //! Output port typedOut
-    OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
+    Ports::OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
 
     //! Output port typedReturnOut
-    OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
+    Ports::OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
 
   PRIVATE:
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedEventsComponentAc.ref.cpp
@@ -24,19 +24,19 @@ namespace {
 
   // Get the max size by doing a union of the input and internal port serialization sizes
   union BuffUnion {
-    BYTE noArgsAsyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsGuardedPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnGuardedPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnSyncPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsSyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE typedAsyncPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncAssertPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncBlockPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncDropPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedGuardedPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedReturnGuardedPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedReturnSyncPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedSyncPortSize[InputTypedPort::SERIALIZED_SIZE];
+    BYTE noArgsAsyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsGuardedPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE typedAsyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncAssertPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncBlockPriorityPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncDropPriorityPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedGuardedPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedReturnGuardedPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedReturnSyncPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedSyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
     BYTE cmdPortSize[Fw::InputCmdPort::SERIALIZED_SIZE];
   };
 
@@ -693,7 +693,7 @@ Fw::InputCmdPort* QueuedEventsComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-InputNoArgsPort* QueuedEventsComponentBase ::
+Ports::InputNoArgsPort* QueuedEventsComponentBase ::
   get_noArgsAsync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -704,7 +704,7 @@ InputNoArgsPort* QueuedEventsComponentBase ::
   return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-InputNoArgsPort* QueuedEventsComponentBase ::
+Ports::InputNoArgsPort* QueuedEventsComponentBase ::
   get_noArgsGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -715,7 +715,7 @@ InputNoArgsPort* QueuedEventsComponentBase ::
   return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* QueuedEventsComponentBase ::
+Ports::InputNoArgsReturnPort* QueuedEventsComponentBase ::
   get_noArgsReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -726,7 +726,7 @@ InputNoArgsReturnPort* QueuedEventsComponentBase ::
   return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* QueuedEventsComponentBase ::
+Ports::InputNoArgsReturnPort* QueuedEventsComponentBase ::
   get_noArgsReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -737,7 +737,7 @@ InputNoArgsReturnPort* QueuedEventsComponentBase ::
   return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-InputNoArgsPort* QueuedEventsComponentBase ::
+Ports::InputNoArgsPort* QueuedEventsComponentBase ::
   get_noArgsSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -748,7 +748,7 @@ InputNoArgsPort* QueuedEventsComponentBase ::
   return &this->m_noArgsSync_InputPort[portNum];
 }
 
-InputTypedPort* QueuedEventsComponentBase ::
+Ports::InputTypedPort* QueuedEventsComponentBase ::
   get_typedAsync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -759,7 +759,7 @@ InputTypedPort* QueuedEventsComponentBase ::
   return &this->m_typedAsync_InputPort[portNum];
 }
 
-InputTypedPort* QueuedEventsComponentBase ::
+Ports::InputTypedPort* QueuedEventsComponentBase ::
   get_typedAsyncAssert_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -770,7 +770,7 @@ InputTypedPort* QueuedEventsComponentBase ::
   return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-InputTypedPort* QueuedEventsComponentBase ::
+Ports::InputTypedPort* QueuedEventsComponentBase ::
   get_typedAsyncBlockPriority_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -781,7 +781,7 @@ InputTypedPort* QueuedEventsComponentBase ::
   return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-InputTypedPort* QueuedEventsComponentBase ::
+Ports::InputTypedPort* QueuedEventsComponentBase ::
   get_typedAsyncDropPriority_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -792,7 +792,7 @@ InputTypedPort* QueuedEventsComponentBase ::
   return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-InputTypedPort* QueuedEventsComponentBase ::
+Ports::InputTypedPort* QueuedEventsComponentBase ::
   get_typedGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -803,7 +803,7 @@ InputTypedPort* QueuedEventsComponentBase ::
   return &this->m_typedGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* QueuedEventsComponentBase ::
+Ports::InputTypedReturnPort* QueuedEventsComponentBase ::
   get_typedReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -814,7 +814,7 @@ InputTypedReturnPort* QueuedEventsComponentBase ::
   return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* QueuedEventsComponentBase ::
+Ports::InputTypedReturnPort* QueuedEventsComponentBase ::
   get_typedReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -825,7 +825,7 @@ InputTypedReturnPort* QueuedEventsComponentBase ::
   return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-InputTypedPort* QueuedEventsComponentBase ::
+Ports::InputTypedPort* QueuedEventsComponentBase ::
   get_typedSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -963,7 +963,7 @@ void QueuedEventsComponentBase ::
 void QueuedEventsComponentBase ::
   set_typedOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -977,7 +977,7 @@ void QueuedEventsComponentBase ::
 void QueuedEventsComponentBase ::
   set_typedReturnOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -1549,7 +1549,7 @@ void QueuedEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1656,7 +1656,7 @@ void QueuedEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1763,7 +1763,7 @@ void QueuedEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1870,7 +1870,7 @@ void QueuedEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1982,7 +1982,7 @@ void QueuedEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2019,7 +2019,7 @@ F32 QueuedEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2060,7 +2060,7 @@ F32 QueuedEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2095,7 +2095,7 @@ void QueuedEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2140,7 +2140,7 @@ void QueuedEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2155,7 +2155,7 @@ void QueuedEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2170,7 +2170,7 @@ void QueuedEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2185,7 +2185,7 @@ void QueuedEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2204,7 +2204,7 @@ void QueuedEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2231,7 +2231,7 @@ F32 QueuedEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -3067,7 +3067,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -3139,7 +3139,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -3211,7 +3211,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -3283,7 +3283,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -3420,7 +3420,7 @@ void QueuedEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3447,7 +3447,7 @@ void QueuedEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3474,7 +3474,7 @@ void QueuedEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3501,7 +3501,7 @@ void QueuedEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3528,7 +3528,7 @@ void QueuedEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3555,7 +3555,7 @@ F32 QueuedEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -3582,7 +3582,7 @@ F32 QueuedEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -3609,7 +3609,7 @@ void QueuedEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedEventsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedEventsComponentAc.ref.hpp
@@ -145,91 +145,91 @@ class QueuedEventsComponentBase :
     //! Get typed input port at index
     //!
     //! \return noArgsAsync[portNum]
-    InputNoArgsPort* get_noArgsAsync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsAsync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsGuarded[portNum]
-    InputNoArgsPort* get_noArgsGuarded_InputPort(
+    Ports::InputNoArgsPort* get_noArgsGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnGuarded[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnSync[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsSync[portNum]
-    InputNoArgsPort* get_noArgsSync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsync[portNum]
-    InputTypedPort* get_typedAsync_InputPort(
+    Ports::InputTypedPort* get_typedAsync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncAssert[portNum]
-    InputTypedPort* get_typedAsyncAssert_InputPort(
+    Ports::InputTypedPort* get_typedAsyncAssert_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncBlockPriority[portNum]
-    InputTypedPort* get_typedAsyncBlockPriority_InputPort(
+    Ports::InputTypedPort* get_typedAsyncBlockPriority_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncDropPriority[portNum]
-    InputTypedPort* get_typedAsyncDropPriority_InputPort(
+    Ports::InputTypedPort* get_typedAsyncDropPriority_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedGuarded[portNum]
-    InputTypedPort* get_typedGuarded_InputPort(
+    Ports::InputTypedPort* get_typedGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnGuarded[portNum]
-    InputTypedReturnPort* get_typedReturnGuarded_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnSync[portNum]
-    InputTypedReturnPort* get_typedReturnSync_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedSync[portNum]
-    InputTypedPort* get_typedSync_InputPort(
+    Ports::InputTypedPort* get_typedSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -300,13 +300,13 @@ class QueuedEventsComponentBase :
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnOut[portNum]
     void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
 #if FW_PORT_SERIALIZATION
@@ -666,7 +666,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -678,7 +678,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -690,7 +690,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -702,7 +702,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -714,7 +714,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -726,7 +726,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -738,7 +738,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -750,7 +750,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -795,7 +795,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -807,7 +807,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -819,7 +819,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -831,7 +831,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -843,7 +843,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -855,7 +855,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -867,7 +867,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -879,7 +879,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -906,7 +906,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -918,7 +918,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -930,7 +930,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -942,7 +942,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -960,7 +960,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -972,7 +972,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1140,7 +1140,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1153,7 +1153,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1166,7 +1166,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1179,7 +1179,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1192,7 +1192,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1205,7 +1205,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1218,7 +1218,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1231,7 +1231,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1253,43 +1253,43 @@ class QueuedEventsComponentBase :
     // ----------------------------------------------------------------------
 
     //! Input port noArgsAsync
-    InputNoArgsPort m_noArgsAsync_InputPort[NUM_NOARGSASYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsAsync_InputPort[NUM_NOARGSASYNC_INPUT_PORTS];
 
     //! Input port noArgsGuarded
-    InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnGuarded
-    InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnSync
-    InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
 
     //! Input port noArgsSync
-    InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedAsync
-    InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];
 
     //! Input port typedAsyncAssert
-    InputTypedPort m_typedAsyncAssert_InputPort[NUM_TYPEDASYNCASSERT_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncAssert_InputPort[NUM_TYPEDASYNCASSERT_INPUT_PORTS];
 
     //! Input port typedAsyncBlockPriority
-    InputTypedPort m_typedAsyncBlockPriority_InputPort[NUM_TYPEDASYNCBLOCKPRIORITY_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncBlockPriority_InputPort[NUM_TYPEDASYNCBLOCKPRIORITY_INPUT_PORTS];
 
     //! Input port typedAsyncDropPriority
-    InputTypedPort m_typedAsyncDropPriority_InputPort[NUM_TYPEDASYNCDROPPRIORITY_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncDropPriority_InputPort[NUM_TYPEDASYNCDROPPRIORITY_INPUT_PORTS];
 
     //! Input port typedGuarded
-    InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
+    Ports::InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnGuarded
-    InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnSync
-    InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
 
     //! Input port typedSync
-    InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
 
   PRIVATE:
 
@@ -1332,10 +1332,10 @@ class QueuedEventsComponentBase :
     // ----------------------------------------------------------------------
 
     //! Output port typedOut
-    OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
+    Ports::OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
 
     //! Output port typedReturnOut
-    OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
+    Ports::OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
 
   PRIVATE:
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedParamsComponentAc.ref.cpp
@@ -24,19 +24,19 @@ namespace {
 
   // Get the max size by doing a union of the input and internal port serialization sizes
   union BuffUnion {
-    BYTE noArgsAsyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsGuardedPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnGuardedPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnSyncPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsSyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE typedAsyncPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncAssertPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncBlockPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncDropPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedGuardedPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedReturnGuardedPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedReturnSyncPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedSyncPortSize[InputTypedPort::SERIALIZED_SIZE];
+    BYTE noArgsAsyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsGuardedPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE typedAsyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncAssertPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncBlockPriorityPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncDropPriorityPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedGuardedPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedReturnGuardedPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedReturnSyncPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedSyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
     BYTE cmdPortSize[Fw::InputCmdPort::SERIALIZED_SIZE];
   };
 
@@ -693,7 +693,7 @@ Fw::InputCmdPort* QueuedParamsComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-InputNoArgsPort* QueuedParamsComponentBase ::
+Ports::InputNoArgsPort* QueuedParamsComponentBase ::
   get_noArgsAsync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -704,7 +704,7 @@ InputNoArgsPort* QueuedParamsComponentBase ::
   return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-InputNoArgsPort* QueuedParamsComponentBase ::
+Ports::InputNoArgsPort* QueuedParamsComponentBase ::
   get_noArgsGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -715,7 +715,7 @@ InputNoArgsPort* QueuedParamsComponentBase ::
   return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* QueuedParamsComponentBase ::
+Ports::InputNoArgsReturnPort* QueuedParamsComponentBase ::
   get_noArgsReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -726,7 +726,7 @@ InputNoArgsReturnPort* QueuedParamsComponentBase ::
   return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* QueuedParamsComponentBase ::
+Ports::InputNoArgsReturnPort* QueuedParamsComponentBase ::
   get_noArgsReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -737,7 +737,7 @@ InputNoArgsReturnPort* QueuedParamsComponentBase ::
   return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-InputNoArgsPort* QueuedParamsComponentBase ::
+Ports::InputNoArgsPort* QueuedParamsComponentBase ::
   get_noArgsSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -748,7 +748,7 @@ InputNoArgsPort* QueuedParamsComponentBase ::
   return &this->m_noArgsSync_InputPort[portNum];
 }
 
-InputTypedPort* QueuedParamsComponentBase ::
+Ports::InputTypedPort* QueuedParamsComponentBase ::
   get_typedAsync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -759,7 +759,7 @@ InputTypedPort* QueuedParamsComponentBase ::
   return &this->m_typedAsync_InputPort[portNum];
 }
 
-InputTypedPort* QueuedParamsComponentBase ::
+Ports::InputTypedPort* QueuedParamsComponentBase ::
   get_typedAsyncAssert_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -770,7 +770,7 @@ InputTypedPort* QueuedParamsComponentBase ::
   return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-InputTypedPort* QueuedParamsComponentBase ::
+Ports::InputTypedPort* QueuedParamsComponentBase ::
   get_typedAsyncBlockPriority_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -781,7 +781,7 @@ InputTypedPort* QueuedParamsComponentBase ::
   return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-InputTypedPort* QueuedParamsComponentBase ::
+Ports::InputTypedPort* QueuedParamsComponentBase ::
   get_typedAsyncDropPriority_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -792,7 +792,7 @@ InputTypedPort* QueuedParamsComponentBase ::
   return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-InputTypedPort* QueuedParamsComponentBase ::
+Ports::InputTypedPort* QueuedParamsComponentBase ::
   get_typedGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -803,7 +803,7 @@ InputTypedPort* QueuedParamsComponentBase ::
   return &this->m_typedGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* QueuedParamsComponentBase ::
+Ports::InputTypedReturnPort* QueuedParamsComponentBase ::
   get_typedReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -814,7 +814,7 @@ InputTypedReturnPort* QueuedParamsComponentBase ::
   return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* QueuedParamsComponentBase ::
+Ports::InputTypedReturnPort* QueuedParamsComponentBase ::
   get_typedReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -825,7 +825,7 @@ InputTypedReturnPort* QueuedParamsComponentBase ::
   return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-InputTypedPort* QueuedParamsComponentBase ::
+Ports::InputTypedPort* QueuedParamsComponentBase ::
   get_typedSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -963,7 +963,7 @@ void QueuedParamsComponentBase ::
 void QueuedParamsComponentBase ::
   set_typedOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -977,7 +977,7 @@ void QueuedParamsComponentBase ::
 void QueuedParamsComponentBase ::
   set_typedReturnOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -1785,7 +1785,7 @@ void QueuedParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1892,7 +1892,7 @@ void QueuedParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1999,7 +1999,7 @@ void QueuedParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2106,7 +2106,7 @@ void QueuedParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2218,7 +2218,7 @@ void QueuedParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2255,7 +2255,7 @@ F32 QueuedParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2296,7 +2296,7 @@ F32 QueuedParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2331,7 +2331,7 @@ void QueuedParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2376,7 +2376,7 @@ void QueuedParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2391,7 +2391,7 @@ void QueuedParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2406,7 +2406,7 @@ void QueuedParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2421,7 +2421,7 @@ void QueuedParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2440,7 +2440,7 @@ void QueuedParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2467,7 +2467,7 @@ F32 QueuedParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2709,7 +2709,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -2781,7 +2781,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -2853,7 +2853,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -2925,7 +2925,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -3186,7 +3186,7 @@ void QueuedParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3213,7 +3213,7 @@ void QueuedParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3240,7 +3240,7 @@ void QueuedParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3267,7 +3267,7 @@ void QueuedParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3294,7 +3294,7 @@ void QueuedParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3321,7 +3321,7 @@ F32 QueuedParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -3348,7 +3348,7 @@ F32 QueuedParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -3375,7 +3375,7 @@ void QueuedParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedParamsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedParamsComponentAc.ref.hpp
@@ -155,91 +155,91 @@ class QueuedParamsComponentBase :
     //! Get typed input port at index
     //!
     //! \return noArgsAsync[portNum]
-    InputNoArgsPort* get_noArgsAsync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsAsync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsGuarded[portNum]
-    InputNoArgsPort* get_noArgsGuarded_InputPort(
+    Ports::InputNoArgsPort* get_noArgsGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnGuarded[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnSync[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsSync[portNum]
-    InputNoArgsPort* get_noArgsSync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsync[portNum]
-    InputTypedPort* get_typedAsync_InputPort(
+    Ports::InputTypedPort* get_typedAsync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncAssert[portNum]
-    InputTypedPort* get_typedAsyncAssert_InputPort(
+    Ports::InputTypedPort* get_typedAsyncAssert_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncBlockPriority[portNum]
-    InputTypedPort* get_typedAsyncBlockPriority_InputPort(
+    Ports::InputTypedPort* get_typedAsyncBlockPriority_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncDropPriority[portNum]
-    InputTypedPort* get_typedAsyncDropPriority_InputPort(
+    Ports::InputTypedPort* get_typedAsyncDropPriority_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedGuarded[portNum]
-    InputTypedPort* get_typedGuarded_InputPort(
+    Ports::InputTypedPort* get_typedGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnGuarded[portNum]
-    InputTypedReturnPort* get_typedReturnGuarded_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnSync[portNum]
-    InputTypedReturnPort* get_typedReturnSync_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedSync[portNum]
-    InputTypedPort* get_typedSync_InputPort(
+    Ports::InputTypedPort* get_typedSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -310,13 +310,13 @@ class QueuedParamsComponentBase :
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnOut[portNum]
     void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
 #if FW_PORT_SERIALIZATION
@@ -698,7 +698,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -710,7 +710,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -722,7 +722,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -734,7 +734,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -746,7 +746,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -758,7 +758,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -770,7 +770,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -782,7 +782,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -827,7 +827,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -839,7 +839,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -851,7 +851,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -863,7 +863,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -875,7 +875,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -887,7 +887,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -899,7 +899,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -911,7 +911,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -938,7 +938,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -950,7 +950,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -962,7 +962,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -974,7 +974,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -992,7 +992,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1004,7 +1004,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1199,7 +1199,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1212,7 +1212,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1225,7 +1225,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1238,7 +1238,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1251,7 +1251,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1264,7 +1264,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1277,7 +1277,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1290,7 +1290,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1396,43 +1396,43 @@ class QueuedParamsComponentBase :
     // ----------------------------------------------------------------------
 
     //! Input port noArgsAsync
-    InputNoArgsPort m_noArgsAsync_InputPort[NUM_NOARGSASYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsAsync_InputPort[NUM_NOARGSASYNC_INPUT_PORTS];
 
     //! Input port noArgsGuarded
-    InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnGuarded
-    InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnSync
-    InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
 
     //! Input port noArgsSync
-    InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedAsync
-    InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];
 
     //! Input port typedAsyncAssert
-    InputTypedPort m_typedAsyncAssert_InputPort[NUM_TYPEDASYNCASSERT_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncAssert_InputPort[NUM_TYPEDASYNCASSERT_INPUT_PORTS];
 
     //! Input port typedAsyncBlockPriority
-    InputTypedPort m_typedAsyncBlockPriority_InputPort[NUM_TYPEDASYNCBLOCKPRIORITY_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncBlockPriority_InputPort[NUM_TYPEDASYNCBLOCKPRIORITY_INPUT_PORTS];
 
     //! Input port typedAsyncDropPriority
-    InputTypedPort m_typedAsyncDropPriority_InputPort[NUM_TYPEDASYNCDROPPRIORITY_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncDropPriority_InputPort[NUM_TYPEDASYNCDROPPRIORITY_INPUT_PORTS];
 
     //! Input port typedGuarded
-    InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
+    Ports::InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnGuarded
-    InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnSync
-    InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
 
     //! Input port typedSync
-    InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
 
   PRIVATE:
 
@@ -1475,10 +1475,10 @@ class QueuedParamsComponentBase :
     // ----------------------------------------------------------------------
 
     //! Output port typedOut
-    OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
+    Ports::OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
 
     //! Output port typedReturnOut
-    OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
+    Ports::OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
 
   PRIVATE:
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.cpp
@@ -39,19 +39,19 @@ namespace {
 
   // Get the max size by doing a union of the input and internal port serialization sizes
   union BuffUnion {
-    BYTE noArgsAsyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsGuardedPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnGuardedPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnSyncPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsSyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE typedAsyncPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncAssertPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncBlockPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncDropPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedGuardedPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedReturnGuardedPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedReturnSyncPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedSyncPortSize[InputTypedPort::SERIALIZED_SIZE];
+    BYTE noArgsAsyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsGuardedPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE typedAsyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncAssertPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncBlockPriorityPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncDropPriorityPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedGuardedPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedReturnGuardedPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedReturnSyncPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedSyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
     BYTE cmdPortSize[Fw::InputCmdPort::SERIALIZED_SIZE];
     // Size of internalArray argument list
     BYTE internalArrayIntIfSize[
@@ -917,7 +917,7 @@ Fw::InputCmdPort* QueuedSerialComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-InputNoArgsPort* QueuedSerialComponentBase ::
+Ports::InputNoArgsPort* QueuedSerialComponentBase ::
   get_noArgsAsync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -928,7 +928,7 @@ InputNoArgsPort* QueuedSerialComponentBase ::
   return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-InputNoArgsPort* QueuedSerialComponentBase ::
+Ports::InputNoArgsPort* QueuedSerialComponentBase ::
   get_noArgsGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -939,7 +939,7 @@ InputNoArgsPort* QueuedSerialComponentBase ::
   return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* QueuedSerialComponentBase ::
+Ports::InputNoArgsReturnPort* QueuedSerialComponentBase ::
   get_noArgsReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -950,7 +950,7 @@ InputNoArgsReturnPort* QueuedSerialComponentBase ::
   return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* QueuedSerialComponentBase ::
+Ports::InputNoArgsReturnPort* QueuedSerialComponentBase ::
   get_noArgsReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -961,7 +961,7 @@ InputNoArgsReturnPort* QueuedSerialComponentBase ::
   return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-InputNoArgsPort* QueuedSerialComponentBase ::
+Ports::InputNoArgsPort* QueuedSerialComponentBase ::
   get_noArgsSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -972,7 +972,7 @@ InputNoArgsPort* QueuedSerialComponentBase ::
   return &this->m_noArgsSync_InputPort[portNum];
 }
 
-InputTypedPort* QueuedSerialComponentBase ::
+Ports::InputTypedPort* QueuedSerialComponentBase ::
   get_typedAsync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -983,7 +983,7 @@ InputTypedPort* QueuedSerialComponentBase ::
   return &this->m_typedAsync_InputPort[portNum];
 }
 
-InputTypedPort* QueuedSerialComponentBase ::
+Ports::InputTypedPort* QueuedSerialComponentBase ::
   get_typedAsyncAssert_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -994,7 +994,7 @@ InputTypedPort* QueuedSerialComponentBase ::
   return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-InputTypedPort* QueuedSerialComponentBase ::
+Ports::InputTypedPort* QueuedSerialComponentBase ::
   get_typedAsyncBlockPriority_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -1005,7 +1005,7 @@ InputTypedPort* QueuedSerialComponentBase ::
   return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-InputTypedPort* QueuedSerialComponentBase ::
+Ports::InputTypedPort* QueuedSerialComponentBase ::
   get_typedAsyncDropPriority_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -1016,7 +1016,7 @@ InputTypedPort* QueuedSerialComponentBase ::
   return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-InputTypedPort* QueuedSerialComponentBase ::
+Ports::InputTypedPort* QueuedSerialComponentBase ::
   get_typedGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -1027,7 +1027,7 @@ InputTypedPort* QueuedSerialComponentBase ::
   return &this->m_typedGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* QueuedSerialComponentBase ::
+Ports::InputTypedReturnPort* QueuedSerialComponentBase ::
   get_typedReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -1038,7 +1038,7 @@ InputTypedReturnPort* QueuedSerialComponentBase ::
   return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* QueuedSerialComponentBase ::
+Ports::InputTypedReturnPort* QueuedSerialComponentBase ::
   get_typedReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -1049,7 +1049,7 @@ InputTypedReturnPort* QueuedSerialComponentBase ::
   return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-InputTypedPort* QueuedSerialComponentBase ::
+Ports::InputTypedPort* QueuedSerialComponentBase ::
   get_typedSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -1257,7 +1257,7 @@ void QueuedSerialComponentBase ::
 void QueuedSerialComponentBase ::
   set_typedOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -1271,7 +1271,7 @@ void QueuedSerialComponentBase ::
 void QueuedSerialComponentBase ::
   set_typedReturnOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -2245,7 +2245,7 @@ void QueuedSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2352,7 +2352,7 @@ void QueuedSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2459,7 +2459,7 @@ void QueuedSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2566,7 +2566,7 @@ void QueuedSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2678,7 +2678,7 @@ void QueuedSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2715,7 +2715,7 @@ F32 QueuedSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2756,7 +2756,7 @@ F32 QueuedSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2791,7 +2791,7 @@ void QueuedSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3091,7 +3091,7 @@ void QueuedSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3106,7 +3106,7 @@ void QueuedSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3121,7 +3121,7 @@ void QueuedSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3136,7 +3136,7 @@ void QueuedSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3199,7 +3199,7 @@ void QueuedSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3226,7 +3226,7 @@ F32 QueuedSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -5821,7 +5821,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -5893,7 +5893,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -5965,7 +5965,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -6037,7 +6037,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -6957,7 +6957,7 @@ void QueuedSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -6984,7 +6984,7 @@ void QueuedSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -7011,7 +7011,7 @@ void QueuedSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -7038,7 +7038,7 @@ void QueuedSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -7065,7 +7065,7 @@ void QueuedSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -7092,7 +7092,7 @@ F32 QueuedSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -7119,7 +7119,7 @@ F32 QueuedSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -7146,7 +7146,7 @@ void QueuedSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.hpp
@@ -229,91 +229,91 @@ class QueuedSerialComponentBase :
     //! Get typed input port at index
     //!
     //! \return noArgsAsync[portNum]
-    InputNoArgsPort* get_noArgsAsync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsAsync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsGuarded[portNum]
-    InputNoArgsPort* get_noArgsGuarded_InputPort(
+    Ports::InputNoArgsPort* get_noArgsGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnGuarded[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnSync[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsSync[portNum]
-    InputNoArgsPort* get_noArgsSync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsync[portNum]
-    InputTypedPort* get_typedAsync_InputPort(
+    Ports::InputTypedPort* get_typedAsync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncAssert[portNum]
-    InputTypedPort* get_typedAsyncAssert_InputPort(
+    Ports::InputTypedPort* get_typedAsyncAssert_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncBlockPriority[portNum]
-    InputTypedPort* get_typedAsyncBlockPriority_InputPort(
+    Ports::InputTypedPort* get_typedAsyncBlockPriority_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncDropPriority[portNum]
-    InputTypedPort* get_typedAsyncDropPriority_InputPort(
+    Ports::InputTypedPort* get_typedAsyncDropPriority_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedGuarded[portNum]
-    InputTypedPort* get_typedGuarded_InputPort(
+    Ports::InputTypedPort* get_typedGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnGuarded[portNum]
-    InputTypedReturnPort* get_typedReturnGuarded_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnSync[portNum]
-    InputTypedReturnPort* get_typedReturnSync_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedSync[portNum]
-    InputTypedPort* get_typedSync_InputPort(
+    Ports::InputTypedPort* get_typedSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -432,13 +432,13 @@ class QueuedSerialComponentBase :
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnOut[portNum]
     void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
 #if FW_PORT_SERIALIZATION
@@ -896,7 +896,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -908,7 +908,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -920,7 +920,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -932,7 +932,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -944,7 +944,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -956,7 +956,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -968,7 +968,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -980,7 +980,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1025,7 +1025,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1037,7 +1037,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1049,7 +1049,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1061,7 +1061,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1073,7 +1073,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1085,7 +1085,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1097,7 +1097,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1109,7 +1109,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1222,7 +1222,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1234,7 +1234,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1246,7 +1246,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1258,7 +1258,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1310,7 +1310,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1322,7 +1322,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -2127,7 +2127,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -2140,7 +2140,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -2153,7 +2153,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -2166,7 +2166,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -2179,7 +2179,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -2192,7 +2192,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -2205,7 +2205,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -2218,7 +2218,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -2376,43 +2376,43 @@ class QueuedSerialComponentBase :
     // ----------------------------------------------------------------------
 
     //! Input port noArgsAsync
-    InputNoArgsPort m_noArgsAsync_InputPort[NUM_NOARGSASYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsAsync_InputPort[NUM_NOARGSASYNC_INPUT_PORTS];
 
     //! Input port noArgsGuarded
-    InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnGuarded
-    InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnSync
-    InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
 
     //! Input port noArgsSync
-    InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedAsync
-    InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];
 
     //! Input port typedAsyncAssert
-    InputTypedPort m_typedAsyncAssert_InputPort[NUM_TYPEDASYNCASSERT_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncAssert_InputPort[NUM_TYPEDASYNCASSERT_INPUT_PORTS];
 
     //! Input port typedAsyncBlockPriority
-    InputTypedPort m_typedAsyncBlockPriority_InputPort[NUM_TYPEDASYNCBLOCKPRIORITY_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncBlockPriority_InputPort[NUM_TYPEDASYNCBLOCKPRIORITY_INPUT_PORTS];
 
     //! Input port typedAsyncDropPriority
-    InputTypedPort m_typedAsyncDropPriority_InputPort[NUM_TYPEDASYNCDROPPRIORITY_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncDropPriority_InputPort[NUM_TYPEDASYNCDROPPRIORITY_INPUT_PORTS];
 
     //! Input port typedGuarded
-    InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
+    Ports::InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnGuarded
-    InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnSync
-    InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
 
     //! Input port typedSync
-    InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
 
   PRIVATE:
 
@@ -2479,10 +2479,10 @@ class QueuedSerialComponentBase :
     // ----------------------------------------------------------------------
 
     //! Output port typedOut
-    OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
+    Ports::OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
 
     //! Output port typedReturnOut
-    OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
+    Ports::OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
 
   PRIVATE:
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTelemetryComponentAc.ref.cpp
@@ -24,19 +24,19 @@ namespace {
 
   // Get the max size by doing a union of the input and internal port serialization sizes
   union BuffUnion {
-    BYTE noArgsAsyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsGuardedPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnGuardedPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnSyncPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsSyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE typedAsyncPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncAssertPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncBlockPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncDropPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedGuardedPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedReturnGuardedPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedReturnSyncPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedSyncPortSize[InputTypedPort::SERIALIZED_SIZE];
+    BYTE noArgsAsyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsGuardedPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE typedAsyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncAssertPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncBlockPriorityPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncDropPriorityPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedGuardedPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedReturnGuardedPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedReturnSyncPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedSyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
     BYTE cmdPortSize[Fw::InputCmdPort::SERIALIZED_SIZE];
   };
 
@@ -693,7 +693,7 @@ Fw::InputCmdPort* QueuedTelemetryComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-InputNoArgsPort* QueuedTelemetryComponentBase ::
+Ports::InputNoArgsPort* QueuedTelemetryComponentBase ::
   get_noArgsAsync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -704,7 +704,7 @@ InputNoArgsPort* QueuedTelemetryComponentBase ::
   return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-InputNoArgsPort* QueuedTelemetryComponentBase ::
+Ports::InputNoArgsPort* QueuedTelemetryComponentBase ::
   get_noArgsGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -715,7 +715,7 @@ InputNoArgsPort* QueuedTelemetryComponentBase ::
   return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* QueuedTelemetryComponentBase ::
+Ports::InputNoArgsReturnPort* QueuedTelemetryComponentBase ::
   get_noArgsReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -726,7 +726,7 @@ InputNoArgsReturnPort* QueuedTelemetryComponentBase ::
   return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* QueuedTelemetryComponentBase ::
+Ports::InputNoArgsReturnPort* QueuedTelemetryComponentBase ::
   get_noArgsReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -737,7 +737,7 @@ InputNoArgsReturnPort* QueuedTelemetryComponentBase ::
   return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-InputNoArgsPort* QueuedTelemetryComponentBase ::
+Ports::InputNoArgsPort* QueuedTelemetryComponentBase ::
   get_noArgsSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -748,7 +748,7 @@ InputNoArgsPort* QueuedTelemetryComponentBase ::
   return &this->m_noArgsSync_InputPort[portNum];
 }
 
-InputTypedPort* QueuedTelemetryComponentBase ::
+Ports::InputTypedPort* QueuedTelemetryComponentBase ::
   get_typedAsync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -759,7 +759,7 @@ InputTypedPort* QueuedTelemetryComponentBase ::
   return &this->m_typedAsync_InputPort[portNum];
 }
 
-InputTypedPort* QueuedTelemetryComponentBase ::
+Ports::InputTypedPort* QueuedTelemetryComponentBase ::
   get_typedAsyncAssert_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -770,7 +770,7 @@ InputTypedPort* QueuedTelemetryComponentBase ::
   return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-InputTypedPort* QueuedTelemetryComponentBase ::
+Ports::InputTypedPort* QueuedTelemetryComponentBase ::
   get_typedAsyncBlockPriority_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -781,7 +781,7 @@ InputTypedPort* QueuedTelemetryComponentBase ::
   return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-InputTypedPort* QueuedTelemetryComponentBase ::
+Ports::InputTypedPort* QueuedTelemetryComponentBase ::
   get_typedAsyncDropPriority_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -792,7 +792,7 @@ InputTypedPort* QueuedTelemetryComponentBase ::
   return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-InputTypedPort* QueuedTelemetryComponentBase ::
+Ports::InputTypedPort* QueuedTelemetryComponentBase ::
   get_typedGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -803,7 +803,7 @@ InputTypedPort* QueuedTelemetryComponentBase ::
   return &this->m_typedGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* QueuedTelemetryComponentBase ::
+Ports::InputTypedReturnPort* QueuedTelemetryComponentBase ::
   get_typedReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -814,7 +814,7 @@ InputTypedReturnPort* QueuedTelemetryComponentBase ::
   return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* QueuedTelemetryComponentBase ::
+Ports::InputTypedReturnPort* QueuedTelemetryComponentBase ::
   get_typedReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -825,7 +825,7 @@ InputTypedReturnPort* QueuedTelemetryComponentBase ::
   return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-InputTypedPort* QueuedTelemetryComponentBase ::
+Ports::InputTypedPort* QueuedTelemetryComponentBase ::
   get_typedSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -963,7 +963,7 @@ void QueuedTelemetryComponentBase ::
 void QueuedTelemetryComponentBase ::
   set_typedOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -977,7 +977,7 @@ void QueuedTelemetryComponentBase ::
 void QueuedTelemetryComponentBase ::
   set_typedReturnOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -1552,7 +1552,7 @@ void QueuedTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1659,7 +1659,7 @@ void QueuedTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1766,7 +1766,7 @@ void QueuedTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1873,7 +1873,7 @@ void QueuedTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1985,7 +1985,7 @@ void QueuedTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2022,7 +2022,7 @@ F32 QueuedTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2063,7 +2063,7 @@ F32 QueuedTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2098,7 +2098,7 @@ void QueuedTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2143,7 +2143,7 @@ void QueuedTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2158,7 +2158,7 @@ void QueuedTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2173,7 +2173,7 @@ void QueuedTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2188,7 +2188,7 @@ void QueuedTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2207,7 +2207,7 @@ void QueuedTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2234,7 +2234,7 @@ F32 QueuedTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2772,7 +2772,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -2844,7 +2844,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -2916,7 +2916,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -2988,7 +2988,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -3125,7 +3125,7 @@ void QueuedTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3152,7 +3152,7 @@ void QueuedTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3179,7 +3179,7 @@ void QueuedTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3206,7 +3206,7 @@ void QueuedTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3233,7 +3233,7 @@ void QueuedTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3260,7 +3260,7 @@ F32 QueuedTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -3287,7 +3287,7 @@ F32 QueuedTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -3314,7 +3314,7 @@ void QueuedTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTelemetryComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTelemetryComponentAc.ref.hpp
@@ -142,91 +142,91 @@ class QueuedTelemetryComponentBase :
     //! Get typed input port at index
     //!
     //! \return noArgsAsync[portNum]
-    InputNoArgsPort* get_noArgsAsync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsAsync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsGuarded[portNum]
-    InputNoArgsPort* get_noArgsGuarded_InputPort(
+    Ports::InputNoArgsPort* get_noArgsGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnGuarded[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnSync[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsSync[portNum]
-    InputNoArgsPort* get_noArgsSync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsync[portNum]
-    InputTypedPort* get_typedAsync_InputPort(
+    Ports::InputTypedPort* get_typedAsync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncAssert[portNum]
-    InputTypedPort* get_typedAsyncAssert_InputPort(
+    Ports::InputTypedPort* get_typedAsyncAssert_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncBlockPriority[portNum]
-    InputTypedPort* get_typedAsyncBlockPriority_InputPort(
+    Ports::InputTypedPort* get_typedAsyncBlockPriority_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncDropPriority[portNum]
-    InputTypedPort* get_typedAsyncDropPriority_InputPort(
+    Ports::InputTypedPort* get_typedAsyncDropPriority_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedGuarded[portNum]
-    InputTypedPort* get_typedGuarded_InputPort(
+    Ports::InputTypedPort* get_typedGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnGuarded[portNum]
-    InputTypedReturnPort* get_typedReturnGuarded_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnSync[portNum]
-    InputTypedReturnPort* get_typedReturnSync_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedSync[portNum]
-    InputTypedPort* get_typedSync_InputPort(
+    Ports::InputTypedPort* get_typedSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -297,13 +297,13 @@ class QueuedTelemetryComponentBase :
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnOut[portNum]
     void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
 #if FW_PORT_SERIALIZATION
@@ -663,7 +663,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -675,7 +675,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -687,7 +687,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -699,7 +699,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -711,7 +711,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -723,7 +723,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -735,7 +735,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -747,7 +747,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -792,7 +792,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -804,7 +804,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -816,7 +816,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -828,7 +828,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -840,7 +840,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -852,7 +852,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -864,7 +864,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -876,7 +876,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -903,7 +903,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -915,7 +915,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -927,7 +927,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -939,7 +939,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -957,7 +957,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -969,7 +969,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1162,7 +1162,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1175,7 +1175,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1188,7 +1188,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1201,7 +1201,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1214,7 +1214,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1227,7 +1227,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1240,7 +1240,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1253,7 +1253,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1275,43 +1275,43 @@ class QueuedTelemetryComponentBase :
     // ----------------------------------------------------------------------
 
     //! Input port noArgsAsync
-    InputNoArgsPort m_noArgsAsync_InputPort[NUM_NOARGSASYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsAsync_InputPort[NUM_NOARGSASYNC_INPUT_PORTS];
 
     //! Input port noArgsGuarded
-    InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnGuarded
-    InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnSync
-    InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
 
     //! Input port noArgsSync
-    InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedAsync
-    InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];
 
     //! Input port typedAsyncAssert
-    InputTypedPort m_typedAsyncAssert_InputPort[NUM_TYPEDASYNCASSERT_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncAssert_InputPort[NUM_TYPEDASYNCASSERT_INPUT_PORTS];
 
     //! Input port typedAsyncBlockPriority
-    InputTypedPort m_typedAsyncBlockPriority_InputPort[NUM_TYPEDASYNCBLOCKPRIORITY_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncBlockPriority_InputPort[NUM_TYPEDASYNCBLOCKPRIORITY_INPUT_PORTS];
 
     //! Input port typedAsyncDropPriority
-    InputTypedPort m_typedAsyncDropPriority_InputPort[NUM_TYPEDASYNCDROPPRIORITY_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncDropPriority_InputPort[NUM_TYPEDASYNCDROPPRIORITY_INPUT_PORTS];
 
     //! Input port typedGuarded
-    InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
+    Ports::InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnGuarded
-    InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnSync
-    InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
 
     //! Input port typedSync
-    InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
 
   PRIVATE:
 
@@ -1354,10 +1354,10 @@ class QueuedTelemetryComponentBase :
     // ----------------------------------------------------------------------
 
     //! Output port typedOut
-    OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
+    Ports::OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
 
     //! Output port typedReturnOut
-    OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
+    Ports::OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
 
   PRIVATE:
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
@@ -35,19 +35,19 @@ namespace {
 
   // Get the max size by doing a union of the input and internal port serialization sizes
   union BuffUnion {
-    BYTE noArgsAsyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsGuardedPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnGuardedPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnSyncPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsSyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE typedAsyncPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncAssertPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncBlockPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncDropPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedGuardedPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedReturnGuardedPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedReturnSyncPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedSyncPortSize[InputTypedPort::SERIALIZED_SIZE];
+    BYTE noArgsAsyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsGuardedPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE typedAsyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncAssertPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncBlockPriorityPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncDropPriorityPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedGuardedPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedReturnGuardedPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedReturnSyncPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedSyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
     BYTE cmdPortSize[Fw::InputCmdPort::SERIALIZED_SIZE];
     // Size of internalArray argument list
     BYTE internalArrayIntIfSize[
@@ -729,7 +729,7 @@ Fw::InputCmdPort* QueuedTestComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-InputNoArgsPort* QueuedTestComponentBase ::
+Ports::InputNoArgsPort* QueuedTestComponentBase ::
   get_noArgsAsync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -740,7 +740,7 @@ InputNoArgsPort* QueuedTestComponentBase ::
   return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-InputNoArgsPort* QueuedTestComponentBase ::
+Ports::InputNoArgsPort* QueuedTestComponentBase ::
   get_noArgsGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -751,7 +751,7 @@ InputNoArgsPort* QueuedTestComponentBase ::
   return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* QueuedTestComponentBase ::
+Ports::InputNoArgsReturnPort* QueuedTestComponentBase ::
   get_noArgsReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -762,7 +762,7 @@ InputNoArgsReturnPort* QueuedTestComponentBase ::
   return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* QueuedTestComponentBase ::
+Ports::InputNoArgsReturnPort* QueuedTestComponentBase ::
   get_noArgsReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -773,7 +773,7 @@ InputNoArgsReturnPort* QueuedTestComponentBase ::
   return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-InputNoArgsPort* QueuedTestComponentBase ::
+Ports::InputNoArgsPort* QueuedTestComponentBase ::
   get_noArgsSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -784,7 +784,7 @@ InputNoArgsPort* QueuedTestComponentBase ::
   return &this->m_noArgsSync_InputPort[portNum];
 }
 
-InputTypedPort* QueuedTestComponentBase ::
+Ports::InputTypedPort* QueuedTestComponentBase ::
   get_typedAsync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -795,7 +795,7 @@ InputTypedPort* QueuedTestComponentBase ::
   return &this->m_typedAsync_InputPort[portNum];
 }
 
-InputTypedPort* QueuedTestComponentBase ::
+Ports::InputTypedPort* QueuedTestComponentBase ::
   get_typedAsyncAssert_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -806,7 +806,7 @@ InputTypedPort* QueuedTestComponentBase ::
   return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-InputTypedPort* QueuedTestComponentBase ::
+Ports::InputTypedPort* QueuedTestComponentBase ::
   get_typedAsyncBlockPriority_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -817,7 +817,7 @@ InputTypedPort* QueuedTestComponentBase ::
   return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-InputTypedPort* QueuedTestComponentBase ::
+Ports::InputTypedPort* QueuedTestComponentBase ::
   get_typedAsyncDropPriority_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -828,7 +828,7 @@ InputTypedPort* QueuedTestComponentBase ::
   return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-InputTypedPort* QueuedTestComponentBase ::
+Ports::InputTypedPort* QueuedTestComponentBase ::
   get_typedGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -839,7 +839,7 @@ InputTypedPort* QueuedTestComponentBase ::
   return &this->m_typedGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* QueuedTestComponentBase ::
+Ports::InputTypedReturnPort* QueuedTestComponentBase ::
   get_typedReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -850,7 +850,7 @@ InputTypedReturnPort* QueuedTestComponentBase ::
   return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* QueuedTestComponentBase ::
+Ports::InputTypedReturnPort* QueuedTestComponentBase ::
   get_typedReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -861,7 +861,7 @@ InputTypedReturnPort* QueuedTestComponentBase ::
   return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-InputTypedPort* QueuedTestComponentBase ::
+Ports::InputTypedPort* QueuedTestComponentBase ::
   get_typedSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -999,7 +999,7 @@ void QueuedTestComponentBase ::
 void QueuedTestComponentBase ::
   set_typedOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -1013,7 +1013,7 @@ void QueuedTestComponentBase ::
 void QueuedTestComponentBase ::
   set_typedReturnOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -1900,7 +1900,7 @@ void QueuedTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2007,7 +2007,7 @@ void QueuedTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2114,7 +2114,7 @@ void QueuedTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2221,7 +2221,7 @@ void QueuedTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2333,7 +2333,7 @@ void QueuedTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2370,7 +2370,7 @@ F32 QueuedTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2411,7 +2411,7 @@ F32 QueuedTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2446,7 +2446,7 @@ void QueuedTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2491,7 +2491,7 @@ void QueuedTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2506,7 +2506,7 @@ void QueuedTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2521,7 +2521,7 @@ void QueuedTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2536,7 +2536,7 @@ void QueuedTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2555,7 +2555,7 @@ void QueuedTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2582,7 +2582,7 @@ F32 QueuedTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -5157,7 +5157,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -5229,7 +5229,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -5301,7 +5301,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -5373,7 +5373,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -6233,7 +6233,7 @@ void QueuedTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -6260,7 +6260,7 @@ void QueuedTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -6287,7 +6287,7 @@ void QueuedTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -6314,7 +6314,7 @@ void QueuedTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -6341,7 +6341,7 @@ void QueuedTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -6368,7 +6368,7 @@ F32 QueuedTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -6395,7 +6395,7 @@ F32 QueuedTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -6422,7 +6422,7 @@ void QueuedTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.hpp
@@ -208,91 +208,91 @@ class QueuedTestComponentBase :
     //! Get typed input port at index
     //!
     //! \return noArgsAsync[portNum]
-    InputNoArgsPort* get_noArgsAsync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsAsync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsGuarded[portNum]
-    InputNoArgsPort* get_noArgsGuarded_InputPort(
+    Ports::InputNoArgsPort* get_noArgsGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnGuarded[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnSync[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsSync[portNum]
-    InputNoArgsPort* get_noArgsSync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsync[portNum]
-    InputTypedPort* get_typedAsync_InputPort(
+    Ports::InputTypedPort* get_typedAsync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncAssert[portNum]
-    InputTypedPort* get_typedAsyncAssert_InputPort(
+    Ports::InputTypedPort* get_typedAsyncAssert_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncBlockPriority[portNum]
-    InputTypedPort* get_typedAsyncBlockPriority_InputPort(
+    Ports::InputTypedPort* get_typedAsyncBlockPriority_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncDropPriority[portNum]
-    InputTypedPort* get_typedAsyncDropPriority_InputPort(
+    Ports::InputTypedPort* get_typedAsyncDropPriority_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedGuarded[portNum]
-    InputTypedPort* get_typedGuarded_InputPort(
+    Ports::InputTypedPort* get_typedGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnGuarded[portNum]
-    InputTypedReturnPort* get_typedReturnGuarded_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnSync[portNum]
-    InputTypedReturnPort* get_typedReturnSync_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedSync[portNum]
-    InputTypedPort* get_typedSync_InputPort(
+    Ports::InputTypedPort* get_typedSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -363,13 +363,13 @@ class QueuedTestComponentBase :
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnOut[portNum]
     void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
 #if FW_PORT_SERIALIZATION
@@ -751,7 +751,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -763,7 +763,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -775,7 +775,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -787,7 +787,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -799,7 +799,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -811,7 +811,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -823,7 +823,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -835,7 +835,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -880,7 +880,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -892,7 +892,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -904,7 +904,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -916,7 +916,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -928,7 +928,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -940,7 +940,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -952,7 +952,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -964,7 +964,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -991,7 +991,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1003,7 +1003,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1015,7 +1015,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1027,7 +1027,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1045,7 +1045,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1057,7 +1057,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1850,7 +1850,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1863,7 +1863,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1876,7 +1876,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1889,7 +1889,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1902,7 +1902,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1915,7 +1915,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1928,7 +1928,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1941,7 +1941,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -2047,43 +2047,43 @@ class QueuedTestComponentBase :
     // ----------------------------------------------------------------------
 
     //! Input port noArgsAsync
-    InputNoArgsPort m_noArgsAsync_InputPort[NUM_NOARGSASYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsAsync_InputPort[NUM_NOARGSASYNC_INPUT_PORTS];
 
     //! Input port noArgsGuarded
-    InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnGuarded
-    InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnSync
-    InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
 
     //! Input port noArgsSync
-    InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedAsync
-    InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];
 
     //! Input port typedAsyncAssert
-    InputTypedPort m_typedAsyncAssert_InputPort[NUM_TYPEDASYNCASSERT_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncAssert_InputPort[NUM_TYPEDASYNCASSERT_INPUT_PORTS];
 
     //! Input port typedAsyncBlockPriority
-    InputTypedPort m_typedAsyncBlockPriority_InputPort[NUM_TYPEDASYNCBLOCKPRIORITY_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncBlockPriority_InputPort[NUM_TYPEDASYNCBLOCKPRIORITY_INPUT_PORTS];
 
     //! Input port typedAsyncDropPriority
-    InputTypedPort m_typedAsyncDropPriority_InputPort[NUM_TYPEDASYNCDROPPRIORITY_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncDropPriority_InputPort[NUM_TYPEDASYNCDROPPRIORITY_INPUT_PORTS];
 
     //! Input port typedGuarded
-    InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
+    Ports::InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnGuarded
-    InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnSync
-    InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
 
     //! Input port typedSync
-    InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
 
   PRIVATE:
 
@@ -2126,10 +2126,10 @@ class QueuedTestComponentBase :
     // ----------------------------------------------------------------------
 
     //! Output port typedOut
-    OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
+    Ports::OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
 
     //! Output port typedReturnOut
-    OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
+    Ports::OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
 
   PRIVATE:
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/TypedPortAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/TypedPortAc.ref.cpp
@@ -8,317 +8,321 @@
 #include "Fw/Types/StringUtils.hpp"
 #include "base/TypedPortAc.hpp"
 
-namespace TypedPortStrings {
+namespace Ports {
 
-  // ----------------------------------------------------------------------
-  // StringSize80 class
-  // ----------------------------------------------------------------------
+  namespace TypedPortStrings {
 
-  StringSize80 ::
-    StringSize80() :
-      StringBase()
-  {
-    this->m_buf[0] = 0;
-  }
+    // ----------------------------------------------------------------------
+    // StringSize80 class
+    // ----------------------------------------------------------------------
 
-  StringSize80 ::
-    StringSize80(const char* src) :
-      StringBase()
-  {
-    Fw::StringUtils::string_copy(this->m_buf, src, sizeof(this->m_buf));
-  }
+    StringSize80 ::
+      StringSize80() :
+        StringBase()
+    {
+      this->m_buf[0] = 0;
+    }
 
-  StringSize80 ::
-    StringSize80(const Fw::StringBase& src) :
-      StringBase()
-  {
-    Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
-  }
+    StringSize80 ::
+      StringSize80(const char* src) :
+        StringBase()
+    {
+      Fw::StringUtils::string_copy(this->m_buf, src, sizeof(this->m_buf));
+    }
 
-  StringSize80 ::
-    StringSize80(const StringSize80& src) :
-      StringBase()
-  {
-    Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
-  }
+    StringSize80 ::
+      StringSize80(const Fw::StringBase& src) :
+        StringBase()
+    {
+      Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
+    }
 
-  StringSize80 ::
-    ~StringSize80()
-  {
+    StringSize80 ::
+      StringSize80(const StringSize80& src) :
+        StringBase()
+    {
+      Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
+    }
 
-  }
+    StringSize80 ::
+      ~StringSize80()
+    {
 
-  StringSize80& StringSize80 ::
-    operator=(const StringSize80& other)
-  {
-    if (this == &other) {
+    }
+
+    StringSize80& StringSize80 ::
+      operator=(const StringSize80& other)
+    {
+      if (this == &other) {
+        return *this;
+      }
+
+      Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
       return *this;
     }
 
-    Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
-    return *this;
-  }
+    StringSize80& StringSize80 ::
+      operator=(const Fw::StringBase& other)
+    {
+      if (this == &other) {
+        return *this;
+      }
 
-  StringSize80& StringSize80 ::
-    operator=(const Fw::StringBase& other)
-  {
-    if (this == &other) {
+      Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
       return *this;
     }
 
-    Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
-    return *this;
+    StringSize80& StringSize80 ::
+      operator=(const char* other)
+    {
+      Fw::StringUtils::string_copy(this->m_buf, other, sizeof(this->m_buf));
+      return *this;
+    }
+
+    const char* StringSize80 ::
+      toChar() const
+    {
+      return this->m_buf;
+    }
+
+    NATIVE_UINT_TYPE StringSize80 ::
+      getCapacity() const
+    {
+      return sizeof(this->m_buf);
+    }
+
   }
 
-  StringSize80& StringSize80 ::
-    operator=(const char* other)
-  {
-    Fw::StringUtils::string_copy(this->m_buf, other, sizeof(this->m_buf));
-    return *this;
+  namespace {
+
+    // ----------------------------------------------------------------------
+    // Port buffer class
+    // ----------------------------------------------------------------------
+
+    class TypedPortBuffer : public Fw::SerializeBufferBase {
+
+      public:
+
+        NATIVE_UINT_TYPE getBuffCapacity() const {
+          return InputTypedPort::SERIALIZED_SIZE;
+        }
+
+        U8* getBuffAddr() {
+          return m_buff;
+        }
+
+        const U8* getBuffAddr() const {
+          return m_buff;
+        }
+
+      private:
+
+        U8 m_buff[InputTypedPort::SERIALIZED_SIZE];
+
+    };
+
   }
-
-  const char* StringSize80 ::
-    toChar() const
-  {
-    return this->m_buf;
-  }
-
-  NATIVE_UINT_TYPE StringSize80 ::
-    getCapacity() const
-  {
-    return sizeof(this->m_buf);
-  }
-
-}
-
-namespace {
 
   // ----------------------------------------------------------------------
-  // Port buffer class
+  // Input Port Member functions
   // ----------------------------------------------------------------------
 
-  class TypedPortBuffer : public Fw::SerializeBufferBase {
+  InputTypedPort ::
+    InputTypedPort() :
+      Fw::InputPortBase(),
+      m_func(nullptr)
+  {
 
-    public:
+  }
 
-      NATIVE_UINT_TYPE getBuffCapacity() const {
-        return InputTypedPort::SERIALIZED_SIZE;
-      }
+  void InputTypedPort ::
+    init()
+  {
+    Fw::InputPortBase::init();
+  }
 
-      U8* getBuffAddr() {
-        return m_buff;
-      }
+  void InputTypedPort ::
+    addCallComp(
+        Fw::PassiveComponentBase* callComp,
+        CompFuncPtr funcPtr
+    )
+  {
+    FW_ASSERT(callComp != nullptr);
+    FW_ASSERT(funcPtr != nullptr);
 
-      const U8* getBuffAddr() const {
-        return m_buff;
-      }
+    this->m_comp = callComp;
+    this->m_func = funcPtr;
+    this->m_connObj = callComp;
+  }
 
-    private:
-
-      U8 m_buff[InputTypedPort::SERIALIZED_SIZE];
-
-  };
-
-}
-
-// ----------------------------------------------------------------------
-// Input Port Member functions
-// ----------------------------------------------------------------------
-
-InputTypedPort ::
-  InputTypedPort() :
-    Fw::InputPortBase(),
-    m_func(nullptr)
-{
-
-}
-
-void InputTypedPort ::
-  init()
-{
-  Fw::InputPortBase::init();
-}
-
-void InputTypedPort ::
-  addCallComp(
-      Fw::PassiveComponentBase* callComp,
-      CompFuncPtr funcPtr
-  )
-{
-  FW_ASSERT(callComp != nullptr);
-  FW_ASSERT(funcPtr != nullptr);
-
-  this->m_comp = callComp;
-  this->m_func = funcPtr;
-  this->m_connObj = callComp;
-}
-
-void InputTypedPort ::
-  invoke(
-      U32 u32,
-      F32 f32,
-      bool b,
-      const TypedPortStrings::StringSize80& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
+  void InputTypedPort ::
+    invoke(
+        U32 u32,
+        F32 f32,
+        bool b,
+        const TypedPortStrings::StringSize80& str1,
+        const E& e,
+        const A& a,
+        const S& s
+    )
+  {
 #if FW_PORT_TRACING == 1
-  this->trace();
+    this->trace();
 #endif
 
-  FW_ASSERT(this->m_comp != nullptr);
-  FW_ASSERT(this->m_func != nullptr);
+    FW_ASSERT(this->m_comp != nullptr);
+    FW_ASSERT(this->m_func != nullptr);
 
-  return this->m_func(this->m_comp, this->m_portNum, u32, f32, b, str1, e, a, s);
-}
+    return this->m_func(this->m_comp, this->m_portNum, u32, f32, b, str1, e, a, s);
+  }
 
 #if FW_PORT_SERIALIZATION == 1
 
-Fw::SerializeStatus InputTypedPort ::
-  invokeSerial(Fw::SerializeBufferBase& _buffer)
-{
-  Fw::SerializeStatus _status;
+  Fw::SerializeStatus InputTypedPort ::
+    invokeSerial(Fw::SerializeBufferBase& _buffer)
+  {
+    Fw::SerializeStatus _status;
 
 #if FW_PORT_TRACING == 1
-  this->trace();
+    this->trace();
 #endif
 
-  FW_ASSERT(this->m_comp != nullptr);
-  FW_ASSERT(this->m_func != nullptr);
+    FW_ASSERT(this->m_comp != nullptr);
+    FW_ASSERT(this->m_func != nullptr);
 
-  U32 u32;
-  _status = _buffer.deserialize(u32);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    return _status;
+    U32 u32;
+    _status = _buffer.deserialize(u32);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+      return _status;
+    }
+
+    F32 f32;
+    _status = _buffer.deserialize(f32);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+      return _status;
+    }
+
+    bool b;
+    _status = _buffer.deserialize(b);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+      return _status;
+    }
+
+    TypedPortStrings::StringSize80 str1;
+    _status = _buffer.deserialize(str1);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+      return _status;
+    }
+
+    E e;
+    _status = _buffer.deserialize(e);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+      return _status;
+    }
+
+    A a;
+    _status = _buffer.deserialize(a);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+      return _status;
+    }
+
+    S s;
+    _status = _buffer.deserialize(s);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+      return _status;
+    }
+
+    this->m_func(this->m_comp, this->m_portNum, u32, f32, b, str1, e, a, s);
+
+    return Fw::FW_SERIALIZE_OK;
   }
-
-  F32 f32;
-  _status = _buffer.deserialize(f32);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    return _status;
-  }
-
-  bool b;
-  _status = _buffer.deserialize(b);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    return _status;
-  }
-
-  TypedPortStrings::StringSize80 str1;
-  _status = _buffer.deserialize(str1);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    return _status;
-  }
-
-  E e;
-  _status = _buffer.deserialize(e);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    return _status;
-  }
-
-  A a;
-  _status = _buffer.deserialize(a);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    return _status;
-  }
-
-  S s;
-  _status = _buffer.deserialize(s);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    return _status;
-  }
-
-  this->m_func(this->m_comp, this->m_portNum, u32, f32, b, str1, e, a, s);
-
-  return Fw::FW_SERIALIZE_OK;
-}
 
 #endif
 
-// ----------------------------------------------------------------------
-// Output Port Member functions
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Output Port Member functions
+  // ----------------------------------------------------------------------
 
-OutputTypedPort ::
-  OutputTypedPort() :
-    Fw::OutputPortBase(),
-    m_port(nullptr)
-{
+  OutputTypedPort ::
+    OutputTypedPort() :
+      Fw::OutputPortBase(),
+      m_port(nullptr)
+  {
 
-}
+  }
 
-void OutputTypedPort ::
-  init()
-{
-  Fw::OutputPortBase::init();
-}
+  void OutputTypedPort ::
+    init()
+  {
+    Fw::OutputPortBase::init();
+  }
 
-void OutputTypedPort ::
-  addCallPort(InputTypedPort* callPort)
-{
-  FW_ASSERT(callPort != nullptr);
+  void OutputTypedPort ::
+    addCallPort(InputTypedPort* callPort)
+  {
+    FW_ASSERT(callPort != nullptr);
 
-  this->m_port = callPort;
-  this->m_connObj = callPort;
+    this->m_port = callPort;
+    this->m_connObj = callPort;
 
 #if FW_PORT_SERIALIZATION == 1
-  this->m_serPort = nullptr;
+    this->m_serPort = nullptr;
 #endif
-}
+  }
 
-void OutputTypedPort ::
-  invoke(
-      U32 u32,
-      F32 f32,
-      bool b,
-      const TypedPortStrings::StringSize80& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
+  void OutputTypedPort ::
+    invoke(
+        U32 u32,
+        F32 f32,
+        bool b,
+        const TypedPortStrings::StringSize80& str1,
+        const E& e,
+        const A& a,
+        const S& s
+    )
+  {
 #if FW_PORT_TRACING == 1
-  this->trace();
+    this->trace();
 #endif
 
 #if FW_PORT_SERIALIZATION
-  FW_ASSERT((this->m_port != nullptr) || (this->m_serPort != nullptr));
+    FW_ASSERT((this->m_port != nullptr) || (this->m_serPort != nullptr));
 
-  if (this->m_port != nullptr) {
-    this->m_port->invoke(u32, f32, b, str1, e, a, s);
-  }
-  else {
-    Fw::SerializeStatus _status;
-    TypedPortBuffer _buffer;
+    if (this->m_port != nullptr) {
+      this->m_port->invoke(u32, f32, b, str1, e, a, s);
+    }
+    else {
+      Fw::SerializeStatus _status;
+      TypedPortBuffer _buffer;
 
-    _status = _buffer.serialize(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+      _status = _buffer.serialize(u32);
+      FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-    _status = _buffer.serialize(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+      _status = _buffer.serialize(f32);
+      FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-    _status = _buffer.serialize(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+      _status = _buffer.serialize(b);
+      FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-    _status = _buffer.serialize(str1);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+      _status = _buffer.serialize(str1);
+      FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-    _status = _buffer.serialize(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+      _status = _buffer.serialize(e);
+      FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-    _status = _buffer.serialize(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+      _status = _buffer.serialize(a);
+      FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-    _status = _buffer.serialize(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+      _status = _buffer.serialize(s);
+      FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-    _status = this->m_serPort->invokeSerial(_buffer);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-  }
+      _status = this->m_serPort->invokeSerial(_buffer);
+      FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    }
 #else
-  FW_ASSERT(this->m_port != nullptr);
-  this->m_port->invoke(u32, f32, b, str1, e, a, s);
+    FW_ASSERT(this->m_port != nullptr);
+    this->m_port->invoke(u32, f32, b, str1, e, a, s);
 #endif
+  }
+
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/TypedPortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/TypedPortAc.ref.hpp
@@ -4,8 +4,8 @@
 // \brief  hpp file for Typed port
 // ======================================================================
 
-#ifndef TypedPortAc_HPP
-#define TypedPortAc_HPP
+#ifndef Ports_TypedPortAc_HPP
+#define Ports_TypedPortAc_HPP
 
 #include <cstdio>
 #include <cstring>
@@ -20,201 +20,205 @@
 #include "Fw/Types/StringType.hpp"
 #include "SSerializableAc.hpp"
 
-namespace TypedPortStrings {
+namespace Ports {
+
+  namespace TypedPortStrings {
+
+    // ----------------------------------------------------------------------
+    // StringSize80 class
+    // ----------------------------------------------------------------------
+
+    class StringSize80 :
+      public Fw::StringBase
+    {
+
+      public:
+
+        enum {
+          //! The size of the string length plus the size of the string buffer
+          SERIALIZED_SIZE = sizeof(FwBuffSizeType) + 80
+        };
+
+        //! Default constructor
+        StringSize80();
+
+        //! Char array constructor
+        StringSize80(const char* src);
+
+        //! String base constructor
+        StringSize80(const Fw::StringBase& src);
+
+        //! Copy constructor
+        StringSize80(const StringSize80& src);
+
+        //! Destructor
+        ~StringSize80();
+
+        //! Copy assignment operator
+        StringSize80& operator=(const StringSize80& other);
+
+        //! String base assignment operator
+        StringSize80& operator=(const Fw::StringBase& other);
+
+        //! char* assignment operator
+        StringSize80& operator=(const char* other);
+
+        //! Retrieves char buffer of string
+        const char* toChar() const;
+
+        NATIVE_UINT_TYPE getCapacity() const;
+
+      private:
+
+        char m_buf[80]; //!< Buffer for string storage
+
+    };
+
+  }
 
   // ----------------------------------------------------------------------
-  // StringSize80 class
+  // String types for backwards compatibility
   // ----------------------------------------------------------------------
 
-  class StringSize80 :
-    public Fw::StringBase
+  typedef TypedPortStrings::StringSize80 str1String;
+
+  //! Input Typed port
+  //! A typed port
+  class InputTypedPort :
+    public Fw::InputPortBase
   {
 
     public:
 
+      // ----------------------------------------------------------------------
+      // Constants
+      // ----------------------------------------------------------------------
+
       enum {
-        //! The size of the string length plus the size of the string buffer
-        SERIALIZED_SIZE = sizeof(FwBuffSizeType) + 80
+        //! The size of the serial representations of the port arguments
+        SERIALIZED_SIZE =
+          sizeof(U32) +
+          sizeof(F32) +
+          sizeof(U8) +
+          TypedPortStrings::StringSize80::SERIALIZED_SIZE +
+          E::SERIALIZED_SIZE +
+          A::SERIALIZED_SIZE +
+          S::SERIALIZED_SIZE
       };
 
-      //! Default constructor
-      StringSize80();
+    public:
 
-      //! Char array constructor
-      StringSize80(const char* src);
+      // ----------------------------------------------------------------------
+      // Types
+      // ----------------------------------------------------------------------
 
-      //! String base constructor
-      StringSize80(const Fw::StringBase& src);
+      //! The port callback function type
+      typedef void (*CompFuncPtr)(
+        Fw::PassiveComponentBase* callComp,
+        NATIVE_INT_TYPE portNum,
+        U32 u32,
+        F32 f32,
+        bool b,
+        const TypedPortStrings::StringSize80& str1,
+        const E& e,
+        const A& a,
+        const S& s
+      );
 
-      //! Copy constructor
-      StringSize80(const StringSize80& src);
+    public:
 
-      //! Destructor
-      ~StringSize80();
+      // ----------------------------------------------------------------------
+      // Input Port Member functions
+      // ----------------------------------------------------------------------
 
-      //! Copy assignment operator
-      StringSize80& operator=(const StringSize80& other);
+      //! Constructor
+      InputTypedPort();
 
-      //! String base assignment operator
-      StringSize80& operator=(const Fw::StringBase& other);
+      //! Initialization function
+      void init();
 
-      //! char* assignment operator
-      StringSize80& operator=(const char* other);
+      //! Register a component
+      void addCallComp(
+          Fw::PassiveComponentBase* callComp, //!< The containing component
+          CompFuncPtr funcPtr //!< The port callback function
+      );
 
-      //! Retrieves char buffer of string
-      const char* toChar() const;
-
-      NATIVE_UINT_TYPE getCapacity() const;
+      //! Invoke a port interface
+      void invoke(
+          U32 u32, //!< A U32
+          F32 f32, //!< An F32
+          bool b, //!< A boolean
+          const TypedPortStrings::StringSize80& str1, //!< A string
+          const E& e, //!< An enum
+          const A& a, //!< An array
+          const S& s //!< A struct
+      );
 
     private:
 
-      char m_buf[80]; //!< Buffer for string storage
+#if FW_PORT_SERIALIZATION == 1
+
+      //! Invoke the port with serialized arguments
+      Fw::SerializeStatus invokeSerial(Fw::SerializeBufferBase& _buffer);
+
+#endif
+
+    private:
+
+      // ----------------------------------------------------------------------
+      // Member variables
+      // ----------------------------------------------------------------------
+
+      //! The pointer to the port callback function
+      CompFuncPtr m_func;
+
+  };
+
+  //! Output Typed port
+  //! A typed port
+  class OutputTypedPort :
+    public Fw::OutputPortBase
+  {
+
+    public:
+
+      // ----------------------------------------------------------------------
+      // Output Port Member functions
+      // ----------------------------------------------------------------------
+
+      //! Constructor
+      OutputTypedPort();
+
+      //! Initialization function
+      void init();
+
+      //! Register an input port
+      void addCallPort(
+          InputTypedPort* callPort //!< The input port
+      );
+
+      //! Invoke a port interface
+      void invoke(
+          U32 u32, //!< A U32
+          F32 f32, //!< An F32
+          bool b, //!< A boolean
+          const TypedPortStrings::StringSize80& str1, //!< A string
+          const E& e, //!< An enum
+          const A& a, //!< An array
+          const S& s //!< A struct
+      );
+
+    private:
+
+      // ----------------------------------------------------------------------
+      // Member variables
+      // ----------------------------------------------------------------------
+
+      //! The pointer to the input port
+      InputTypedPort* m_port;
 
   };
 
 }
-
-// ----------------------------------------------------------------------
-// String types for backwards compatibility
-// ----------------------------------------------------------------------
-
-typedef TypedPortStrings::StringSize80 str1String;
-
-//! Input Typed port
-//! A typed port
-class InputTypedPort :
-  public Fw::InputPortBase
-{
-
-  public:
-
-    // ----------------------------------------------------------------------
-    // Constants
-    // ----------------------------------------------------------------------
-
-    enum {
-      //! The size of the serial representations of the port arguments
-      SERIALIZED_SIZE =
-        sizeof(U32) +
-        sizeof(F32) +
-        sizeof(U8) +
-        TypedPortStrings::StringSize80::SERIALIZED_SIZE +
-        E::SERIALIZED_SIZE +
-        A::SERIALIZED_SIZE +
-        S::SERIALIZED_SIZE
-    };
-
-  public:
-
-    // ----------------------------------------------------------------------
-    // Types
-    // ----------------------------------------------------------------------
-
-    //! The port callback function type
-    typedef void (*CompFuncPtr)(
-      Fw::PassiveComponentBase* callComp,
-      NATIVE_INT_TYPE portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const TypedPortStrings::StringSize80& str1,
-      const E& e,
-      const A& a,
-      const S& s
-    );
-
-  public:
-
-    // ----------------------------------------------------------------------
-    // Input Port Member functions
-    // ----------------------------------------------------------------------
-
-    //! Constructor
-    InputTypedPort();
-
-    //! Initialization function
-    void init();
-
-    //! Register a component
-    void addCallComp(
-        Fw::PassiveComponentBase* callComp, //!< The containing component
-        CompFuncPtr funcPtr //!< The port callback function
-    );
-
-    //! Invoke a port interface
-    void invoke(
-        U32 u32, //!< A U32
-        F32 f32, //!< An F32
-        bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
-        const E& e, //!< An enum
-        const A& a, //!< An array
-        const S& s //!< A struct
-    );
-
-  private:
-
-#if FW_PORT_SERIALIZATION == 1
-
-    //! Invoke the port with serialized arguments
-    Fw::SerializeStatus invokeSerial(Fw::SerializeBufferBase& _buffer);
-
-#endif
-
-  private:
-
-    // ----------------------------------------------------------------------
-    // Member variables
-    // ----------------------------------------------------------------------
-
-    //! The pointer to the port callback function
-    CompFuncPtr m_func;
-
-};
-
-//! Output Typed port
-//! A typed port
-class OutputTypedPort :
-  public Fw::OutputPortBase
-{
-
-  public:
-
-    // ----------------------------------------------------------------------
-    // Output Port Member functions
-    // ----------------------------------------------------------------------
-
-    //! Constructor
-    OutputTypedPort();
-
-    //! Initialization function
-    void init();
-
-    //! Register an input port
-    void addCallPort(
-        InputTypedPort* callPort //!< The input port
-    );
-
-    //! Invoke a port interface
-    void invoke(
-        U32 u32, //!< A U32
-        F32 f32, //!< An F32
-        bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
-        const E& e, //!< An enum
-        const A& a, //!< An array
-        const S& s //!< A struct
-    );
-
-  private:
-
-    // ----------------------------------------------------------------------
-    // Member variables
-    // ----------------------------------------------------------------------
-
-    //! The pointer to the input port
-    InputTypedPort* m_port;
-
-};
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/component/base/TypedReturnPortAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/TypedReturnPortAc.ref.cpp
@@ -8,202 +8,206 @@
 #include "Fw/Types/StringUtils.hpp"
 #include "base/TypedReturnPortAc.hpp"
 
-namespace TypedReturnPortStrings {
+namespace Ports {
 
-  // ----------------------------------------------------------------------
-  // StringSize80 class
-  // ----------------------------------------------------------------------
+  namespace TypedReturnPortStrings {
 
-  StringSize80 ::
-    StringSize80() :
-      StringBase()
-  {
-    this->m_buf[0] = 0;
-  }
+    // ----------------------------------------------------------------------
+    // StringSize80 class
+    // ----------------------------------------------------------------------
 
-  StringSize80 ::
-    StringSize80(const char* src) :
-      StringBase()
-  {
-    Fw::StringUtils::string_copy(this->m_buf, src, sizeof(this->m_buf));
-  }
+    StringSize80 ::
+      StringSize80() :
+        StringBase()
+    {
+      this->m_buf[0] = 0;
+    }
 
-  StringSize80 ::
-    StringSize80(const Fw::StringBase& src) :
-      StringBase()
-  {
-    Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
-  }
+    StringSize80 ::
+      StringSize80(const char* src) :
+        StringBase()
+    {
+      Fw::StringUtils::string_copy(this->m_buf, src, sizeof(this->m_buf));
+    }
 
-  StringSize80 ::
-    StringSize80(const StringSize80& src) :
-      StringBase()
-  {
-    Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
-  }
+    StringSize80 ::
+      StringSize80(const Fw::StringBase& src) :
+        StringBase()
+    {
+      Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
+    }
 
-  StringSize80 ::
-    ~StringSize80()
-  {
+    StringSize80 ::
+      StringSize80(const StringSize80& src) :
+        StringBase()
+    {
+      Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
+    }
 
-  }
+    StringSize80 ::
+      ~StringSize80()
+    {
 
-  StringSize80& StringSize80 ::
-    operator=(const StringSize80& other)
-  {
-    if (this == &other) {
+    }
+
+    StringSize80& StringSize80 ::
+      operator=(const StringSize80& other)
+    {
+      if (this == &other) {
+        return *this;
+      }
+
+      Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
       return *this;
     }
 
-    Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
-    return *this;
-  }
+    StringSize80& StringSize80 ::
+      operator=(const Fw::StringBase& other)
+    {
+      if (this == &other) {
+        return *this;
+      }
 
-  StringSize80& StringSize80 ::
-    operator=(const Fw::StringBase& other)
-  {
-    if (this == &other) {
+      Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
       return *this;
     }
 
-    Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
-    return *this;
+    StringSize80& StringSize80 ::
+      operator=(const char* other)
+    {
+      Fw::StringUtils::string_copy(this->m_buf, other, sizeof(this->m_buf));
+      return *this;
+    }
+
+    const char* StringSize80 ::
+      toChar() const
+    {
+      return this->m_buf;
+    }
+
+    NATIVE_UINT_TYPE StringSize80 ::
+      getCapacity() const
+    {
+      return sizeof(this->m_buf);
+    }
+
   }
 
-  StringSize80& StringSize80 ::
-    operator=(const char* other)
+  // ----------------------------------------------------------------------
+  // Input Port Member functions
+  // ----------------------------------------------------------------------
+
+  InputTypedReturnPort ::
+    InputTypedReturnPort() :
+      Fw::InputPortBase(),
+      m_func(nullptr)
   {
-    Fw::StringUtils::string_copy(this->m_buf, other, sizeof(this->m_buf));
-    return *this;
+
   }
 
-  const char* StringSize80 ::
-    toChar() const
+  void InputTypedReturnPort ::
+    init()
   {
-    return this->m_buf;
+    Fw::InputPortBase::init();
   }
 
-  NATIVE_UINT_TYPE StringSize80 ::
-    getCapacity() const
+  void InputTypedReturnPort ::
+    addCallComp(
+        Fw::PassiveComponentBase* callComp,
+        CompFuncPtr funcPtr
+    )
   {
-    return sizeof(this->m_buf);
+    FW_ASSERT(callComp != nullptr);
+    FW_ASSERT(funcPtr != nullptr);
+
+    this->m_comp = callComp;
+    this->m_func = funcPtr;
+    this->m_connObj = callComp;
   }
 
-}
-
-// ----------------------------------------------------------------------
-// Input Port Member functions
-// ----------------------------------------------------------------------
-
-InputTypedReturnPort ::
-  InputTypedReturnPort() :
-    Fw::InputPortBase(),
-    m_func(nullptr)
-{
-
-}
-
-void InputTypedReturnPort ::
-  init()
-{
-  Fw::InputPortBase::init();
-}
-
-void InputTypedReturnPort ::
-  addCallComp(
-      Fw::PassiveComponentBase* callComp,
-      CompFuncPtr funcPtr
-  )
-{
-  FW_ASSERT(callComp != nullptr);
-  FW_ASSERT(funcPtr != nullptr);
-
-  this->m_comp = callComp;
-  this->m_func = funcPtr;
-  this->m_connObj = callComp;
-}
-
-F32 InputTypedReturnPort ::
-  invoke(
-      U32 u32,
-      F32 f32,
-      bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
+  F32 InputTypedReturnPort ::
+    invoke(
+        U32 u32,
+        F32 f32,
+        bool b,
+        const TypedReturnPortStrings::StringSize80& str2,
+        const E& e,
+        const A& a,
+        const S& s
+    )
+  {
 #if FW_PORT_TRACING == 1
-  this->trace();
+    this->trace();
 #endif
 
-  FW_ASSERT(this->m_comp != nullptr);
-  FW_ASSERT(this->m_func != nullptr);
+    FW_ASSERT(this->m_comp != nullptr);
+    FW_ASSERT(this->m_func != nullptr);
 
-  return this->m_func(this->m_comp, this->m_portNum, u32, f32, b, str2, e, a, s);
-}
+    return this->m_func(this->m_comp, this->m_portNum, u32, f32, b, str2, e, a, s);
+  }
 
 #if FW_PORT_SERIALIZATION == 1
 
-Fw::SerializeStatus InputTypedReturnPort ::
-  invokeSerial(Fw::SerializeBufferBase& _buffer)
-{
-  // For ports with a return type, invokeSerial is not used
-  (void) _buffer;
+  Fw::SerializeStatus InputTypedReturnPort ::
+    invokeSerial(Fw::SerializeBufferBase& _buffer)
+  {
+    // For ports with a return type, invokeSerial is not used
+    (void) _buffer;
 
-  FW_ASSERT(0);
-  return Fw::FW_SERIALIZE_OK;
-}
+    FW_ASSERT(0);
+    return Fw::FW_SERIALIZE_OK;
+  }
 
 #endif
 
-// ----------------------------------------------------------------------
-// Output Port Member functions
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Output Port Member functions
+  // ----------------------------------------------------------------------
 
-OutputTypedReturnPort ::
-  OutputTypedReturnPort() :
-    Fw::OutputPortBase(),
-    m_port(nullptr)
-{
+  OutputTypedReturnPort ::
+    OutputTypedReturnPort() :
+      Fw::OutputPortBase(),
+      m_port(nullptr)
+  {
 
-}
+  }
 
-void OutputTypedReturnPort ::
-  init()
-{
-  Fw::OutputPortBase::init();
-}
+  void OutputTypedReturnPort ::
+    init()
+  {
+    Fw::OutputPortBase::init();
+  }
 
-void OutputTypedReturnPort ::
-  addCallPort(InputTypedReturnPort* callPort)
-{
-  FW_ASSERT(callPort != nullptr);
+  void OutputTypedReturnPort ::
+    addCallPort(InputTypedReturnPort* callPort)
+  {
+    FW_ASSERT(callPort != nullptr);
 
-  this->m_port = callPort;
-  this->m_connObj = callPort;
+    this->m_port = callPort;
+    this->m_connObj = callPort;
 
 #if FW_PORT_SERIALIZATION == 1
-  this->m_serPort = nullptr;
+    this->m_serPort = nullptr;
 #endif
-}
+  }
 
-F32 OutputTypedReturnPort ::
-  invoke(
-      U32 u32,
-      F32 f32,
-      bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
+  F32 OutputTypedReturnPort ::
+    invoke(
+        U32 u32,
+        F32 f32,
+        bool b,
+        const TypedReturnPortStrings::StringSize80& str2,
+        const E& e,
+        const A& a,
+        const S& s
+    )
+  {
 #if FW_PORT_TRACING == 1
-  this->trace();
+    this->trace();
 #endif
 
-  FW_ASSERT(this->m_port != nullptr);
-  return this->m_port->invoke(u32, f32, b, str2, e, a, s);
+    FW_ASSERT(this->m_port != nullptr);
+    return this->m_port->invoke(u32, f32, b, str2, e, a, s);
+  }
+
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/TypedReturnPortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/TypedReturnPortAc.ref.hpp
@@ -4,8 +4,8 @@
 // \brief  hpp file for TypedReturn port
 // ======================================================================
 
-#ifndef TypedReturnPortAc_HPP
-#define TypedReturnPortAc_HPP
+#ifndef Ports_TypedReturnPortAc_HPP
+#define Ports_TypedReturnPortAc_HPP
 
 #include <cstdio>
 #include <cstring>
@@ -19,201 +19,205 @@
 #include "Fw/Types/StringType.hpp"
 #include "SSerializableAc.hpp"
 
-namespace TypedReturnPortStrings {
+namespace Ports {
+
+  namespace TypedReturnPortStrings {
+
+    // ----------------------------------------------------------------------
+    // StringSize80 class
+    // ----------------------------------------------------------------------
+
+    class StringSize80 :
+      public Fw::StringBase
+    {
+
+      public:
+
+        enum {
+          //! The size of the string length plus the size of the string buffer
+          SERIALIZED_SIZE = sizeof(FwBuffSizeType) + 80
+        };
+
+        //! Default constructor
+        StringSize80();
+
+        //! Char array constructor
+        StringSize80(const char* src);
+
+        //! String base constructor
+        StringSize80(const Fw::StringBase& src);
+
+        //! Copy constructor
+        StringSize80(const StringSize80& src);
+
+        //! Destructor
+        ~StringSize80();
+
+        //! Copy assignment operator
+        StringSize80& operator=(const StringSize80& other);
+
+        //! String base assignment operator
+        StringSize80& operator=(const Fw::StringBase& other);
+
+        //! char* assignment operator
+        StringSize80& operator=(const char* other);
+
+        //! Retrieves char buffer of string
+        const char* toChar() const;
+
+        NATIVE_UINT_TYPE getCapacity() const;
+
+      private:
+
+        char m_buf[80]; //!< Buffer for string storage
+
+    };
+
+  }
 
   // ----------------------------------------------------------------------
-  // StringSize80 class
+  // String types for backwards compatibility
   // ----------------------------------------------------------------------
 
-  class StringSize80 :
-    public Fw::StringBase
+  typedef TypedReturnPortStrings::StringSize80 str2String;
+
+  //! Input TypedReturn port
+  //! A typed port with a return type
+  class InputTypedReturnPort :
+    public Fw::InputPortBase
   {
 
     public:
 
+      // ----------------------------------------------------------------------
+      // Constants
+      // ----------------------------------------------------------------------
+
       enum {
-        //! The size of the string length plus the size of the string buffer
-        SERIALIZED_SIZE = sizeof(FwBuffSizeType) + 80
+        //! The size of the serial representations of the port arguments
+        SERIALIZED_SIZE =
+          sizeof(U32) +
+          sizeof(F32) +
+          sizeof(U8) +
+          TypedReturnPortStrings::StringSize80::SERIALIZED_SIZE +
+          E::SERIALIZED_SIZE +
+          A::SERIALIZED_SIZE +
+          S::SERIALIZED_SIZE
       };
 
-      //! Default constructor
-      StringSize80();
+    public:
 
-      //! Char array constructor
-      StringSize80(const char* src);
+      // ----------------------------------------------------------------------
+      // Types
+      // ----------------------------------------------------------------------
 
-      //! String base constructor
-      StringSize80(const Fw::StringBase& src);
+      //! The port callback function type
+      typedef F32 (*CompFuncPtr)(
+        Fw::PassiveComponentBase* callComp,
+        NATIVE_INT_TYPE portNum,
+        U32 u32,
+        F32 f32,
+        bool b,
+        const TypedReturnPortStrings::StringSize80& str2,
+        const E& e,
+        const A& a,
+        const S& s
+      );
 
-      //! Copy constructor
-      StringSize80(const StringSize80& src);
+    public:
 
-      //! Destructor
-      ~StringSize80();
+      // ----------------------------------------------------------------------
+      // Input Port Member functions
+      // ----------------------------------------------------------------------
 
-      //! Copy assignment operator
-      StringSize80& operator=(const StringSize80& other);
+      //! Constructor
+      InputTypedReturnPort();
 
-      //! String base assignment operator
-      StringSize80& operator=(const Fw::StringBase& other);
+      //! Initialization function
+      void init();
 
-      //! char* assignment operator
-      StringSize80& operator=(const char* other);
+      //! Register a component
+      void addCallComp(
+          Fw::PassiveComponentBase* callComp, //!< The containing component
+          CompFuncPtr funcPtr //!< The port callback function
+      );
 
-      //! Retrieves char buffer of string
-      const char* toChar() const;
-
-      NATIVE_UINT_TYPE getCapacity() const;
+      //! Invoke a port interface
+      F32 invoke(
+          U32 u32, //!< A U32
+          F32 f32, //!< An F32
+          bool b, //!< A boolean
+          const TypedReturnPortStrings::StringSize80& str2, //!< A string
+          const E& e, //!< An enum
+          const A& a, //!< An array
+          const S& s //!< A struct
+      );
 
     private:
 
-      char m_buf[80]; //!< Buffer for string storage
+#if FW_PORT_SERIALIZATION == 1
+
+      //! Invoke the port with serialized arguments
+      Fw::SerializeStatus invokeSerial(Fw::SerializeBufferBase& _buffer);
+
+#endif
+
+    private:
+
+      // ----------------------------------------------------------------------
+      // Member variables
+      // ----------------------------------------------------------------------
+
+      //! The pointer to the port callback function
+      CompFuncPtr m_func;
+
+  };
+
+  //! Output TypedReturn port
+  //! A typed port with a return type
+  class OutputTypedReturnPort :
+    public Fw::OutputPortBase
+  {
+
+    public:
+
+      // ----------------------------------------------------------------------
+      // Output Port Member functions
+      // ----------------------------------------------------------------------
+
+      //! Constructor
+      OutputTypedReturnPort();
+
+      //! Initialization function
+      void init();
+
+      //! Register an input port
+      void addCallPort(
+          InputTypedReturnPort* callPort //!< The input port
+      );
+
+      //! Invoke a port interface
+      F32 invoke(
+          U32 u32, //!< A U32
+          F32 f32, //!< An F32
+          bool b, //!< A boolean
+          const TypedReturnPortStrings::StringSize80& str2, //!< A string
+          const E& e, //!< An enum
+          const A& a, //!< An array
+          const S& s //!< A struct
+      );
+
+    private:
+
+      // ----------------------------------------------------------------------
+      // Member variables
+      // ----------------------------------------------------------------------
+
+      //! The pointer to the input port
+      InputTypedReturnPort* m_port;
 
   };
 
 }
-
-// ----------------------------------------------------------------------
-// String types for backwards compatibility
-// ----------------------------------------------------------------------
-
-typedef TypedReturnPortStrings::StringSize80 str2String;
-
-//! Input TypedReturn port
-//! A typed port with a return type
-class InputTypedReturnPort :
-  public Fw::InputPortBase
-{
-
-  public:
-
-    // ----------------------------------------------------------------------
-    // Constants
-    // ----------------------------------------------------------------------
-
-    enum {
-      //! The size of the serial representations of the port arguments
-      SERIALIZED_SIZE =
-        sizeof(U32) +
-        sizeof(F32) +
-        sizeof(U8) +
-        TypedReturnPortStrings::StringSize80::SERIALIZED_SIZE +
-        E::SERIALIZED_SIZE +
-        A::SERIALIZED_SIZE +
-        S::SERIALIZED_SIZE
-    };
-
-  public:
-
-    // ----------------------------------------------------------------------
-    // Types
-    // ----------------------------------------------------------------------
-
-    //! The port callback function type
-    typedef F32 (*CompFuncPtr)(
-      Fw::PassiveComponentBase* callComp,
-      NATIVE_INT_TYPE portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
-      const E& e,
-      const A& a,
-      const S& s
-    );
-
-  public:
-
-    // ----------------------------------------------------------------------
-    // Input Port Member functions
-    // ----------------------------------------------------------------------
-
-    //! Constructor
-    InputTypedReturnPort();
-
-    //! Initialization function
-    void init();
-
-    //! Register a component
-    void addCallComp(
-        Fw::PassiveComponentBase* callComp, //!< The containing component
-        CompFuncPtr funcPtr //!< The port callback function
-    );
-
-    //! Invoke a port interface
-    F32 invoke(
-        U32 u32, //!< A U32
-        F32 f32, //!< An F32
-        bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
-        const E& e, //!< An enum
-        const A& a, //!< An array
-        const S& s //!< A struct
-    );
-
-  private:
-
-#if FW_PORT_SERIALIZATION == 1
-
-    //! Invoke the port with serialized arguments
-    Fw::SerializeStatus invokeSerial(Fw::SerializeBufferBase& _buffer);
-
-#endif
-
-  private:
-
-    // ----------------------------------------------------------------------
-    // Member variables
-    // ----------------------------------------------------------------------
-
-    //! The pointer to the port callback function
-    CompFuncPtr m_func;
-
-};
-
-//! Output TypedReturn port
-//! A typed port with a return type
-class OutputTypedReturnPort :
-  public Fw::OutputPortBase
-{
-
-  public:
-
-    // ----------------------------------------------------------------------
-    // Output Port Member functions
-    // ----------------------------------------------------------------------
-
-    //! Constructor
-    OutputTypedReturnPort();
-
-    //! Initialization function
-    void init();
-
-    //! Register an input port
-    void addCallPort(
-        InputTypedReturnPort* callPort //!< The input port
-    );
-
-    //! Invoke a port interface
-    F32 invoke(
-        U32 u32, //!< A U32
-        F32 f32, //!< An F32
-        bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
-        const E& e, //!< An enum
-        const A& a, //!< An array
-        const S& s //!< A struct
-    );
-
-  private:
-
-    // ----------------------------------------------------------------------
-    // Member variables
-    // ----------------------------------------------------------------------
-
-    //! The pointer to the input port
-    InputTypedReturnPort* m_port;
-
-};
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/component/impl/ActiveCommands.template.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/impl/ActiveCommands.template.ref.cpp
@@ -64,7 +64,7 @@ void ActiveCommands ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -79,7 +79,7 @@ void ActiveCommands ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -94,7 +94,7 @@ void ActiveCommands ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -109,7 +109,7 @@ void ActiveCommands ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -124,7 +124,7 @@ void ActiveCommands ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -139,7 +139,7 @@ F32 ActiveCommands ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -154,7 +154,7 @@ F32 ActiveCommands ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -169,7 +169,7 @@ void ActiveCommands ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/impl/ActiveCommands.template.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/impl/ActiveCommands.template.ref.hpp
@@ -76,7 +76,7 @@ class ActiveCommands :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -90,7 +90,7 @@ class ActiveCommands :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -104,7 +104,7 @@ class ActiveCommands :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -118,7 +118,7 @@ class ActiveCommands :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -132,7 +132,7 @@ class ActiveCommands :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -146,7 +146,7 @@ class ActiveCommands :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -160,7 +160,7 @@ class ActiveCommands :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -174,7 +174,7 @@ class ActiveCommands :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct

--- a/compiler/tools/fpp-to-cpp/test/component/impl/ActiveEvents.template.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/impl/ActiveEvents.template.ref.cpp
@@ -64,7 +64,7 @@ void ActiveEvents ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -79,7 +79,7 @@ void ActiveEvents ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -94,7 +94,7 @@ void ActiveEvents ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -109,7 +109,7 @@ void ActiveEvents ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -124,7 +124,7 @@ void ActiveEvents ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -139,7 +139,7 @@ F32 ActiveEvents ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -154,7 +154,7 @@ F32 ActiveEvents ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -169,7 +169,7 @@ void ActiveEvents ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/impl/ActiveEvents.template.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/impl/ActiveEvents.template.ref.hpp
@@ -76,7 +76,7 @@ class ActiveEvents :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -90,7 +90,7 @@ class ActiveEvents :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -104,7 +104,7 @@ class ActiveEvents :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -118,7 +118,7 @@ class ActiveEvents :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -132,7 +132,7 @@ class ActiveEvents :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -146,7 +146,7 @@ class ActiveEvents :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -160,7 +160,7 @@ class ActiveEvents :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -174,7 +174,7 @@ class ActiveEvents :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct

--- a/compiler/tools/fpp-to-cpp/test/component/impl/ActiveParams.template.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/impl/ActiveParams.template.ref.cpp
@@ -64,7 +64,7 @@ void ActiveParams ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -79,7 +79,7 @@ void ActiveParams ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -94,7 +94,7 @@ void ActiveParams ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -109,7 +109,7 @@ void ActiveParams ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -124,7 +124,7 @@ void ActiveParams ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -139,7 +139,7 @@ F32 ActiveParams ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -154,7 +154,7 @@ F32 ActiveParams ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -169,7 +169,7 @@ void ActiveParams ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/impl/ActiveParams.template.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/impl/ActiveParams.template.ref.hpp
@@ -76,7 +76,7 @@ class ActiveParams :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -90,7 +90,7 @@ class ActiveParams :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -104,7 +104,7 @@ class ActiveParams :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -118,7 +118,7 @@ class ActiveParams :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -132,7 +132,7 @@ class ActiveParams :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -146,7 +146,7 @@ class ActiveParams :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -160,7 +160,7 @@ class ActiveParams :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -174,7 +174,7 @@ class ActiveParams :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct

--- a/compiler/tools/fpp-to-cpp/test/component/impl/ActiveSerial.template.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/impl/ActiveSerial.template.ref.cpp
@@ -64,7 +64,7 @@ void ActiveSerial ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -79,7 +79,7 @@ void ActiveSerial ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -94,7 +94,7 @@ void ActiveSerial ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -109,7 +109,7 @@ void ActiveSerial ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -124,7 +124,7 @@ void ActiveSerial ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -139,7 +139,7 @@ F32 ActiveSerial ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -154,7 +154,7 @@ F32 ActiveSerial ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -169,7 +169,7 @@ void ActiveSerial ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/impl/ActiveSerial.template.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/impl/ActiveSerial.template.ref.hpp
@@ -76,7 +76,7 @@ class ActiveSerial :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -90,7 +90,7 @@ class ActiveSerial :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -104,7 +104,7 @@ class ActiveSerial :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -118,7 +118,7 @@ class ActiveSerial :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -132,7 +132,7 @@ class ActiveSerial :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -146,7 +146,7 @@ class ActiveSerial :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -160,7 +160,7 @@ class ActiveSerial :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -174,7 +174,7 @@ class ActiveSerial :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct

--- a/compiler/tools/fpp-to-cpp/test/component/impl/ActiveTelemetry.template.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/impl/ActiveTelemetry.template.ref.cpp
@@ -64,7 +64,7 @@ void ActiveTelemetry ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -79,7 +79,7 @@ void ActiveTelemetry ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -94,7 +94,7 @@ void ActiveTelemetry ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -109,7 +109,7 @@ void ActiveTelemetry ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -124,7 +124,7 @@ void ActiveTelemetry ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -139,7 +139,7 @@ F32 ActiveTelemetry ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -154,7 +154,7 @@ F32 ActiveTelemetry ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -169,7 +169,7 @@ void ActiveTelemetry ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/impl/ActiveTelemetry.template.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/impl/ActiveTelemetry.template.ref.hpp
@@ -76,7 +76,7 @@ class ActiveTelemetry :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -90,7 +90,7 @@ class ActiveTelemetry :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -104,7 +104,7 @@ class ActiveTelemetry :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -118,7 +118,7 @@ class ActiveTelemetry :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -132,7 +132,7 @@ class ActiveTelemetry :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -146,7 +146,7 @@ class ActiveTelemetry :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -160,7 +160,7 @@ class ActiveTelemetry :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -174,7 +174,7 @@ class ActiveTelemetry :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct

--- a/compiler/tools/fpp-to-cpp/test/component/impl/ActiveTest.template.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/impl/ActiveTest.template.ref.cpp
@@ -66,7 +66,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s
@@ -81,7 +81,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s
@@ -96,7 +96,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s
@@ -111,7 +111,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s
@@ -126,7 +126,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s
@@ -141,7 +141,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedReturnPortStrings::StringSize80& str2,
+        const Ports::TypedReturnPortStrings::StringSize80& str2,
         const E& e,
         const A& a,
         const S& s
@@ -156,7 +156,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedReturnPortStrings::StringSize80& str2,
+        const Ports::TypedReturnPortStrings::StringSize80& str2,
         const E& e,
         const A& a,
         const S& s
@@ -171,7 +171,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/impl/ActiveTest.template.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/impl/ActiveTest.template.ref.hpp
@@ -78,7 +78,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -92,7 +92,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -106,7 +106,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -120,7 +120,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -134,7 +134,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -148,7 +148,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedReturnPortStrings::StringSize80& str2, //!< A string
+          const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -162,7 +162,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedReturnPortStrings::StringSize80& str2, //!< A string
+          const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -176,7 +176,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct

--- a/compiler/tools/fpp-to-cpp/test/component/impl/PassiveCommands.template.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/impl/PassiveCommands.template.ref.cpp
@@ -58,7 +58,7 @@ void PassiveCommands ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -73,7 +73,7 @@ F32 PassiveCommands ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -88,7 +88,7 @@ F32 PassiveCommands ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -103,7 +103,7 @@ void PassiveCommands ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/impl/PassiveCommands.template.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/impl/PassiveCommands.template.ref.hpp
@@ -69,7 +69,7 @@ class PassiveCommands :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -83,7 +83,7 @@ class PassiveCommands :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -97,7 +97,7 @@ class PassiveCommands :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -111,7 +111,7 @@ class PassiveCommands :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct

--- a/compiler/tools/fpp-to-cpp/test/component/impl/PassiveEvents.template.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/impl/PassiveEvents.template.ref.cpp
@@ -58,7 +58,7 @@ void PassiveEvents ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -73,7 +73,7 @@ F32 PassiveEvents ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -88,7 +88,7 @@ F32 PassiveEvents ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -103,7 +103,7 @@ void PassiveEvents ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/impl/PassiveEvents.template.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/impl/PassiveEvents.template.ref.hpp
@@ -69,7 +69,7 @@ class PassiveEvents :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -83,7 +83,7 @@ class PassiveEvents :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -97,7 +97,7 @@ class PassiveEvents :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -111,7 +111,7 @@ class PassiveEvents :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct

--- a/compiler/tools/fpp-to-cpp/test/component/impl/PassiveParams.template.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/impl/PassiveParams.template.ref.cpp
@@ -58,7 +58,7 @@ void PassiveParams ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -73,7 +73,7 @@ F32 PassiveParams ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -88,7 +88,7 @@ F32 PassiveParams ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -103,7 +103,7 @@ void PassiveParams ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/impl/PassiveParams.template.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/impl/PassiveParams.template.ref.hpp
@@ -69,7 +69,7 @@ class PassiveParams :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -83,7 +83,7 @@ class PassiveParams :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -97,7 +97,7 @@ class PassiveParams :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -111,7 +111,7 @@ class PassiveParams :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct

--- a/compiler/tools/fpp-to-cpp/test/component/impl/PassiveSerial.template.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/impl/PassiveSerial.template.ref.cpp
@@ -58,7 +58,7 @@ void PassiveSerial ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -73,7 +73,7 @@ F32 PassiveSerial ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -88,7 +88,7 @@ F32 PassiveSerial ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -103,7 +103,7 @@ void PassiveSerial ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/impl/PassiveSerial.template.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/impl/PassiveSerial.template.ref.hpp
@@ -69,7 +69,7 @@ class PassiveSerial :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -83,7 +83,7 @@ class PassiveSerial :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -97,7 +97,7 @@ class PassiveSerial :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -111,7 +111,7 @@ class PassiveSerial :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct

--- a/compiler/tools/fpp-to-cpp/test/component/impl/PassiveTelemetry.template.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/impl/PassiveTelemetry.template.ref.cpp
@@ -58,7 +58,7 @@ void PassiveTelemetry ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -73,7 +73,7 @@ F32 PassiveTelemetry ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -88,7 +88,7 @@ F32 PassiveTelemetry ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -103,7 +103,7 @@ void PassiveTelemetry ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/impl/PassiveTelemetry.template.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/impl/PassiveTelemetry.template.ref.hpp
@@ -69,7 +69,7 @@ class PassiveTelemetry :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -83,7 +83,7 @@ class PassiveTelemetry :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -97,7 +97,7 @@ class PassiveTelemetry :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -111,7 +111,7 @@ class PassiveTelemetry :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct

--- a/compiler/tools/fpp-to-cpp/test/component/impl/PassiveTest.template.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/impl/PassiveTest.template.ref.cpp
@@ -58,7 +58,7 @@ void PassiveTest ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -73,7 +73,7 @@ F32 PassiveTest ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -88,7 +88,7 @@ F32 PassiveTest ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -103,7 +103,7 @@ void PassiveTest ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/impl/PassiveTest.template.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/impl/PassiveTest.template.ref.hpp
@@ -69,7 +69,7 @@ class PassiveTest :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -83,7 +83,7 @@ class PassiveTest :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -97,7 +97,7 @@ class PassiveTest :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -111,7 +111,7 @@ class PassiveTest :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct

--- a/compiler/tools/fpp-to-cpp/test/component/impl/QueuedCommands.template.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/impl/QueuedCommands.template.ref.cpp
@@ -64,7 +64,7 @@ void QueuedCommands ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -79,7 +79,7 @@ void QueuedCommands ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -94,7 +94,7 @@ void QueuedCommands ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -109,7 +109,7 @@ void QueuedCommands ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -124,7 +124,7 @@ void QueuedCommands ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -139,7 +139,7 @@ F32 QueuedCommands ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -154,7 +154,7 @@ F32 QueuedCommands ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -169,7 +169,7 @@ void QueuedCommands ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/impl/QueuedCommands.template.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/impl/QueuedCommands.template.ref.hpp
@@ -76,7 +76,7 @@ class QueuedCommands :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -90,7 +90,7 @@ class QueuedCommands :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -104,7 +104,7 @@ class QueuedCommands :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -118,7 +118,7 @@ class QueuedCommands :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -132,7 +132,7 @@ class QueuedCommands :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -146,7 +146,7 @@ class QueuedCommands :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -160,7 +160,7 @@ class QueuedCommands :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -174,7 +174,7 @@ class QueuedCommands :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct

--- a/compiler/tools/fpp-to-cpp/test/component/impl/QueuedEvents.template.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/impl/QueuedEvents.template.ref.cpp
@@ -64,7 +64,7 @@ void QueuedEvents ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -79,7 +79,7 @@ void QueuedEvents ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -94,7 +94,7 @@ void QueuedEvents ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -109,7 +109,7 @@ void QueuedEvents ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -124,7 +124,7 @@ void QueuedEvents ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -139,7 +139,7 @@ F32 QueuedEvents ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -154,7 +154,7 @@ F32 QueuedEvents ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -169,7 +169,7 @@ void QueuedEvents ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/impl/QueuedEvents.template.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/impl/QueuedEvents.template.ref.hpp
@@ -76,7 +76,7 @@ class QueuedEvents :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -90,7 +90,7 @@ class QueuedEvents :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -104,7 +104,7 @@ class QueuedEvents :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -118,7 +118,7 @@ class QueuedEvents :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -132,7 +132,7 @@ class QueuedEvents :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -146,7 +146,7 @@ class QueuedEvents :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -160,7 +160,7 @@ class QueuedEvents :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -174,7 +174,7 @@ class QueuedEvents :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct

--- a/compiler/tools/fpp-to-cpp/test/component/impl/QueuedParams.template.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/impl/QueuedParams.template.ref.cpp
@@ -64,7 +64,7 @@ void QueuedParams ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -79,7 +79,7 @@ void QueuedParams ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -94,7 +94,7 @@ void QueuedParams ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -109,7 +109,7 @@ void QueuedParams ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -124,7 +124,7 @@ void QueuedParams ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -139,7 +139,7 @@ F32 QueuedParams ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -154,7 +154,7 @@ F32 QueuedParams ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -169,7 +169,7 @@ void QueuedParams ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/impl/QueuedParams.template.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/impl/QueuedParams.template.ref.hpp
@@ -76,7 +76,7 @@ class QueuedParams :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -90,7 +90,7 @@ class QueuedParams :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -104,7 +104,7 @@ class QueuedParams :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -118,7 +118,7 @@ class QueuedParams :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -132,7 +132,7 @@ class QueuedParams :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -146,7 +146,7 @@ class QueuedParams :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -160,7 +160,7 @@ class QueuedParams :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -174,7 +174,7 @@ class QueuedParams :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct

--- a/compiler/tools/fpp-to-cpp/test/component/impl/QueuedSerial.template.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/impl/QueuedSerial.template.ref.cpp
@@ -64,7 +64,7 @@ void QueuedSerial ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -79,7 +79,7 @@ void QueuedSerial ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -94,7 +94,7 @@ void QueuedSerial ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -109,7 +109,7 @@ void QueuedSerial ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -124,7 +124,7 @@ void QueuedSerial ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -139,7 +139,7 @@ F32 QueuedSerial ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -154,7 +154,7 @@ F32 QueuedSerial ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -169,7 +169,7 @@ void QueuedSerial ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/impl/QueuedSerial.template.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/impl/QueuedSerial.template.ref.hpp
@@ -76,7 +76,7 @@ class QueuedSerial :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -90,7 +90,7 @@ class QueuedSerial :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -104,7 +104,7 @@ class QueuedSerial :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -118,7 +118,7 @@ class QueuedSerial :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -132,7 +132,7 @@ class QueuedSerial :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -146,7 +146,7 @@ class QueuedSerial :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -160,7 +160,7 @@ class QueuedSerial :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -174,7 +174,7 @@ class QueuedSerial :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct

--- a/compiler/tools/fpp-to-cpp/test/component/impl/QueuedTelemetry.template.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/impl/QueuedTelemetry.template.ref.cpp
@@ -64,7 +64,7 @@ void QueuedTelemetry ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -79,7 +79,7 @@ void QueuedTelemetry ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -94,7 +94,7 @@ void QueuedTelemetry ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -109,7 +109,7 @@ void QueuedTelemetry ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -124,7 +124,7 @@ void QueuedTelemetry ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -139,7 +139,7 @@ F32 QueuedTelemetry ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -154,7 +154,7 @@ F32 QueuedTelemetry ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -169,7 +169,7 @@ void QueuedTelemetry ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/impl/QueuedTelemetry.template.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/impl/QueuedTelemetry.template.ref.hpp
@@ -76,7 +76,7 @@ class QueuedTelemetry :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -90,7 +90,7 @@ class QueuedTelemetry :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -104,7 +104,7 @@ class QueuedTelemetry :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -118,7 +118,7 @@ class QueuedTelemetry :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -132,7 +132,7 @@ class QueuedTelemetry :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -146,7 +146,7 @@ class QueuedTelemetry :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -160,7 +160,7 @@ class QueuedTelemetry :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -174,7 +174,7 @@ class QueuedTelemetry :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct

--- a/compiler/tools/fpp-to-cpp/test/component/impl/QueuedTest.template.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/impl/QueuedTest.template.ref.cpp
@@ -64,7 +64,7 @@ void QueuedTest ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -79,7 +79,7 @@ void QueuedTest ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -94,7 +94,7 @@ void QueuedTest ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -109,7 +109,7 @@ void QueuedTest ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -124,7 +124,7 @@ void QueuedTest ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -139,7 +139,7 @@ F32 QueuedTest ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -154,7 +154,7 @@ F32 QueuedTest ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -169,7 +169,7 @@ void QueuedTest ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/impl/QueuedTest.template.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/impl/QueuedTest.template.ref.hpp
@@ -76,7 +76,7 @@ class QueuedTest :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -90,7 +90,7 @@ class QueuedTest :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -104,7 +104,7 @@ class QueuedTest :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -118,7 +118,7 @@ class QueuedTest :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -132,7 +132,7 @@ class QueuedTest :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -146,7 +146,7 @@ class QueuedTest :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -160,7 +160,7 @@ class QueuedTest :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -174,7 +174,7 @@ class QueuedTest :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct

--- a/compiler/tools/fpp-to-cpp/test/component/include/typed_ports.fppi
+++ b/compiler/tools/fpp-to-cpp/test/component/include/typed_ports.fppi
@@ -3,31 +3,31 @@
 # ----------------------------------------------------------------------
 
 @ A typed sync input port
-sync input port noArgsSync: [3] NoArgs
+sync input port noArgsSync: [3] Ports.NoArgs
 
 @ A typed guarded input
-guarded input port noArgsGuarded: NoArgs
+guarded input port noArgsGuarded: Ports.NoArgs
 
 @ A typed sync input port
-sync input port noArgsReturnSync: [3] NoArgsReturn
+sync input port noArgsReturnSync: [3] Ports.NoArgsReturn
 
 @ A typed guarded input
-guarded input port noArgsReturnGuarded: NoArgsReturn
+guarded input port noArgsReturnGuarded: Ports.NoArgsReturn
 
 @ A typed sync input port
-sync input port typedSync: [3] Typed
+sync input port typedSync: [3] Ports.Typed
 
 @ A typed guarded input
-guarded input port typedGuarded: Typed
+guarded input port typedGuarded: Ports.Typed
 
 @ A typed sync input port with a return type
-sync input port typedReturnSync: [3] TypedReturn
+sync input port typedReturnSync: [3] Ports.TypedReturn
 
 @ A typed guarded input with a return type
-guarded input port typedReturnGuarded: TypedReturn
+guarded input port typedReturnGuarded: Ports.TypedReturn
 
 @ A typed output port
-output port typedOut: Typed
+output port typedOut: Ports.Typed
 
 @ A typed output port with a return type
-output port typedReturnOut: TypedReturn
+output port typedReturnOut: Ports.TypedReturn

--- a/compiler/tools/fpp-to-cpp/test/component/include/typed_ports_async.fppi
+++ b/compiler/tools/fpp-to-cpp/test/component/include/typed_ports_async.fppi
@@ -1,14 +1,14 @@
 @ A typed async input port
-async input port noArgsAsync: NoArgs
+async input port noArgsAsync: Ports.NoArgs
 
 @ A typed async input port
-async input port typedAsync: Typed
+async input port typedAsync: Ports.Typed
 
 @ A typed async input port with queue full behavior and priority
-async input port typedAsyncAssert: Typed assert
+async input port typedAsyncAssert: Ports.Typed assert
 
 @ A typed async input port with queue full behavior and priority
-async input port typedAsyncBlockPriority: Typed priority 10 block
+async input port typedAsyncBlockPriority: Ports.Typed priority 10 block
 
 @ A typed async input port with queue full behavior and priority
-async input port typedAsyncDropPriority: Typed priority 5 drop
+async input port typedAsyncDropPriority: Ports.Typed priority 5 drop

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveCommandsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveCommandsComponentAc.ref.cpp
@@ -29,11 +29,11 @@ namespace {
 
   // Get the max size by doing a union of the input and internal port serialization sizes
   union BuffUnion {
-    BYTE noArgsAsyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsGuardedPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnGuardedPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnSyncPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsSyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsAsyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsGuardedPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
     BYTE typedAsyncPortSize[InputTypedPort::SERIALIZED_SIZE];
     BYTE typedAsyncAssertPortSize[InputTypedPort::SERIALIZED_SIZE];
     BYTE typedAsyncBlockPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
@@ -698,7 +698,7 @@ Fw::InputCmdPort* ActiveCommandsComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-InputNoArgsPort* ActiveCommandsComponentBase ::
+Ports::InputNoArgsPort* ActiveCommandsComponentBase ::
   get_noArgsAsync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -709,7 +709,7 @@ InputNoArgsPort* ActiveCommandsComponentBase ::
   return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-InputNoArgsPort* ActiveCommandsComponentBase ::
+Ports::InputNoArgsPort* ActiveCommandsComponentBase ::
   get_noArgsGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -720,7 +720,7 @@ InputNoArgsPort* ActiveCommandsComponentBase ::
   return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* ActiveCommandsComponentBase ::
+Ports::InputNoArgsReturnPort* ActiveCommandsComponentBase ::
   get_noArgsReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -731,7 +731,7 @@ InputNoArgsReturnPort* ActiveCommandsComponentBase ::
   return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* ActiveCommandsComponentBase ::
+Ports::InputNoArgsReturnPort* ActiveCommandsComponentBase ::
   get_noArgsReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -742,7 +742,7 @@ InputNoArgsReturnPort* ActiveCommandsComponentBase ::
   return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-InputNoArgsPort* ActiveCommandsComponentBase ::
+Ports::InputNoArgsPort* ActiveCommandsComponentBase ::
   get_noArgsSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveCommandsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveCommandsComponentAc.ref.cpp
@@ -34,14 +34,14 @@ namespace {
     BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
     BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
     BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE typedAsyncPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncAssertPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncBlockPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncDropPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedGuardedPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedReturnGuardedPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedReturnSyncPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedSyncPortSize[InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncAssertPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncBlockPriorityPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncDropPriorityPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedGuardedPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedReturnGuardedPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedReturnSyncPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedSyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
     BYTE cmdPortSize[Fw::InputCmdPort::SERIALIZED_SIZE];
   };
 
@@ -753,7 +753,7 @@ Ports::InputNoArgsPort* ActiveCommandsComponentBase ::
   return &this->m_noArgsSync_InputPort[portNum];
 }
 
-InputTypedPort* ActiveCommandsComponentBase ::
+Ports::InputTypedPort* ActiveCommandsComponentBase ::
   get_typedAsync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -764,7 +764,7 @@ InputTypedPort* ActiveCommandsComponentBase ::
   return &this->m_typedAsync_InputPort[portNum];
 }
 
-InputTypedPort* ActiveCommandsComponentBase ::
+Ports::InputTypedPort* ActiveCommandsComponentBase ::
   get_typedAsyncAssert_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -775,7 +775,7 @@ InputTypedPort* ActiveCommandsComponentBase ::
   return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-InputTypedPort* ActiveCommandsComponentBase ::
+Ports::InputTypedPort* ActiveCommandsComponentBase ::
   get_typedAsyncBlockPriority_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -786,7 +786,7 @@ InputTypedPort* ActiveCommandsComponentBase ::
   return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-InputTypedPort* ActiveCommandsComponentBase ::
+Ports::InputTypedPort* ActiveCommandsComponentBase ::
   get_typedAsyncDropPriority_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -797,7 +797,7 @@ InputTypedPort* ActiveCommandsComponentBase ::
   return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-InputTypedPort* ActiveCommandsComponentBase ::
+Ports::InputTypedPort* ActiveCommandsComponentBase ::
   get_typedGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -808,7 +808,7 @@ InputTypedPort* ActiveCommandsComponentBase ::
   return &this->m_typedGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* ActiveCommandsComponentBase ::
+Ports::InputTypedReturnPort* ActiveCommandsComponentBase ::
   get_typedReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -819,7 +819,7 @@ InputTypedReturnPort* ActiveCommandsComponentBase ::
   return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* ActiveCommandsComponentBase ::
+Ports::InputTypedReturnPort* ActiveCommandsComponentBase ::
   get_typedReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -830,7 +830,7 @@ InputTypedReturnPort* ActiveCommandsComponentBase ::
   return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-InputTypedPort* ActiveCommandsComponentBase ::
+Ports::InputTypedPort* ActiveCommandsComponentBase ::
   get_typedSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -968,7 +968,7 @@ void ActiveCommandsComponentBase ::
 void ActiveCommandsComponentBase ::
   set_typedOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -982,7 +982,7 @@ void ActiveCommandsComponentBase ::
 void ActiveCommandsComponentBase ::
   set_typedReturnOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -1630,7 +1630,7 @@ void ActiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1737,7 +1737,7 @@ void ActiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1844,7 +1844,7 @@ void ActiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1951,7 +1951,7 @@ void ActiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2063,7 +2063,7 @@ void ActiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2100,7 +2100,7 @@ F32 ActiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2141,7 +2141,7 @@ F32 ActiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2176,7 +2176,7 @@ void ActiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2221,7 +2221,7 @@ void ActiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2236,7 +2236,7 @@ void ActiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2251,7 +2251,7 @@ void ActiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2266,7 +2266,7 @@ void ActiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2285,7 +2285,7 @@ void ActiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2312,7 +2312,7 @@ F32 ActiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -3455,7 +3455,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -3527,7 +3527,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -3599,7 +3599,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -3671,7 +3671,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveCommandsComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -4236,7 +4236,7 @@ void ActiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -4263,7 +4263,7 @@ void ActiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -4290,7 +4290,7 @@ void ActiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -4317,7 +4317,7 @@ void ActiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -4344,7 +4344,7 @@ void ActiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -4371,7 +4371,7 @@ F32 ActiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -4398,7 +4398,7 @@ F32 ActiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -4425,7 +4425,7 @@ void ActiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveCommandsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveCommandsComponentAc.ref.hpp
@@ -148,35 +148,35 @@ class ActiveCommandsComponentBase :
     //! Get typed input port at index
     //!
     //! \return noArgsAsync[portNum]
-    InputNoArgsPort* get_noArgsAsync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsAsync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsGuarded[portNum]
-    InputNoArgsPort* get_noArgsGuarded_InputPort(
+    Ports::InputNoArgsPort* get_noArgsGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnGuarded[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnSync[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsSync[portNum]
-    InputNoArgsPort* get_noArgsSync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -1572,19 +1572,19 @@ class ActiveCommandsComponentBase :
     // ----------------------------------------------------------------------
 
     //! Input port noArgsAsync
-    InputNoArgsPort m_noArgsAsync_InputPort[NUM_NOARGSASYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsAsync_InputPort[NUM_NOARGSASYNC_INPUT_PORTS];
 
     //! Input port noArgsGuarded
-    InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnGuarded
-    InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnSync
-    InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
 
     //! Input port noArgsSync
-    InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedAsync
     InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveCommandsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveCommandsComponentAc.ref.hpp
@@ -183,56 +183,56 @@ class ActiveCommandsComponentBase :
     //! Get typed input port at index
     //!
     //! \return typedAsync[portNum]
-    InputTypedPort* get_typedAsync_InputPort(
+    Ports::InputTypedPort* get_typedAsync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncAssert[portNum]
-    InputTypedPort* get_typedAsyncAssert_InputPort(
+    Ports::InputTypedPort* get_typedAsyncAssert_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncBlockPriority[portNum]
-    InputTypedPort* get_typedAsyncBlockPriority_InputPort(
+    Ports::InputTypedPort* get_typedAsyncBlockPriority_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncDropPriority[portNum]
-    InputTypedPort* get_typedAsyncDropPriority_InputPort(
+    Ports::InputTypedPort* get_typedAsyncDropPriority_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedGuarded[portNum]
-    InputTypedPort* get_typedGuarded_InputPort(
+    Ports::InputTypedPort* get_typedGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnGuarded[portNum]
-    InputTypedReturnPort* get_typedReturnGuarded_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnSync[portNum]
-    InputTypedReturnPort* get_typedReturnSync_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedSync[portNum]
-    InputTypedPort* get_typedSync_InputPort(
+    Ports::InputTypedPort* get_typedSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -303,13 +303,13 @@ class ActiveCommandsComponentBase :
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnOut[portNum]
     void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
 #if FW_PORT_SERIALIZATION
@@ -680,7 +680,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -692,7 +692,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -704,7 +704,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -716,7 +716,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -728,7 +728,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -740,7 +740,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -752,7 +752,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -764,7 +764,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -809,7 +809,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -821,7 +821,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -833,7 +833,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -845,7 +845,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -857,7 +857,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -869,7 +869,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -881,7 +881,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -893,7 +893,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -920,7 +920,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -932,7 +932,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -944,7 +944,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -956,7 +956,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -974,7 +974,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -986,7 +986,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1459,7 +1459,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1472,7 +1472,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1485,7 +1485,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1498,7 +1498,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1511,7 +1511,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1524,7 +1524,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1537,7 +1537,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1550,7 +1550,7 @@ class ActiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1587,28 +1587,28 @@ class ActiveCommandsComponentBase :
     Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedAsync
-    InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];
 
     //! Input port typedAsyncAssert
-    InputTypedPort m_typedAsyncAssert_InputPort[NUM_TYPEDASYNCASSERT_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncAssert_InputPort[NUM_TYPEDASYNCASSERT_INPUT_PORTS];
 
     //! Input port typedAsyncBlockPriority
-    InputTypedPort m_typedAsyncBlockPriority_InputPort[NUM_TYPEDASYNCBLOCKPRIORITY_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncBlockPriority_InputPort[NUM_TYPEDASYNCBLOCKPRIORITY_INPUT_PORTS];
 
     //! Input port typedAsyncDropPriority
-    InputTypedPort m_typedAsyncDropPriority_InputPort[NUM_TYPEDASYNCDROPPRIORITY_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncDropPriority_InputPort[NUM_TYPEDASYNCDROPPRIORITY_INPUT_PORTS];
 
     //! Input port typedGuarded
-    InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
+    Ports::InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnGuarded
-    InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnSync
-    InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
 
     //! Input port typedSync
-    InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
 
   PRIVATE:
 
@@ -1651,10 +1651,10 @@ class ActiveCommandsComponentBase :
     // ----------------------------------------------------------------------
 
     //! Output port typedOut
-    OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
+    Ports::OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
 
     //! Output port typedReturnOut
-    OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
+    Ports::OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
 
   PRIVATE:
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveCommandsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveCommandsTesterBase.ref.cpp
@@ -465,7 +465,7 @@ void ActiveCommandsTesterBase ::
 void ActiveCommandsTesterBase ::
   connect_to_noArgsAsync(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsPort* port
+      Ports::InputNoArgsPort* port
   )
 {
   FW_ASSERT(
@@ -479,7 +479,7 @@ void ActiveCommandsTesterBase ::
 void ActiveCommandsTesterBase ::
   connect_to_noArgsGuarded(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsPort* port
+      Ports::InputNoArgsPort* port
   )
 {
   FW_ASSERT(
@@ -493,7 +493,7 @@ void ActiveCommandsTesterBase ::
 void ActiveCommandsTesterBase ::
   connect_to_noArgsReturnGuarded(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsReturnPort* port
+      Ports::InputNoArgsReturnPort* port
   )
 {
   FW_ASSERT(
@@ -507,7 +507,7 @@ void ActiveCommandsTesterBase ::
 void ActiveCommandsTesterBase ::
   connect_to_noArgsReturnSync(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsReturnPort* port
+      Ports::InputNoArgsReturnPort* port
   )
 {
   FW_ASSERT(
@@ -521,7 +521,7 @@ void ActiveCommandsTesterBase ::
 void ActiveCommandsTesterBase ::
   connect_to_noArgsSync(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsPort* port
+      Ports::InputNoArgsPort* port
   )
 {
   FW_ASSERT(

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveCommandsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveCommandsTesterBase.ref.cpp
@@ -535,7 +535,7 @@ void ActiveCommandsTesterBase ::
 void ActiveCommandsTesterBase ::
   connect_to_typedAsync(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -549,7 +549,7 @@ void ActiveCommandsTesterBase ::
 void ActiveCommandsTesterBase ::
   connect_to_typedAsyncAssert(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -563,7 +563,7 @@ void ActiveCommandsTesterBase ::
 void ActiveCommandsTesterBase ::
   connect_to_typedAsyncBlockPriority(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -577,7 +577,7 @@ void ActiveCommandsTesterBase ::
 void ActiveCommandsTesterBase ::
   connect_to_typedAsyncDropPriority(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -591,7 +591,7 @@ void ActiveCommandsTesterBase ::
 void ActiveCommandsTesterBase ::
   connect_to_typedGuarded(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -605,7 +605,7 @@ void ActiveCommandsTesterBase ::
 void ActiveCommandsTesterBase ::
   connect_to_typedReturnGuarded(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -619,7 +619,7 @@ void ActiveCommandsTesterBase ::
 void ActiveCommandsTesterBase ::
   connect_to_typedReturnSync(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -633,7 +633,7 @@ void ActiveCommandsTesterBase ::
 void ActiveCommandsTesterBase ::
   connect_to_typedSync(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -740,7 +740,7 @@ Fw::InputTlmPort* ActiveCommandsTesterBase ::
   return &this->m_from_tlmOut[portNum];
 }
 
-InputTypedPort* ActiveCommandsTesterBase ::
+Ports::InputTypedPort* ActiveCommandsTesterBase ::
   get_from_typedOut(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -751,7 +751,7 @@ InputTypedPort* ActiveCommandsTesterBase ::
   return &this->m_from_typedOut[portNum];
 }
 
-InputTypedReturnPort* ActiveCommandsTesterBase ::
+Ports::InputTypedReturnPort* ActiveCommandsTesterBase ::
   get_from_typedReturnOut(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -805,7 +805,7 @@ void ActiveCommandsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -834,7 +834,7 @@ F32 ActiveCommandsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -922,7 +922,7 @@ void ActiveCommandsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -950,7 +950,7 @@ void ActiveCommandsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -978,7 +978,7 @@ void ActiveCommandsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1006,7 +1006,7 @@ void ActiveCommandsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1034,7 +1034,7 @@ void ActiveCommandsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1062,7 +1062,7 @@ F32 ActiveCommandsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1090,7 +1090,7 @@ F32 ActiveCommandsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1118,7 +1118,7 @@ void ActiveCommandsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2095,7 +2095,7 @@ void ActiveCommandsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2119,7 +2119,7 @@ void ActiveCommandsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2183,7 +2183,7 @@ void ActiveCommandsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2210,7 +2210,7 @@ F32 ActiveCommandsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveCommandsTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveCommandsTesterBase.ref.hpp
@@ -111,7 +111,7 @@ class ActiveCommandsTesterBase :
       U32 u32;
       F32 f32;
       bool b;
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       E e;
       A a;
       S s;
@@ -122,7 +122,7 @@ class ActiveCommandsTesterBase :
       U32 u32;
       F32 f32;
       bool b;
-      TypedReturnPortStrings::StringSize80 str2;
+      Ports::TypedReturnPortStrings::StringSize80 str2;
       E e;
       A a;
       S s;
@@ -191,49 +191,49 @@ class ActiveCommandsTesterBase :
     //! Connect port to typedAsync[portNum]
     void connect_to_typedAsync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedAsyncAssert[portNum]
     void connect_to_typedAsyncAssert(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedAsyncBlockPriority[portNum]
     void connect_to_typedAsyncBlockPriority(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedAsyncDropPriority[portNum]
     void connect_to_typedAsyncDropPriority(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedGuarded[portNum]
     void connect_to_typedGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnGuarded[portNum]
     void connect_to_typedReturnGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
     //! Connect port to typedReturnSync[portNum]
     void connect_to_typedReturnSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
     //! Connect port to typedSync[portNum]
     void connect_to_typedSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
   public:
@@ -305,14 +305,14 @@ class ActiveCommandsTesterBase :
     //! Get from port at index
     //!
     //! \return from_typedOut[portNum]
-    InputTypedPort* get_from_typedOut(
+    Ports::InputTypedPort* get_from_typedOut(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get from port at index
     //!
     //! \return from_typedReturnOut[portNum]
-    InputTypedReturnPort* get_from_typedReturnOut(
+    Ports::InputTypedReturnPort* get_from_typedReturnOut(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -343,7 +343,7 @@ class ActiveCommandsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -355,7 +355,7 @@ class ActiveCommandsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -373,7 +373,7 @@ class ActiveCommandsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -385,7 +385,7 @@ class ActiveCommandsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -428,7 +428,7 @@ class ActiveCommandsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -440,7 +440,7 @@ class ActiveCommandsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -452,7 +452,7 @@ class ActiveCommandsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -464,7 +464,7 @@ class ActiveCommandsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -476,7 +476,7 @@ class ActiveCommandsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -488,7 +488,7 @@ class ActiveCommandsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -500,7 +500,7 @@ class ActiveCommandsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -512,7 +512,7 @@ class ActiveCommandsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -920,7 +920,7 @@ class ActiveCommandsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -931,7 +931,7 @@ class ActiveCommandsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -973,7 +973,7 @@ class ActiveCommandsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -986,7 +986,7 @@ class ActiveCommandsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1035,28 +1035,28 @@ class ActiveCommandsTesterBase :
     Ports::OutputNoArgsPort m_to_noArgsSync[3];
 
     //! To port connected to typedAsync
-    OutputTypedPort m_to_typedAsync[1];
+    Ports::OutputTypedPort m_to_typedAsync[1];
 
     //! To port connected to typedAsyncAssert
-    OutputTypedPort m_to_typedAsyncAssert[1];
+    Ports::OutputTypedPort m_to_typedAsyncAssert[1];
 
     //! To port connected to typedAsyncBlockPriority
-    OutputTypedPort m_to_typedAsyncBlockPriority[1];
+    Ports::OutputTypedPort m_to_typedAsyncBlockPriority[1];
 
     //! To port connected to typedAsyncDropPriority
-    OutputTypedPort m_to_typedAsyncDropPriority[1];
+    Ports::OutputTypedPort m_to_typedAsyncDropPriority[1];
 
     //! To port connected to typedGuarded
-    OutputTypedPort m_to_typedGuarded[1];
+    Ports::OutputTypedPort m_to_typedGuarded[1];
 
     //! To port connected to typedReturnGuarded
-    OutputTypedReturnPort m_to_typedReturnGuarded[1];
+    Ports::OutputTypedReturnPort m_to_typedReturnGuarded[1];
 
     //! To port connected to typedReturnSync
-    OutputTypedReturnPort m_to_typedReturnSync[3];
+    Ports::OutputTypedReturnPort m_to_typedReturnSync[3];
 
     //! To port connected to typedSync
-    OutputTypedPort m_to_typedSync[3];
+    Ports::OutputTypedPort m_to_typedSync[3];
 
   private:
 
@@ -1093,10 +1093,10 @@ class ActiveCommandsTesterBase :
     Fw::InputTlmPort m_from_tlmOut[1];
 
     //! From port connected to typedOut
-    InputTypedPort m_from_typedOut[1];
+    Ports::InputTypedPort m_from_typedOut[1];
 
     //! From port connected to typedReturnOut
-    InputTypedReturnPort m_from_typedReturnOut[1];
+    Ports::InputTypedReturnPort m_from_typedReturnOut[1];
 
   private:
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveCommandsTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveCommandsTesterBase.ref.hpp
@@ -161,31 +161,31 @@ class ActiveCommandsTesterBase :
     //! Connect port to noArgsAsync[portNum]
     void connect_to_noArgsAsync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsPort* port //!< The input port
+        Ports::InputNoArgsPort* port //!< The input port
     );
 
     //! Connect port to noArgsGuarded[portNum]
     void connect_to_noArgsGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsPort* port //!< The input port
+        Ports::InputNoArgsPort* port //!< The input port
     );
 
     //! Connect port to noArgsReturnGuarded[portNum]
     void connect_to_noArgsReturnGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsReturnPort* port //!< The input port
+        Ports::InputNoArgsReturnPort* port //!< The input port
     );
 
     //! Connect port to noArgsReturnSync[portNum]
     void connect_to_noArgsReturnSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsReturnPort* port //!< The input port
+        Ports::InputNoArgsReturnPort* port //!< The input port
     );
 
     //! Connect port to noArgsSync[portNum]
     void connect_to_noArgsSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsPort* port //!< The input port
+        Ports::InputNoArgsPort* port //!< The input port
     );
 
     //! Connect port to typedAsync[portNum]
@@ -1020,19 +1020,19 @@ class ActiveCommandsTesterBase :
     Fw::OutputCmdPort m_to_cmdIn[1];
 
     //! To port connected to noArgsAsync
-    OutputNoArgsPort m_to_noArgsAsync[1];
+    Ports::OutputNoArgsPort m_to_noArgsAsync[1];
 
     //! To port connected to noArgsGuarded
-    OutputNoArgsPort m_to_noArgsGuarded[1];
+    Ports::OutputNoArgsPort m_to_noArgsGuarded[1];
 
     //! To port connected to noArgsReturnGuarded
-    OutputNoArgsReturnPort m_to_noArgsReturnGuarded[1];
+    Ports::OutputNoArgsReturnPort m_to_noArgsReturnGuarded[1];
 
     //! To port connected to noArgsReturnSync
-    OutputNoArgsReturnPort m_to_noArgsReturnSync[3];
+    Ports::OutputNoArgsReturnPort m_to_noArgsReturnSync[3];
 
     //! To port connected to noArgsSync
-    OutputNoArgsPort m_to_noArgsSync[3];
+    Ports::OutputNoArgsPort m_to_noArgsSync[3];
 
     //! To port connected to typedAsync
     OutputTypedPort m_to_typedAsync[1];

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveEventsComponentAc.ref.cpp
@@ -29,14 +29,14 @@ namespace {
     BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
     BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
     BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE typedAsyncPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncAssertPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncBlockPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncDropPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedGuardedPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedReturnGuardedPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedReturnSyncPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedSyncPortSize[InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncAssertPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncBlockPriorityPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncDropPriorityPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedGuardedPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedReturnGuardedPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedReturnSyncPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedSyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
     BYTE cmdPortSize[Fw::InputCmdPort::SERIALIZED_SIZE];
   };
 
@@ -748,7 +748,7 @@ Ports::InputNoArgsPort* ActiveEventsComponentBase ::
   return &this->m_noArgsSync_InputPort[portNum];
 }
 
-InputTypedPort* ActiveEventsComponentBase ::
+Ports::InputTypedPort* ActiveEventsComponentBase ::
   get_typedAsync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -759,7 +759,7 @@ InputTypedPort* ActiveEventsComponentBase ::
   return &this->m_typedAsync_InputPort[portNum];
 }
 
-InputTypedPort* ActiveEventsComponentBase ::
+Ports::InputTypedPort* ActiveEventsComponentBase ::
   get_typedAsyncAssert_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -770,7 +770,7 @@ InputTypedPort* ActiveEventsComponentBase ::
   return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-InputTypedPort* ActiveEventsComponentBase ::
+Ports::InputTypedPort* ActiveEventsComponentBase ::
   get_typedAsyncBlockPriority_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -781,7 +781,7 @@ InputTypedPort* ActiveEventsComponentBase ::
   return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-InputTypedPort* ActiveEventsComponentBase ::
+Ports::InputTypedPort* ActiveEventsComponentBase ::
   get_typedAsyncDropPriority_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -792,7 +792,7 @@ InputTypedPort* ActiveEventsComponentBase ::
   return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-InputTypedPort* ActiveEventsComponentBase ::
+Ports::InputTypedPort* ActiveEventsComponentBase ::
   get_typedGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -803,7 +803,7 @@ InputTypedPort* ActiveEventsComponentBase ::
   return &this->m_typedGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* ActiveEventsComponentBase ::
+Ports::InputTypedReturnPort* ActiveEventsComponentBase ::
   get_typedReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -814,7 +814,7 @@ InputTypedReturnPort* ActiveEventsComponentBase ::
   return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* ActiveEventsComponentBase ::
+Ports::InputTypedReturnPort* ActiveEventsComponentBase ::
   get_typedReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -825,7 +825,7 @@ InputTypedReturnPort* ActiveEventsComponentBase ::
   return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-InputTypedPort* ActiveEventsComponentBase ::
+Ports::InputTypedPort* ActiveEventsComponentBase ::
   get_typedSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -963,7 +963,7 @@ void ActiveEventsComponentBase ::
 void ActiveEventsComponentBase ::
   set_typedOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -977,7 +977,7 @@ void ActiveEventsComponentBase ::
 void ActiveEventsComponentBase ::
   set_typedReturnOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -1549,7 +1549,7 @@ void ActiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1656,7 +1656,7 @@ void ActiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1763,7 +1763,7 @@ void ActiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1870,7 +1870,7 @@ void ActiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1982,7 +1982,7 @@ void ActiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2019,7 +2019,7 @@ F32 ActiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2060,7 +2060,7 @@ F32 ActiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2095,7 +2095,7 @@ void ActiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2140,7 +2140,7 @@ void ActiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2155,7 +2155,7 @@ void ActiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2170,7 +2170,7 @@ void ActiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2185,7 +2185,7 @@ void ActiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2204,7 +2204,7 @@ void ActiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2231,7 +2231,7 @@ F32 ActiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -3062,7 +3062,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -3134,7 +3134,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -3206,7 +3206,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -3278,7 +3278,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveEventsComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -3415,7 +3415,7 @@ void ActiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3442,7 +3442,7 @@ void ActiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3469,7 +3469,7 @@ void ActiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3496,7 +3496,7 @@ void ActiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3523,7 +3523,7 @@ void ActiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3550,7 +3550,7 @@ F32 ActiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -3577,7 +3577,7 @@ F32 ActiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -3604,7 +3604,7 @@ void ActiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveEventsComponentAc.ref.cpp
@@ -24,11 +24,11 @@ namespace {
 
   // Get the max size by doing a union of the input and internal port serialization sizes
   union BuffUnion {
-    BYTE noArgsAsyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsGuardedPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnGuardedPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnSyncPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsSyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsAsyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsGuardedPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
     BYTE typedAsyncPortSize[InputTypedPort::SERIALIZED_SIZE];
     BYTE typedAsyncAssertPortSize[InputTypedPort::SERIALIZED_SIZE];
     BYTE typedAsyncBlockPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
@@ -693,7 +693,7 @@ Fw::InputCmdPort* ActiveEventsComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-InputNoArgsPort* ActiveEventsComponentBase ::
+Ports::InputNoArgsPort* ActiveEventsComponentBase ::
   get_noArgsAsync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -704,7 +704,7 @@ InputNoArgsPort* ActiveEventsComponentBase ::
   return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-InputNoArgsPort* ActiveEventsComponentBase ::
+Ports::InputNoArgsPort* ActiveEventsComponentBase ::
   get_noArgsGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -715,7 +715,7 @@ InputNoArgsPort* ActiveEventsComponentBase ::
   return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* ActiveEventsComponentBase ::
+Ports::InputNoArgsReturnPort* ActiveEventsComponentBase ::
   get_noArgsReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -726,7 +726,7 @@ InputNoArgsReturnPort* ActiveEventsComponentBase ::
   return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* ActiveEventsComponentBase ::
+Ports::InputNoArgsReturnPort* ActiveEventsComponentBase ::
   get_noArgsReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -737,7 +737,7 @@ InputNoArgsReturnPort* ActiveEventsComponentBase ::
   return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-InputNoArgsPort* ActiveEventsComponentBase ::
+Ports::InputNoArgsPort* ActiveEventsComponentBase ::
   get_noArgsSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveEventsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveEventsComponentAc.ref.hpp
@@ -180,56 +180,56 @@ class ActiveEventsComponentBase :
     //! Get typed input port at index
     //!
     //! \return typedAsync[portNum]
-    InputTypedPort* get_typedAsync_InputPort(
+    Ports::InputTypedPort* get_typedAsync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncAssert[portNum]
-    InputTypedPort* get_typedAsyncAssert_InputPort(
+    Ports::InputTypedPort* get_typedAsyncAssert_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncBlockPriority[portNum]
-    InputTypedPort* get_typedAsyncBlockPriority_InputPort(
+    Ports::InputTypedPort* get_typedAsyncBlockPriority_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncDropPriority[portNum]
-    InputTypedPort* get_typedAsyncDropPriority_InputPort(
+    Ports::InputTypedPort* get_typedAsyncDropPriority_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedGuarded[portNum]
-    InputTypedPort* get_typedGuarded_InputPort(
+    Ports::InputTypedPort* get_typedGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnGuarded[portNum]
-    InputTypedReturnPort* get_typedReturnGuarded_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnSync[portNum]
-    InputTypedReturnPort* get_typedReturnSync_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedSync[portNum]
-    InputTypedPort* get_typedSync_InputPort(
+    Ports::InputTypedPort* get_typedSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -300,13 +300,13 @@ class ActiveEventsComponentBase :
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnOut[portNum]
     void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
 #if FW_PORT_SERIALIZATION
@@ -666,7 +666,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -678,7 +678,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -690,7 +690,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -702,7 +702,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -714,7 +714,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -726,7 +726,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -738,7 +738,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -750,7 +750,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -795,7 +795,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -807,7 +807,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -819,7 +819,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -831,7 +831,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -843,7 +843,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -855,7 +855,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -867,7 +867,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -879,7 +879,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -906,7 +906,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -918,7 +918,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -930,7 +930,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -942,7 +942,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -960,7 +960,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -972,7 +972,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1140,7 +1140,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1153,7 +1153,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1166,7 +1166,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1179,7 +1179,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1192,7 +1192,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1205,7 +1205,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1218,7 +1218,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1231,7 +1231,7 @@ class ActiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1268,28 +1268,28 @@ class ActiveEventsComponentBase :
     Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedAsync
-    InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];
 
     //! Input port typedAsyncAssert
-    InputTypedPort m_typedAsyncAssert_InputPort[NUM_TYPEDASYNCASSERT_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncAssert_InputPort[NUM_TYPEDASYNCASSERT_INPUT_PORTS];
 
     //! Input port typedAsyncBlockPriority
-    InputTypedPort m_typedAsyncBlockPriority_InputPort[NUM_TYPEDASYNCBLOCKPRIORITY_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncBlockPriority_InputPort[NUM_TYPEDASYNCBLOCKPRIORITY_INPUT_PORTS];
 
     //! Input port typedAsyncDropPriority
-    InputTypedPort m_typedAsyncDropPriority_InputPort[NUM_TYPEDASYNCDROPPRIORITY_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncDropPriority_InputPort[NUM_TYPEDASYNCDROPPRIORITY_INPUT_PORTS];
 
     //! Input port typedGuarded
-    InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
+    Ports::InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnGuarded
-    InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnSync
-    InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
 
     //! Input port typedSync
-    InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
 
   PRIVATE:
 
@@ -1332,10 +1332,10 @@ class ActiveEventsComponentBase :
     // ----------------------------------------------------------------------
 
     //! Output port typedOut
-    OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
+    Ports::OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
 
     //! Output port typedReturnOut
-    OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
+    Ports::OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
 
   PRIVATE:
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveEventsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveEventsComponentAc.ref.hpp
@@ -145,35 +145,35 @@ class ActiveEventsComponentBase :
     //! Get typed input port at index
     //!
     //! \return noArgsAsync[portNum]
-    InputNoArgsPort* get_noArgsAsync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsAsync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsGuarded[portNum]
-    InputNoArgsPort* get_noArgsGuarded_InputPort(
+    Ports::InputNoArgsPort* get_noArgsGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnGuarded[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnSync[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsSync[portNum]
-    InputNoArgsPort* get_noArgsSync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -1253,19 +1253,19 @@ class ActiveEventsComponentBase :
     // ----------------------------------------------------------------------
 
     //! Input port noArgsAsync
-    InputNoArgsPort m_noArgsAsync_InputPort[NUM_NOARGSASYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsAsync_InputPort[NUM_NOARGSASYNC_INPUT_PORTS];
 
     //! Input port noArgsGuarded
-    InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnGuarded
-    InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnSync
-    InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
 
     //! Input port noArgsSync
-    InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedAsync
     InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveEventsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveEventsTesterBase.ref.cpp
@@ -516,7 +516,7 @@ void ActiveEventsTesterBase ::
 void ActiveEventsTesterBase ::
   connect_to_typedAsync(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -530,7 +530,7 @@ void ActiveEventsTesterBase ::
 void ActiveEventsTesterBase ::
   connect_to_typedAsyncAssert(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -544,7 +544,7 @@ void ActiveEventsTesterBase ::
 void ActiveEventsTesterBase ::
   connect_to_typedAsyncBlockPriority(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -558,7 +558,7 @@ void ActiveEventsTesterBase ::
 void ActiveEventsTesterBase ::
   connect_to_typedAsyncDropPriority(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -572,7 +572,7 @@ void ActiveEventsTesterBase ::
 void ActiveEventsTesterBase ::
   connect_to_typedGuarded(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -586,7 +586,7 @@ void ActiveEventsTesterBase ::
 void ActiveEventsTesterBase ::
   connect_to_typedReturnGuarded(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -600,7 +600,7 @@ void ActiveEventsTesterBase ::
 void ActiveEventsTesterBase ::
   connect_to_typedReturnSync(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -614,7 +614,7 @@ void ActiveEventsTesterBase ::
 void ActiveEventsTesterBase ::
   connect_to_typedSync(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -721,7 +721,7 @@ Fw::InputTlmPort* ActiveEventsTesterBase ::
   return &this->m_from_tlmOut[portNum];
 }
 
-InputTypedPort* ActiveEventsTesterBase ::
+Ports::InputTypedPort* ActiveEventsTesterBase ::
   get_from_typedOut(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -732,7 +732,7 @@ InputTypedPort* ActiveEventsTesterBase ::
   return &this->m_from_typedOut[portNum];
 }
 
-InputTypedReturnPort* ActiveEventsTesterBase ::
+Ports::InputTypedReturnPort* ActiveEventsTesterBase ::
   get_from_typedReturnOut(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -800,7 +800,7 @@ void ActiveEventsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -829,7 +829,7 @@ F32 ActiveEventsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -917,7 +917,7 @@ void ActiveEventsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -945,7 +945,7 @@ void ActiveEventsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -973,7 +973,7 @@ void ActiveEventsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1001,7 +1001,7 @@ void ActiveEventsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1029,7 +1029,7 @@ void ActiveEventsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1057,7 +1057,7 @@ F32 ActiveEventsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1085,7 +1085,7 @@ F32 ActiveEventsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1113,7 +1113,7 @@ void ActiveEventsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1886,7 +1886,7 @@ void ActiveEventsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1910,7 +1910,7 @@ void ActiveEventsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2058,7 +2058,7 @@ void ActiveEventsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2085,7 +2085,7 @@ F32 ActiveEventsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveEventsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveEventsTesterBase.ref.cpp
@@ -446,7 +446,7 @@ void ActiveEventsTesterBase ::
 void ActiveEventsTesterBase ::
   connect_to_noArgsAsync(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsPort* port
+      Ports::InputNoArgsPort* port
   )
 {
   FW_ASSERT(
@@ -460,7 +460,7 @@ void ActiveEventsTesterBase ::
 void ActiveEventsTesterBase ::
   connect_to_noArgsGuarded(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsPort* port
+      Ports::InputNoArgsPort* port
   )
 {
   FW_ASSERT(
@@ -474,7 +474,7 @@ void ActiveEventsTesterBase ::
 void ActiveEventsTesterBase ::
   connect_to_noArgsReturnGuarded(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsReturnPort* port
+      Ports::InputNoArgsReturnPort* port
   )
 {
   FW_ASSERT(
@@ -488,7 +488,7 @@ void ActiveEventsTesterBase ::
 void ActiveEventsTesterBase ::
   connect_to_noArgsReturnSync(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsReturnPort* port
+      Ports::InputNoArgsReturnPort* port
   )
 {
   FW_ASSERT(
@@ -502,7 +502,7 @@ void ActiveEventsTesterBase ::
 void ActiveEventsTesterBase ::
   connect_to_noArgsSync(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsPort* port
+      Ports::InputNoArgsPort* port
   )
 {
   FW_ASSERT(

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveEventsTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveEventsTesterBase.ref.hpp
@@ -194,31 +194,31 @@ class ActiveEventsTesterBase :
     //! Connect port to noArgsAsync[portNum]
     void connect_to_noArgsAsync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsPort* port //!< The input port
+        Ports::InputNoArgsPort* port //!< The input port
     );
 
     //! Connect port to noArgsGuarded[portNum]
     void connect_to_noArgsGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsPort* port //!< The input port
+        Ports::InputNoArgsPort* port //!< The input port
     );
 
     //! Connect port to noArgsReturnGuarded[portNum]
     void connect_to_noArgsReturnGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsReturnPort* port //!< The input port
+        Ports::InputNoArgsReturnPort* port //!< The input port
     );
 
     //! Connect port to noArgsReturnSync[portNum]
     void connect_to_noArgsReturnSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsReturnPort* port //!< The input port
+        Ports::InputNoArgsReturnPort* port //!< The input port
     );
 
     //! Connect port to noArgsSync[portNum]
     void connect_to_noArgsSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsPort* port //!< The input port
+        Ports::InputNoArgsPort* port //!< The input port
     );
 
     //! Connect port to typedAsync[portNum]
@@ -1025,19 +1025,19 @@ class ActiveEventsTesterBase :
     Fw::OutputCmdPort m_to_cmdIn[1];
 
     //! To port connected to noArgsAsync
-    OutputNoArgsPort m_to_noArgsAsync[1];
+    Ports::OutputNoArgsPort m_to_noArgsAsync[1];
 
     //! To port connected to noArgsGuarded
-    OutputNoArgsPort m_to_noArgsGuarded[1];
+    Ports::OutputNoArgsPort m_to_noArgsGuarded[1];
 
     //! To port connected to noArgsReturnGuarded
-    OutputNoArgsReturnPort m_to_noArgsReturnGuarded[1];
+    Ports::OutputNoArgsReturnPort m_to_noArgsReturnGuarded[1];
 
     //! To port connected to noArgsReturnSync
-    OutputNoArgsReturnPort m_to_noArgsReturnSync[3];
+    Ports::OutputNoArgsReturnPort m_to_noArgsReturnSync[3];
 
     //! To port connected to noArgsSync
-    OutputNoArgsPort m_to_noArgsSync[3];
+    Ports::OutputNoArgsPort m_to_noArgsSync[3];
 
     //! To port connected to typedAsync
     OutputTypedPort m_to_typedAsync[1];

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveEventsTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveEventsTesterBase.ref.hpp
@@ -111,7 +111,7 @@ class ActiveEventsTesterBase :
       U32 u32;
       F32 f32;
       bool b;
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       E e;
       A a;
       S s;
@@ -122,7 +122,7 @@ class ActiveEventsTesterBase :
       U32 u32;
       F32 f32;
       bool b;
-      TypedReturnPortStrings::StringSize80 str2;
+      Ports::TypedReturnPortStrings::StringSize80 str2;
       E e;
       A a;
       S s;
@@ -224,49 +224,49 @@ class ActiveEventsTesterBase :
     //! Connect port to typedAsync[portNum]
     void connect_to_typedAsync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedAsyncAssert[portNum]
     void connect_to_typedAsyncAssert(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedAsyncBlockPriority[portNum]
     void connect_to_typedAsyncBlockPriority(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedAsyncDropPriority[portNum]
     void connect_to_typedAsyncDropPriority(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedGuarded[portNum]
     void connect_to_typedGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnGuarded[portNum]
     void connect_to_typedReturnGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
     //! Connect port to typedReturnSync[portNum]
     void connect_to_typedReturnSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
     //! Connect port to typedSync[portNum]
     void connect_to_typedSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
   public:
@@ -338,14 +338,14 @@ class ActiveEventsTesterBase :
     //! Get from port at index
     //!
     //! \return from_typedOut[portNum]
-    InputTypedPort* get_from_typedOut(
+    Ports::InputTypedPort* get_from_typedOut(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get from port at index
     //!
     //! \return from_typedReturnOut[portNum]
-    InputTypedReturnPort* get_from_typedReturnOut(
+    Ports::InputTypedReturnPort* get_from_typedReturnOut(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -376,7 +376,7 @@ class ActiveEventsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -388,7 +388,7 @@ class ActiveEventsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -406,7 +406,7 @@ class ActiveEventsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -418,7 +418,7 @@ class ActiveEventsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -461,7 +461,7 @@ class ActiveEventsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -473,7 +473,7 @@ class ActiveEventsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -485,7 +485,7 @@ class ActiveEventsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -497,7 +497,7 @@ class ActiveEventsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -509,7 +509,7 @@ class ActiveEventsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -521,7 +521,7 @@ class ActiveEventsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -533,7 +533,7 @@ class ActiveEventsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -545,7 +545,7 @@ class ActiveEventsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -873,7 +873,7 @@ class ActiveEventsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -884,7 +884,7 @@ class ActiveEventsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -950,7 +950,7 @@ class ActiveEventsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -963,7 +963,7 @@ class ActiveEventsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1040,28 +1040,28 @@ class ActiveEventsTesterBase :
     Ports::OutputNoArgsPort m_to_noArgsSync[3];
 
     //! To port connected to typedAsync
-    OutputTypedPort m_to_typedAsync[1];
+    Ports::OutputTypedPort m_to_typedAsync[1];
 
     //! To port connected to typedAsyncAssert
-    OutputTypedPort m_to_typedAsyncAssert[1];
+    Ports::OutputTypedPort m_to_typedAsyncAssert[1];
 
     //! To port connected to typedAsyncBlockPriority
-    OutputTypedPort m_to_typedAsyncBlockPriority[1];
+    Ports::OutputTypedPort m_to_typedAsyncBlockPriority[1];
 
     //! To port connected to typedAsyncDropPriority
-    OutputTypedPort m_to_typedAsyncDropPriority[1];
+    Ports::OutputTypedPort m_to_typedAsyncDropPriority[1];
 
     //! To port connected to typedGuarded
-    OutputTypedPort m_to_typedGuarded[1];
+    Ports::OutputTypedPort m_to_typedGuarded[1];
 
     //! To port connected to typedReturnGuarded
-    OutputTypedReturnPort m_to_typedReturnGuarded[1];
+    Ports::OutputTypedReturnPort m_to_typedReturnGuarded[1];
 
     //! To port connected to typedReturnSync
-    OutputTypedReturnPort m_to_typedReturnSync[3];
+    Ports::OutputTypedReturnPort m_to_typedReturnSync[3];
 
     //! To port connected to typedSync
-    OutputTypedPort m_to_typedSync[3];
+    Ports::OutputTypedPort m_to_typedSync[3];
 
   private:
 
@@ -1098,10 +1098,10 @@ class ActiveEventsTesterBase :
     Fw::InputTlmPort m_from_tlmOut[1];
 
     //! From port connected to typedOut
-    InputTypedPort m_from_typedOut[1];
+    Ports::InputTypedPort m_from_typedOut[1];
 
     //! From port connected to typedReturnOut
-    InputTypedReturnPort m_from_typedReturnOut[1];
+    Ports::InputTypedReturnPort m_from_typedReturnOut[1];
 
   private:
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveParamsComponentAc.ref.cpp
@@ -29,14 +29,14 @@ namespace {
     BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
     BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
     BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE typedAsyncPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncAssertPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncBlockPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncDropPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedGuardedPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedReturnGuardedPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedReturnSyncPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedSyncPortSize[InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncAssertPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncBlockPriorityPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncDropPriorityPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedGuardedPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedReturnGuardedPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedReturnSyncPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedSyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
     BYTE cmdPortSize[Fw::InputCmdPort::SERIALIZED_SIZE];
   };
 
@@ -748,7 +748,7 @@ Ports::InputNoArgsPort* ActiveParamsComponentBase ::
   return &this->m_noArgsSync_InputPort[portNum];
 }
 
-InputTypedPort* ActiveParamsComponentBase ::
+Ports::InputTypedPort* ActiveParamsComponentBase ::
   get_typedAsync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -759,7 +759,7 @@ InputTypedPort* ActiveParamsComponentBase ::
   return &this->m_typedAsync_InputPort[portNum];
 }
 
-InputTypedPort* ActiveParamsComponentBase ::
+Ports::InputTypedPort* ActiveParamsComponentBase ::
   get_typedAsyncAssert_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -770,7 +770,7 @@ InputTypedPort* ActiveParamsComponentBase ::
   return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-InputTypedPort* ActiveParamsComponentBase ::
+Ports::InputTypedPort* ActiveParamsComponentBase ::
   get_typedAsyncBlockPriority_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -781,7 +781,7 @@ InputTypedPort* ActiveParamsComponentBase ::
   return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-InputTypedPort* ActiveParamsComponentBase ::
+Ports::InputTypedPort* ActiveParamsComponentBase ::
   get_typedAsyncDropPriority_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -792,7 +792,7 @@ InputTypedPort* ActiveParamsComponentBase ::
   return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-InputTypedPort* ActiveParamsComponentBase ::
+Ports::InputTypedPort* ActiveParamsComponentBase ::
   get_typedGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -803,7 +803,7 @@ InputTypedPort* ActiveParamsComponentBase ::
   return &this->m_typedGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* ActiveParamsComponentBase ::
+Ports::InputTypedReturnPort* ActiveParamsComponentBase ::
   get_typedReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -814,7 +814,7 @@ InputTypedReturnPort* ActiveParamsComponentBase ::
   return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* ActiveParamsComponentBase ::
+Ports::InputTypedReturnPort* ActiveParamsComponentBase ::
   get_typedReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -825,7 +825,7 @@ InputTypedReturnPort* ActiveParamsComponentBase ::
   return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-InputTypedPort* ActiveParamsComponentBase ::
+Ports::InputTypedPort* ActiveParamsComponentBase ::
   get_typedSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -963,7 +963,7 @@ void ActiveParamsComponentBase ::
 void ActiveParamsComponentBase ::
   set_typedOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -977,7 +977,7 @@ void ActiveParamsComponentBase ::
 void ActiveParamsComponentBase ::
   set_typedReturnOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -1785,7 +1785,7 @@ void ActiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1892,7 +1892,7 @@ void ActiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1999,7 +1999,7 @@ void ActiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2106,7 +2106,7 @@ void ActiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2218,7 +2218,7 @@ void ActiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2255,7 +2255,7 @@ F32 ActiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2296,7 +2296,7 @@ F32 ActiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2331,7 +2331,7 @@ void ActiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2376,7 +2376,7 @@ void ActiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2391,7 +2391,7 @@ void ActiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2406,7 +2406,7 @@ void ActiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2421,7 +2421,7 @@ void ActiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2440,7 +2440,7 @@ void ActiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2467,7 +2467,7 @@ F32 ActiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2704,7 +2704,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -2776,7 +2776,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -2848,7 +2848,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -2920,7 +2920,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveParamsComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -3181,7 +3181,7 @@ void ActiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3208,7 +3208,7 @@ void ActiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3235,7 +3235,7 @@ void ActiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3262,7 +3262,7 @@ void ActiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3289,7 +3289,7 @@ void ActiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3316,7 +3316,7 @@ F32 ActiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -3343,7 +3343,7 @@ F32 ActiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -3370,7 +3370,7 @@ void ActiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveParamsComponentAc.ref.cpp
@@ -24,11 +24,11 @@ namespace {
 
   // Get the max size by doing a union of the input and internal port serialization sizes
   union BuffUnion {
-    BYTE noArgsAsyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsGuardedPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnGuardedPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnSyncPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsSyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsAsyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsGuardedPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
     BYTE typedAsyncPortSize[InputTypedPort::SERIALIZED_SIZE];
     BYTE typedAsyncAssertPortSize[InputTypedPort::SERIALIZED_SIZE];
     BYTE typedAsyncBlockPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
@@ -693,7 +693,7 @@ Fw::InputCmdPort* ActiveParamsComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-InputNoArgsPort* ActiveParamsComponentBase ::
+Ports::InputNoArgsPort* ActiveParamsComponentBase ::
   get_noArgsAsync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -704,7 +704,7 @@ InputNoArgsPort* ActiveParamsComponentBase ::
   return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-InputNoArgsPort* ActiveParamsComponentBase ::
+Ports::InputNoArgsPort* ActiveParamsComponentBase ::
   get_noArgsGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -715,7 +715,7 @@ InputNoArgsPort* ActiveParamsComponentBase ::
   return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* ActiveParamsComponentBase ::
+Ports::InputNoArgsReturnPort* ActiveParamsComponentBase ::
   get_noArgsReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -726,7 +726,7 @@ InputNoArgsReturnPort* ActiveParamsComponentBase ::
   return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* ActiveParamsComponentBase ::
+Ports::InputNoArgsReturnPort* ActiveParamsComponentBase ::
   get_noArgsReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -737,7 +737,7 @@ InputNoArgsReturnPort* ActiveParamsComponentBase ::
   return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-InputNoArgsPort* ActiveParamsComponentBase ::
+Ports::InputNoArgsPort* ActiveParamsComponentBase ::
   get_noArgsSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveParamsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveParamsComponentAc.ref.hpp
@@ -190,56 +190,56 @@ class ActiveParamsComponentBase :
     //! Get typed input port at index
     //!
     //! \return typedAsync[portNum]
-    InputTypedPort* get_typedAsync_InputPort(
+    Ports::InputTypedPort* get_typedAsync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncAssert[portNum]
-    InputTypedPort* get_typedAsyncAssert_InputPort(
+    Ports::InputTypedPort* get_typedAsyncAssert_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncBlockPriority[portNum]
-    InputTypedPort* get_typedAsyncBlockPriority_InputPort(
+    Ports::InputTypedPort* get_typedAsyncBlockPriority_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncDropPriority[portNum]
-    InputTypedPort* get_typedAsyncDropPriority_InputPort(
+    Ports::InputTypedPort* get_typedAsyncDropPriority_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedGuarded[portNum]
-    InputTypedPort* get_typedGuarded_InputPort(
+    Ports::InputTypedPort* get_typedGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnGuarded[portNum]
-    InputTypedReturnPort* get_typedReturnGuarded_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnSync[portNum]
-    InputTypedReturnPort* get_typedReturnSync_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedSync[portNum]
-    InputTypedPort* get_typedSync_InputPort(
+    Ports::InputTypedPort* get_typedSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -310,13 +310,13 @@ class ActiveParamsComponentBase :
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnOut[portNum]
     void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
 #if FW_PORT_SERIALIZATION
@@ -698,7 +698,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -710,7 +710,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -722,7 +722,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -734,7 +734,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -746,7 +746,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -758,7 +758,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -770,7 +770,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -782,7 +782,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -827,7 +827,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -839,7 +839,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -851,7 +851,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -863,7 +863,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -875,7 +875,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -887,7 +887,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -899,7 +899,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -911,7 +911,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -938,7 +938,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -950,7 +950,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -962,7 +962,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -974,7 +974,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -992,7 +992,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1004,7 +1004,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1199,7 +1199,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1212,7 +1212,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1225,7 +1225,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1238,7 +1238,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1251,7 +1251,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1264,7 +1264,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1277,7 +1277,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1290,7 +1290,7 @@ class ActiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1411,28 +1411,28 @@ class ActiveParamsComponentBase :
     Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedAsync
-    InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];
 
     //! Input port typedAsyncAssert
-    InputTypedPort m_typedAsyncAssert_InputPort[NUM_TYPEDASYNCASSERT_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncAssert_InputPort[NUM_TYPEDASYNCASSERT_INPUT_PORTS];
 
     //! Input port typedAsyncBlockPriority
-    InputTypedPort m_typedAsyncBlockPriority_InputPort[NUM_TYPEDASYNCBLOCKPRIORITY_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncBlockPriority_InputPort[NUM_TYPEDASYNCBLOCKPRIORITY_INPUT_PORTS];
 
     //! Input port typedAsyncDropPriority
-    InputTypedPort m_typedAsyncDropPriority_InputPort[NUM_TYPEDASYNCDROPPRIORITY_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncDropPriority_InputPort[NUM_TYPEDASYNCDROPPRIORITY_INPUT_PORTS];
 
     //! Input port typedGuarded
-    InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
+    Ports::InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnGuarded
-    InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnSync
-    InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
 
     //! Input port typedSync
-    InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
 
   PRIVATE:
 
@@ -1475,10 +1475,10 @@ class ActiveParamsComponentBase :
     // ----------------------------------------------------------------------
 
     //! Output port typedOut
-    OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
+    Ports::OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
 
     //! Output port typedReturnOut
-    OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
+    Ports::OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
 
   PRIVATE:
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveParamsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveParamsComponentAc.ref.hpp
@@ -155,35 +155,35 @@ class ActiveParamsComponentBase :
     //! Get typed input port at index
     //!
     //! \return noArgsAsync[portNum]
-    InputNoArgsPort* get_noArgsAsync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsAsync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsGuarded[portNum]
-    InputNoArgsPort* get_noArgsGuarded_InputPort(
+    Ports::InputNoArgsPort* get_noArgsGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnGuarded[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnSync[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsSync[portNum]
-    InputNoArgsPort* get_noArgsSync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -1396,19 +1396,19 @@ class ActiveParamsComponentBase :
     // ----------------------------------------------------------------------
 
     //! Input port noArgsAsync
-    InputNoArgsPort m_noArgsAsync_InputPort[NUM_NOARGSASYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsAsync_InputPort[NUM_NOARGSASYNC_INPUT_PORTS];
 
     //! Input port noArgsGuarded
-    InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnGuarded
-    InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnSync
-    InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
 
     //! Input port noArgsSync
-    InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedAsync
     InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveParamsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveParamsTesterBase.ref.cpp
@@ -587,7 +587,7 @@ void ActiveParamsTesterBase ::
 void ActiveParamsTesterBase ::
   connect_to_typedAsync(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -601,7 +601,7 @@ void ActiveParamsTesterBase ::
 void ActiveParamsTesterBase ::
   connect_to_typedAsyncAssert(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -615,7 +615,7 @@ void ActiveParamsTesterBase ::
 void ActiveParamsTesterBase ::
   connect_to_typedAsyncBlockPriority(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -629,7 +629,7 @@ void ActiveParamsTesterBase ::
 void ActiveParamsTesterBase ::
   connect_to_typedAsyncDropPriority(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -643,7 +643,7 @@ void ActiveParamsTesterBase ::
 void ActiveParamsTesterBase ::
   connect_to_typedGuarded(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -657,7 +657,7 @@ void ActiveParamsTesterBase ::
 void ActiveParamsTesterBase ::
   connect_to_typedReturnGuarded(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -671,7 +671,7 @@ void ActiveParamsTesterBase ::
 void ActiveParamsTesterBase ::
   connect_to_typedReturnSync(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -685,7 +685,7 @@ void ActiveParamsTesterBase ::
 void ActiveParamsTesterBase ::
   connect_to_typedSync(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -792,7 +792,7 @@ Fw::InputTlmPort* ActiveParamsTesterBase ::
   return &this->m_from_tlmOut[portNum];
 }
 
-InputTypedPort* ActiveParamsTesterBase ::
+Ports::InputTypedPort* ActiveParamsTesterBase ::
   get_from_typedOut(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -803,7 +803,7 @@ InputTypedPort* ActiveParamsTesterBase ::
   return &this->m_from_typedOut[portNum];
 }
 
-InputTypedReturnPort* ActiveParamsTesterBase ::
+Ports::InputTypedReturnPort* ActiveParamsTesterBase ::
   get_from_typedReturnOut(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -863,7 +863,7 @@ void ActiveParamsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -892,7 +892,7 @@ F32 ActiveParamsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -980,7 +980,7 @@ void ActiveParamsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1008,7 +1008,7 @@ void ActiveParamsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1036,7 +1036,7 @@ void ActiveParamsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1064,7 +1064,7 @@ void ActiveParamsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1092,7 +1092,7 @@ void ActiveParamsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1120,7 +1120,7 @@ F32 ActiveParamsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1148,7 +1148,7 @@ F32 ActiveParamsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1176,7 +1176,7 @@ void ActiveParamsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1936,7 +1936,7 @@ void ActiveParamsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1960,7 +1960,7 @@ void ActiveParamsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2217,7 +2217,7 @@ void ActiveParamsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2244,7 +2244,7 @@ F32 ActiveParamsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveParamsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveParamsTesterBase.ref.cpp
@@ -517,7 +517,7 @@ void ActiveParamsTesterBase ::
 void ActiveParamsTesterBase ::
   connect_to_noArgsAsync(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsPort* port
+      Ports::InputNoArgsPort* port
   )
 {
   FW_ASSERT(
@@ -531,7 +531,7 @@ void ActiveParamsTesterBase ::
 void ActiveParamsTesterBase ::
   connect_to_noArgsGuarded(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsPort* port
+      Ports::InputNoArgsPort* port
   )
 {
   FW_ASSERT(
@@ -545,7 +545,7 @@ void ActiveParamsTesterBase ::
 void ActiveParamsTesterBase ::
   connect_to_noArgsReturnGuarded(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsReturnPort* port
+      Ports::InputNoArgsReturnPort* port
   )
 {
   FW_ASSERT(
@@ -559,7 +559,7 @@ void ActiveParamsTesterBase ::
 void ActiveParamsTesterBase ::
   connect_to_noArgsReturnSync(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsReturnPort* port
+      Ports::InputNoArgsReturnPort* port
   )
 {
   FW_ASSERT(
@@ -573,7 +573,7 @@ void ActiveParamsTesterBase ::
 void ActiveParamsTesterBase ::
   connect_to_noArgsSync(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsPort* port
+      Ports::InputNoArgsPort* port
   )
 {
   FW_ASSERT(

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveParamsTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveParamsTesterBase.ref.hpp
@@ -111,7 +111,7 @@ class ActiveParamsTesterBase :
       U32 u32;
       F32 f32;
       bool b;
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       E e;
       A a;
       S s;
@@ -122,7 +122,7 @@ class ActiveParamsTesterBase :
       U32 u32;
       F32 f32;
       bool b;
-      TypedReturnPortStrings::StringSize80 str2;
+      Ports::TypedReturnPortStrings::StringSize80 str2;
       E e;
       A a;
       S s;
@@ -191,49 +191,49 @@ class ActiveParamsTesterBase :
     //! Connect port to typedAsync[portNum]
     void connect_to_typedAsync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedAsyncAssert[portNum]
     void connect_to_typedAsyncAssert(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedAsyncBlockPriority[portNum]
     void connect_to_typedAsyncBlockPriority(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedAsyncDropPriority[portNum]
     void connect_to_typedAsyncDropPriority(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedGuarded[portNum]
     void connect_to_typedGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnGuarded[portNum]
     void connect_to_typedReturnGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
     //! Connect port to typedReturnSync[portNum]
     void connect_to_typedReturnSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
     //! Connect port to typedSync[portNum]
     void connect_to_typedSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
   public:
@@ -305,14 +305,14 @@ class ActiveParamsTesterBase :
     //! Get from port at index
     //!
     //! \return from_typedOut[portNum]
-    InputTypedPort* get_from_typedOut(
+    Ports::InputTypedPort* get_from_typedOut(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get from port at index
     //!
     //! \return from_typedReturnOut[portNum]
-    InputTypedReturnPort* get_from_typedReturnOut(
+    Ports::InputTypedReturnPort* get_from_typedReturnOut(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -343,7 +343,7 @@ class ActiveParamsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -355,7 +355,7 @@ class ActiveParamsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -373,7 +373,7 @@ class ActiveParamsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -385,7 +385,7 @@ class ActiveParamsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -428,7 +428,7 @@ class ActiveParamsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -440,7 +440,7 @@ class ActiveParamsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -452,7 +452,7 @@ class ActiveParamsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -464,7 +464,7 @@ class ActiveParamsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -476,7 +476,7 @@ class ActiveParamsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -488,7 +488,7 @@ class ActiveParamsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -500,7 +500,7 @@ class ActiveParamsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -512,7 +512,7 @@ class ActiveParamsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -914,7 +914,7 @@ class ActiveParamsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -925,7 +925,7 @@ class ActiveParamsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -983,7 +983,7 @@ class ActiveParamsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -996,7 +996,7 @@ class ActiveParamsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1045,28 +1045,28 @@ class ActiveParamsTesterBase :
     Ports::OutputNoArgsPort m_to_noArgsSync[3];
 
     //! To port connected to typedAsync
-    OutputTypedPort m_to_typedAsync[1];
+    Ports::OutputTypedPort m_to_typedAsync[1];
 
     //! To port connected to typedAsyncAssert
-    OutputTypedPort m_to_typedAsyncAssert[1];
+    Ports::OutputTypedPort m_to_typedAsyncAssert[1];
 
     //! To port connected to typedAsyncBlockPriority
-    OutputTypedPort m_to_typedAsyncBlockPriority[1];
+    Ports::OutputTypedPort m_to_typedAsyncBlockPriority[1];
 
     //! To port connected to typedAsyncDropPriority
-    OutputTypedPort m_to_typedAsyncDropPriority[1];
+    Ports::OutputTypedPort m_to_typedAsyncDropPriority[1];
 
     //! To port connected to typedGuarded
-    OutputTypedPort m_to_typedGuarded[1];
+    Ports::OutputTypedPort m_to_typedGuarded[1];
 
     //! To port connected to typedReturnGuarded
-    OutputTypedReturnPort m_to_typedReturnGuarded[1];
+    Ports::OutputTypedReturnPort m_to_typedReturnGuarded[1];
 
     //! To port connected to typedReturnSync
-    OutputTypedReturnPort m_to_typedReturnSync[3];
+    Ports::OutputTypedReturnPort m_to_typedReturnSync[3];
 
     //! To port connected to typedSync
-    OutputTypedPort m_to_typedSync[3];
+    Ports::OutputTypedPort m_to_typedSync[3];
 
   private:
 
@@ -1103,10 +1103,10 @@ class ActiveParamsTesterBase :
     Fw::InputTlmPort m_from_tlmOut[1];
 
     //! From port connected to typedOut
-    InputTypedPort m_from_typedOut[1];
+    Ports::InputTypedPort m_from_typedOut[1];
 
     //! From port connected to typedReturnOut
-    InputTypedReturnPort m_from_typedReturnOut[1];
+    Ports::InputTypedReturnPort m_from_typedReturnOut[1];
 
   private:
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveParamsTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveParamsTesterBase.ref.hpp
@@ -161,31 +161,31 @@ class ActiveParamsTesterBase :
     //! Connect port to noArgsAsync[portNum]
     void connect_to_noArgsAsync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsPort* port //!< The input port
+        Ports::InputNoArgsPort* port //!< The input port
     );
 
     //! Connect port to noArgsGuarded[portNum]
     void connect_to_noArgsGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsPort* port //!< The input port
+        Ports::InputNoArgsPort* port //!< The input port
     );
 
     //! Connect port to noArgsReturnGuarded[portNum]
     void connect_to_noArgsReturnGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsReturnPort* port //!< The input port
+        Ports::InputNoArgsReturnPort* port //!< The input port
     );
 
     //! Connect port to noArgsReturnSync[portNum]
     void connect_to_noArgsReturnSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsReturnPort* port //!< The input port
+        Ports::InputNoArgsReturnPort* port //!< The input port
     );
 
     //! Connect port to noArgsSync[portNum]
     void connect_to_noArgsSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsPort* port //!< The input port
+        Ports::InputNoArgsPort* port //!< The input port
     );
 
     //! Connect port to typedAsync[portNum]
@@ -1030,19 +1030,19 @@ class ActiveParamsTesterBase :
     Fw::OutputCmdPort m_to_cmdIn[1];
 
     //! To port connected to noArgsAsync
-    OutputNoArgsPort m_to_noArgsAsync[1];
+    Ports::OutputNoArgsPort m_to_noArgsAsync[1];
 
     //! To port connected to noArgsGuarded
-    OutputNoArgsPort m_to_noArgsGuarded[1];
+    Ports::OutputNoArgsPort m_to_noArgsGuarded[1];
 
     //! To port connected to noArgsReturnGuarded
-    OutputNoArgsReturnPort m_to_noArgsReturnGuarded[1];
+    Ports::OutputNoArgsReturnPort m_to_noArgsReturnGuarded[1];
 
     //! To port connected to noArgsReturnSync
-    OutputNoArgsReturnPort m_to_noArgsReturnSync[3];
+    Ports::OutputNoArgsReturnPort m_to_noArgsReturnSync[3];
 
     //! To port connected to noArgsSync
-    OutputNoArgsPort m_to_noArgsSync[3];
+    Ports::OutputNoArgsPort m_to_noArgsSync[3];
 
     //! To port connected to typedAsync
     OutputTypedPort m_to_typedAsync[1];

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialComponentAc.ref.cpp
@@ -39,11 +39,11 @@ namespace {
 
   // Get the max size by doing a union of the input and internal port serialization sizes
   union BuffUnion {
-    BYTE noArgsAsyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsGuardedPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnGuardedPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnSyncPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsSyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsAsyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsGuardedPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
     BYTE typedAsyncPortSize[InputTypedPort::SERIALIZED_SIZE];
     BYTE typedAsyncAssertPortSize[InputTypedPort::SERIALIZED_SIZE];
     BYTE typedAsyncBlockPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
@@ -917,7 +917,7 @@ Fw::InputCmdPort* ActiveSerialComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-InputNoArgsPort* ActiveSerialComponentBase ::
+Ports::InputNoArgsPort* ActiveSerialComponentBase ::
   get_noArgsAsync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -928,7 +928,7 @@ InputNoArgsPort* ActiveSerialComponentBase ::
   return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-InputNoArgsPort* ActiveSerialComponentBase ::
+Ports::InputNoArgsPort* ActiveSerialComponentBase ::
   get_noArgsGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -939,7 +939,7 @@ InputNoArgsPort* ActiveSerialComponentBase ::
   return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* ActiveSerialComponentBase ::
+Ports::InputNoArgsReturnPort* ActiveSerialComponentBase ::
   get_noArgsReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -950,7 +950,7 @@ InputNoArgsReturnPort* ActiveSerialComponentBase ::
   return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* ActiveSerialComponentBase ::
+Ports::InputNoArgsReturnPort* ActiveSerialComponentBase ::
   get_noArgsReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -961,7 +961,7 @@ InputNoArgsReturnPort* ActiveSerialComponentBase ::
   return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-InputNoArgsPort* ActiveSerialComponentBase ::
+Ports::InputNoArgsPort* ActiveSerialComponentBase ::
   get_noArgsSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialComponentAc.ref.cpp
@@ -44,14 +44,14 @@ namespace {
     BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
     BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
     BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE typedAsyncPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncAssertPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncBlockPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncDropPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedGuardedPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedReturnGuardedPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedReturnSyncPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedSyncPortSize[InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncAssertPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncBlockPriorityPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncDropPriorityPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedGuardedPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedReturnGuardedPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedReturnSyncPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedSyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
     BYTE cmdPortSize[Fw::InputCmdPort::SERIALIZED_SIZE];
     // Size of internalArray argument list
     BYTE internalArrayIntIfSize[
@@ -972,7 +972,7 @@ Ports::InputNoArgsPort* ActiveSerialComponentBase ::
   return &this->m_noArgsSync_InputPort[portNum];
 }
 
-InputTypedPort* ActiveSerialComponentBase ::
+Ports::InputTypedPort* ActiveSerialComponentBase ::
   get_typedAsync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -983,7 +983,7 @@ InputTypedPort* ActiveSerialComponentBase ::
   return &this->m_typedAsync_InputPort[portNum];
 }
 
-InputTypedPort* ActiveSerialComponentBase ::
+Ports::InputTypedPort* ActiveSerialComponentBase ::
   get_typedAsyncAssert_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -994,7 +994,7 @@ InputTypedPort* ActiveSerialComponentBase ::
   return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-InputTypedPort* ActiveSerialComponentBase ::
+Ports::InputTypedPort* ActiveSerialComponentBase ::
   get_typedAsyncBlockPriority_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -1005,7 +1005,7 @@ InputTypedPort* ActiveSerialComponentBase ::
   return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-InputTypedPort* ActiveSerialComponentBase ::
+Ports::InputTypedPort* ActiveSerialComponentBase ::
   get_typedAsyncDropPriority_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -1016,7 +1016,7 @@ InputTypedPort* ActiveSerialComponentBase ::
   return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-InputTypedPort* ActiveSerialComponentBase ::
+Ports::InputTypedPort* ActiveSerialComponentBase ::
   get_typedGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -1027,7 +1027,7 @@ InputTypedPort* ActiveSerialComponentBase ::
   return &this->m_typedGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* ActiveSerialComponentBase ::
+Ports::InputTypedReturnPort* ActiveSerialComponentBase ::
   get_typedReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -1038,7 +1038,7 @@ InputTypedReturnPort* ActiveSerialComponentBase ::
   return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* ActiveSerialComponentBase ::
+Ports::InputTypedReturnPort* ActiveSerialComponentBase ::
   get_typedReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -1049,7 +1049,7 @@ InputTypedReturnPort* ActiveSerialComponentBase ::
   return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-InputTypedPort* ActiveSerialComponentBase ::
+Ports::InputTypedPort* ActiveSerialComponentBase ::
   get_typedSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -1257,7 +1257,7 @@ void ActiveSerialComponentBase ::
 void ActiveSerialComponentBase ::
   set_typedOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -1271,7 +1271,7 @@ void ActiveSerialComponentBase ::
 void ActiveSerialComponentBase ::
   set_typedReturnOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -2245,7 +2245,7 @@ void ActiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2352,7 +2352,7 @@ void ActiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2459,7 +2459,7 @@ void ActiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2566,7 +2566,7 @@ void ActiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2678,7 +2678,7 @@ void ActiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2715,7 +2715,7 @@ F32 ActiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2756,7 +2756,7 @@ F32 ActiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2791,7 +2791,7 @@ void ActiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3091,7 +3091,7 @@ void ActiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3106,7 +3106,7 @@ void ActiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3121,7 +3121,7 @@ void ActiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3136,7 +3136,7 @@ void ActiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3199,7 +3199,7 @@ void ActiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3226,7 +3226,7 @@ F32 ActiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -5816,7 +5816,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -5888,7 +5888,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -5960,7 +5960,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -6032,7 +6032,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveSerialComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -6952,7 +6952,7 @@ void ActiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -6979,7 +6979,7 @@ void ActiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -7006,7 +7006,7 @@ void ActiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -7033,7 +7033,7 @@ void ActiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -7060,7 +7060,7 @@ void ActiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -7087,7 +7087,7 @@ F32 ActiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -7114,7 +7114,7 @@ F32 ActiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -7141,7 +7141,7 @@ void ActiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialComponentAc.ref.hpp
@@ -264,56 +264,56 @@ class ActiveSerialComponentBase :
     //! Get typed input port at index
     //!
     //! \return typedAsync[portNum]
-    InputTypedPort* get_typedAsync_InputPort(
+    Ports::InputTypedPort* get_typedAsync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncAssert[portNum]
-    InputTypedPort* get_typedAsyncAssert_InputPort(
+    Ports::InputTypedPort* get_typedAsyncAssert_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncBlockPriority[portNum]
-    InputTypedPort* get_typedAsyncBlockPriority_InputPort(
+    Ports::InputTypedPort* get_typedAsyncBlockPriority_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncDropPriority[portNum]
-    InputTypedPort* get_typedAsyncDropPriority_InputPort(
+    Ports::InputTypedPort* get_typedAsyncDropPriority_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedGuarded[portNum]
-    InputTypedPort* get_typedGuarded_InputPort(
+    Ports::InputTypedPort* get_typedGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnGuarded[portNum]
-    InputTypedReturnPort* get_typedReturnGuarded_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnSync[portNum]
-    InputTypedReturnPort* get_typedReturnSync_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedSync[portNum]
-    InputTypedPort* get_typedSync_InputPort(
+    Ports::InputTypedPort* get_typedSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -432,13 +432,13 @@ class ActiveSerialComponentBase :
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnOut[portNum]
     void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
 #if FW_PORT_SERIALIZATION
@@ -896,7 +896,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -908,7 +908,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -920,7 +920,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -932,7 +932,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -944,7 +944,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -956,7 +956,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -968,7 +968,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -980,7 +980,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1025,7 +1025,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1037,7 +1037,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1049,7 +1049,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1061,7 +1061,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1073,7 +1073,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1085,7 +1085,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1097,7 +1097,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1109,7 +1109,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1222,7 +1222,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1234,7 +1234,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1246,7 +1246,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1258,7 +1258,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1310,7 +1310,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1322,7 +1322,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -2127,7 +2127,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -2140,7 +2140,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -2153,7 +2153,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -2166,7 +2166,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -2179,7 +2179,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -2192,7 +2192,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -2205,7 +2205,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -2218,7 +2218,7 @@ class ActiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -2391,28 +2391,28 @@ class ActiveSerialComponentBase :
     Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedAsync
-    InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];
 
     //! Input port typedAsyncAssert
-    InputTypedPort m_typedAsyncAssert_InputPort[NUM_TYPEDASYNCASSERT_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncAssert_InputPort[NUM_TYPEDASYNCASSERT_INPUT_PORTS];
 
     //! Input port typedAsyncBlockPriority
-    InputTypedPort m_typedAsyncBlockPriority_InputPort[NUM_TYPEDASYNCBLOCKPRIORITY_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncBlockPriority_InputPort[NUM_TYPEDASYNCBLOCKPRIORITY_INPUT_PORTS];
 
     //! Input port typedAsyncDropPriority
-    InputTypedPort m_typedAsyncDropPriority_InputPort[NUM_TYPEDASYNCDROPPRIORITY_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncDropPriority_InputPort[NUM_TYPEDASYNCDROPPRIORITY_INPUT_PORTS];
 
     //! Input port typedGuarded
-    InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
+    Ports::InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnGuarded
-    InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnSync
-    InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
 
     //! Input port typedSync
-    InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
 
   PRIVATE:
 
@@ -2479,10 +2479,10 @@ class ActiveSerialComponentBase :
     // ----------------------------------------------------------------------
 
     //! Output port typedOut
-    OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
+    Ports::OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
 
     //! Output port typedReturnOut
-    OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
+    Ports::OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
 
   PRIVATE:
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialComponentAc.ref.hpp
@@ -229,35 +229,35 @@ class ActiveSerialComponentBase :
     //! Get typed input port at index
     //!
     //! \return noArgsAsync[portNum]
-    InputNoArgsPort* get_noArgsAsync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsAsync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsGuarded[portNum]
-    InputNoArgsPort* get_noArgsGuarded_InputPort(
+    Ports::InputNoArgsPort* get_noArgsGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnGuarded[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnSync[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsSync[portNum]
-    InputNoArgsPort* get_noArgsSync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -2376,19 +2376,19 @@ class ActiveSerialComponentBase :
     // ----------------------------------------------------------------------
 
     //! Input port noArgsAsync
-    InputNoArgsPort m_noArgsAsync_InputPort[NUM_NOARGSASYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsAsync_InputPort[NUM_NOARGSASYNC_INPUT_PORTS];
 
     //! Input port noArgsGuarded
-    InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnGuarded
-    InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnSync
-    InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
 
     //! Input port noArgsSync
-    InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedAsync
     InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.cpp
@@ -749,7 +749,7 @@ void ActiveSerialTesterBase ::
 void ActiveSerialTesterBase ::
   connect_to_noArgsAsync(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsPort* port
+      Ports::InputNoArgsPort* port
   )
 {
   FW_ASSERT(
@@ -763,7 +763,7 @@ void ActiveSerialTesterBase ::
 void ActiveSerialTesterBase ::
   connect_to_noArgsGuarded(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsPort* port
+      Ports::InputNoArgsPort* port
   )
 {
   FW_ASSERT(
@@ -777,7 +777,7 @@ void ActiveSerialTesterBase ::
 void ActiveSerialTesterBase ::
   connect_to_noArgsReturnGuarded(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsReturnPort* port
+      Ports::InputNoArgsReturnPort* port
   )
 {
   FW_ASSERT(
@@ -791,7 +791,7 @@ void ActiveSerialTesterBase ::
 void ActiveSerialTesterBase ::
   connect_to_noArgsReturnSync(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsReturnPort* port
+      Ports::InputNoArgsReturnPort* port
   )
 {
   FW_ASSERT(
@@ -805,7 +805,7 @@ void ActiveSerialTesterBase ::
 void ActiveSerialTesterBase ::
   connect_to_noArgsSync(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsPort* port
+      Ports::InputNoArgsPort* port
   )
 {
   FW_ASSERT(

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.cpp
@@ -819,7 +819,7 @@ void ActiveSerialTesterBase ::
 void ActiveSerialTesterBase ::
   connect_to_typedAsync(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -833,7 +833,7 @@ void ActiveSerialTesterBase ::
 void ActiveSerialTesterBase ::
   connect_to_typedAsyncAssert(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -847,7 +847,7 @@ void ActiveSerialTesterBase ::
 void ActiveSerialTesterBase ::
   connect_to_typedAsyncBlockPriority(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -861,7 +861,7 @@ void ActiveSerialTesterBase ::
 void ActiveSerialTesterBase ::
   connect_to_typedAsyncDropPriority(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -875,7 +875,7 @@ void ActiveSerialTesterBase ::
 void ActiveSerialTesterBase ::
   connect_to_typedGuarded(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -889,7 +889,7 @@ void ActiveSerialTesterBase ::
 void ActiveSerialTesterBase ::
   connect_to_typedReturnGuarded(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -903,7 +903,7 @@ void ActiveSerialTesterBase ::
 void ActiveSerialTesterBase ::
   connect_to_typedReturnSync(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -917,7 +917,7 @@ void ActiveSerialTesterBase ::
 void ActiveSerialTesterBase ::
   connect_to_typedSync(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -1108,7 +1108,7 @@ Fw::InputTlmPort* ActiveSerialTesterBase ::
   return &this->m_from_tlmOut[portNum];
 }
 
-InputTypedPort* ActiveSerialTesterBase ::
+Ports::InputTypedPort* ActiveSerialTesterBase ::
   get_from_typedOut(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -1119,7 +1119,7 @@ InputTypedPort* ActiveSerialTesterBase ::
   return &this->m_from_typedOut[portNum];
 }
 
-InputTypedReturnPort* ActiveSerialTesterBase ::
+Ports::InputTypedReturnPort* ActiveSerialTesterBase ::
   get_from_typedReturnOut(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -1236,7 +1236,7 @@ void ActiveSerialTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1265,7 +1265,7 @@ F32 ActiveSerialTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1370,7 +1370,7 @@ void ActiveSerialTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1398,7 +1398,7 @@ void ActiveSerialTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1426,7 +1426,7 @@ void ActiveSerialTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1454,7 +1454,7 @@ void ActiveSerialTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1482,7 +1482,7 @@ void ActiveSerialTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1510,7 +1510,7 @@ F32 ActiveSerialTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1538,7 +1538,7 @@ F32 ActiveSerialTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1566,7 +1566,7 @@ void ActiveSerialTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3802,7 +3802,7 @@ void ActiveSerialTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3826,7 +3826,7 @@ void ActiveSerialTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -4220,7 +4220,7 @@ void ActiveSerialTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -4247,7 +4247,7 @@ F32 ActiveSerialTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.hpp
@@ -267,31 +267,31 @@ class ActiveSerialTesterBase :
     //! Connect port to noArgsAsync[portNum]
     void connect_to_noArgsAsync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsPort* port //!< The input port
+        Ports::InputNoArgsPort* port //!< The input port
     );
 
     //! Connect port to noArgsGuarded[portNum]
     void connect_to_noArgsGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsPort* port //!< The input port
+        Ports::InputNoArgsPort* port //!< The input port
     );
 
     //! Connect port to noArgsReturnGuarded[portNum]
     void connect_to_noArgsReturnGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsReturnPort* port //!< The input port
+        Ports::InputNoArgsReturnPort* port //!< The input port
     );
 
     //! Connect port to noArgsReturnSync[portNum]
     void connect_to_noArgsReturnSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsReturnPort* port //!< The input port
+        Ports::InputNoArgsReturnPort* port //!< The input port
     );
 
     //! Connect port to noArgsSync[portNum]
     void connect_to_noArgsSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsPort* port //!< The input port
+        Ports::InputNoArgsPort* port //!< The input port
     );
 
     //! Connect port to typedAsync[portNum]
@@ -1689,19 +1689,19 @@ class ActiveSerialTesterBase :
     Fw::OutputCmdPort m_to_cmdIn[1];
 
     //! To port connected to noArgsAsync
-    OutputNoArgsPort m_to_noArgsAsync[1];
+    Ports::OutputNoArgsPort m_to_noArgsAsync[1];
 
     //! To port connected to noArgsGuarded
-    OutputNoArgsPort m_to_noArgsGuarded[1];
+    Ports::OutputNoArgsPort m_to_noArgsGuarded[1];
 
     //! To port connected to noArgsReturnGuarded
-    OutputNoArgsReturnPort m_to_noArgsReturnGuarded[1];
+    Ports::OutputNoArgsReturnPort m_to_noArgsReturnGuarded[1];
 
     //! To port connected to noArgsReturnSync
-    OutputNoArgsReturnPort m_to_noArgsReturnSync[3];
+    Ports::OutputNoArgsReturnPort m_to_noArgsReturnSync[3];
 
     //! To port connected to noArgsSync
-    OutputNoArgsPort m_to_noArgsSync[3];
+    Ports::OutputNoArgsPort m_to_noArgsSync[3];
 
     //! To port connected to typedAsync
     OutputTypedPort m_to_typedAsync[1];

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.hpp
@@ -111,7 +111,7 @@ class ActiveSerialTesterBase :
       U32 u32;
       F32 f32;
       bool b;
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       E e;
       A a;
       S s;
@@ -122,7 +122,7 @@ class ActiveSerialTesterBase :
       U32 u32;
       F32 f32;
       bool b;
-      TypedReturnPortStrings::StringSize80 str2;
+      Ports::TypedReturnPortStrings::StringSize80 str2;
       E e;
       A a;
       S s;
@@ -297,49 +297,49 @@ class ActiveSerialTesterBase :
     //! Connect port to typedAsync[portNum]
     void connect_to_typedAsync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedAsyncAssert[portNum]
     void connect_to_typedAsyncAssert(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedAsyncBlockPriority[portNum]
     void connect_to_typedAsyncBlockPriority(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedAsyncDropPriority[portNum]
     void connect_to_typedAsyncDropPriority(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedGuarded[portNum]
     void connect_to_typedGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnGuarded[portNum]
     void connect_to_typedReturnGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
     //! Connect port to typedReturnSync[portNum]
     void connect_to_typedReturnSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
     //! Connect port to typedSync[portNum]
     void connect_to_typedSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to serialAsync[portNum]
@@ -447,14 +447,14 @@ class ActiveSerialTesterBase :
     //! Get from port at index
     //!
     //! \return from_typedOut[portNum]
-    InputTypedPort* get_from_typedOut(
+    Ports::InputTypedPort* get_from_typedOut(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get from port at index
     //!
     //! \return from_typedReturnOut[portNum]
-    InputTypedReturnPort* get_from_typedReturnOut(
+    Ports::InputTypedReturnPort* get_from_typedReturnOut(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -492,7 +492,7 @@ class ActiveSerialTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -504,7 +504,7 @@ class ActiveSerialTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -528,7 +528,7 @@ class ActiveSerialTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -540,7 +540,7 @@ class ActiveSerialTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -589,7 +589,7 @@ class ActiveSerialTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -601,7 +601,7 @@ class ActiveSerialTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -613,7 +613,7 @@ class ActiveSerialTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -625,7 +625,7 @@ class ActiveSerialTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -637,7 +637,7 @@ class ActiveSerialTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -649,7 +649,7 @@ class ActiveSerialTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -661,7 +661,7 @@ class ActiveSerialTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -673,7 +673,7 @@ class ActiveSerialTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1447,7 +1447,7 @@ class ActiveSerialTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1458,7 +1458,7 @@ class ActiveSerialTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1568,7 +1568,7 @@ class ActiveSerialTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1581,7 +1581,7 @@ class ActiveSerialTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1704,28 +1704,28 @@ class ActiveSerialTesterBase :
     Ports::OutputNoArgsPort m_to_noArgsSync[3];
 
     //! To port connected to typedAsync
-    OutputTypedPort m_to_typedAsync[1];
+    Ports::OutputTypedPort m_to_typedAsync[1];
 
     //! To port connected to typedAsyncAssert
-    OutputTypedPort m_to_typedAsyncAssert[1];
+    Ports::OutputTypedPort m_to_typedAsyncAssert[1];
 
     //! To port connected to typedAsyncBlockPriority
-    OutputTypedPort m_to_typedAsyncBlockPriority[1];
+    Ports::OutputTypedPort m_to_typedAsyncBlockPriority[1];
 
     //! To port connected to typedAsyncDropPriority
-    OutputTypedPort m_to_typedAsyncDropPriority[1];
+    Ports::OutputTypedPort m_to_typedAsyncDropPriority[1];
 
     //! To port connected to typedGuarded
-    OutputTypedPort m_to_typedGuarded[1];
+    Ports::OutputTypedPort m_to_typedGuarded[1];
 
     //! To port connected to typedReturnGuarded
-    OutputTypedReturnPort m_to_typedReturnGuarded[1];
+    Ports::OutputTypedReturnPort m_to_typedReturnGuarded[1];
 
     //! To port connected to typedReturnSync
-    OutputTypedReturnPort m_to_typedReturnSync[3];
+    Ports::OutputTypedReturnPort m_to_typedReturnSync[3];
 
     //! To port connected to typedSync
-    OutputTypedPort m_to_typedSync[3];
+    Ports::OutputTypedPort m_to_typedSync[3];
 
     //! To port connected to serialAsync
     Fw::OutputSerializePort m_to_serialAsync[1];
@@ -1780,10 +1780,10 @@ class ActiveSerialTesterBase :
     Fw::InputTlmPort m_from_tlmOut[1];
 
     //! From port connected to typedOut
-    InputTypedPort m_from_typedOut[1];
+    Ports::InputTypedPort m_from_typedOut[1];
 
     //! From port connected to typedReturnOut
-    InputTypedReturnPort m_from_typedReturnOut[1];
+    Ports::InputTypedReturnPort m_from_typedReturnOut[1];
 
     //! From port connected to serialOut
     Fw::InputSerializePort m_from_serialOut[5];

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTelemetryComponentAc.ref.cpp
@@ -24,11 +24,11 @@ namespace {
 
   // Get the max size by doing a union of the input and internal port serialization sizes
   union BuffUnion {
-    BYTE noArgsAsyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsGuardedPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnGuardedPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnSyncPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsSyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsAsyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsGuardedPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
     BYTE typedAsyncPortSize[InputTypedPort::SERIALIZED_SIZE];
     BYTE typedAsyncAssertPortSize[InputTypedPort::SERIALIZED_SIZE];
     BYTE typedAsyncBlockPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
@@ -693,7 +693,7 @@ Fw::InputCmdPort* ActiveTelemetryComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-InputNoArgsPort* ActiveTelemetryComponentBase ::
+Ports::InputNoArgsPort* ActiveTelemetryComponentBase ::
   get_noArgsAsync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -704,7 +704,7 @@ InputNoArgsPort* ActiveTelemetryComponentBase ::
   return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-InputNoArgsPort* ActiveTelemetryComponentBase ::
+Ports::InputNoArgsPort* ActiveTelemetryComponentBase ::
   get_noArgsGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -715,7 +715,7 @@ InputNoArgsPort* ActiveTelemetryComponentBase ::
   return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* ActiveTelemetryComponentBase ::
+Ports::InputNoArgsReturnPort* ActiveTelemetryComponentBase ::
   get_noArgsReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -726,7 +726,7 @@ InputNoArgsReturnPort* ActiveTelemetryComponentBase ::
   return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* ActiveTelemetryComponentBase ::
+Ports::InputNoArgsReturnPort* ActiveTelemetryComponentBase ::
   get_noArgsReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -737,7 +737,7 @@ InputNoArgsReturnPort* ActiveTelemetryComponentBase ::
   return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-InputNoArgsPort* ActiveTelemetryComponentBase ::
+Ports::InputNoArgsPort* ActiveTelemetryComponentBase ::
   get_noArgsSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTelemetryComponentAc.ref.cpp
@@ -29,14 +29,14 @@ namespace {
     BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
     BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
     BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE typedAsyncPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncAssertPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncBlockPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncDropPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedGuardedPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedReturnGuardedPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedReturnSyncPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedSyncPortSize[InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncAssertPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncBlockPriorityPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncDropPriorityPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedGuardedPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedReturnGuardedPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedReturnSyncPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedSyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
     BYTE cmdPortSize[Fw::InputCmdPort::SERIALIZED_SIZE];
   };
 
@@ -748,7 +748,7 @@ Ports::InputNoArgsPort* ActiveTelemetryComponentBase ::
   return &this->m_noArgsSync_InputPort[portNum];
 }
 
-InputTypedPort* ActiveTelemetryComponentBase ::
+Ports::InputTypedPort* ActiveTelemetryComponentBase ::
   get_typedAsync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -759,7 +759,7 @@ InputTypedPort* ActiveTelemetryComponentBase ::
   return &this->m_typedAsync_InputPort[portNum];
 }
 
-InputTypedPort* ActiveTelemetryComponentBase ::
+Ports::InputTypedPort* ActiveTelemetryComponentBase ::
   get_typedAsyncAssert_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -770,7 +770,7 @@ InputTypedPort* ActiveTelemetryComponentBase ::
   return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-InputTypedPort* ActiveTelemetryComponentBase ::
+Ports::InputTypedPort* ActiveTelemetryComponentBase ::
   get_typedAsyncBlockPriority_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -781,7 +781,7 @@ InputTypedPort* ActiveTelemetryComponentBase ::
   return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-InputTypedPort* ActiveTelemetryComponentBase ::
+Ports::InputTypedPort* ActiveTelemetryComponentBase ::
   get_typedAsyncDropPriority_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -792,7 +792,7 @@ InputTypedPort* ActiveTelemetryComponentBase ::
   return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-InputTypedPort* ActiveTelemetryComponentBase ::
+Ports::InputTypedPort* ActiveTelemetryComponentBase ::
   get_typedGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -803,7 +803,7 @@ InputTypedPort* ActiveTelemetryComponentBase ::
   return &this->m_typedGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* ActiveTelemetryComponentBase ::
+Ports::InputTypedReturnPort* ActiveTelemetryComponentBase ::
   get_typedReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -814,7 +814,7 @@ InputTypedReturnPort* ActiveTelemetryComponentBase ::
   return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* ActiveTelemetryComponentBase ::
+Ports::InputTypedReturnPort* ActiveTelemetryComponentBase ::
   get_typedReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -825,7 +825,7 @@ InputTypedReturnPort* ActiveTelemetryComponentBase ::
   return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-InputTypedPort* ActiveTelemetryComponentBase ::
+Ports::InputTypedPort* ActiveTelemetryComponentBase ::
   get_typedSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -963,7 +963,7 @@ void ActiveTelemetryComponentBase ::
 void ActiveTelemetryComponentBase ::
   set_typedOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -977,7 +977,7 @@ void ActiveTelemetryComponentBase ::
 void ActiveTelemetryComponentBase ::
   set_typedReturnOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -1552,7 +1552,7 @@ void ActiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1659,7 +1659,7 @@ void ActiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1766,7 +1766,7 @@ void ActiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1873,7 +1873,7 @@ void ActiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1985,7 +1985,7 @@ void ActiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2022,7 +2022,7 @@ F32 ActiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2063,7 +2063,7 @@ F32 ActiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2098,7 +2098,7 @@ void ActiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2143,7 +2143,7 @@ void ActiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2158,7 +2158,7 @@ void ActiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2173,7 +2173,7 @@ void ActiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2188,7 +2188,7 @@ void ActiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2207,7 +2207,7 @@ void ActiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2234,7 +2234,7 @@ F32 ActiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2767,7 +2767,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -2839,7 +2839,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -2911,7 +2911,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -2983,7 +2983,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus ActiveTelemetryComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -3120,7 +3120,7 @@ void ActiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3147,7 +3147,7 @@ void ActiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3174,7 +3174,7 @@ void ActiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3201,7 +3201,7 @@ void ActiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3228,7 +3228,7 @@ void ActiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3255,7 +3255,7 @@ F32 ActiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -3282,7 +3282,7 @@ F32 ActiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -3309,7 +3309,7 @@ void ActiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTelemetryComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTelemetryComponentAc.ref.hpp
@@ -177,56 +177,56 @@ class ActiveTelemetryComponentBase :
     //! Get typed input port at index
     //!
     //! \return typedAsync[portNum]
-    InputTypedPort* get_typedAsync_InputPort(
+    Ports::InputTypedPort* get_typedAsync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncAssert[portNum]
-    InputTypedPort* get_typedAsyncAssert_InputPort(
+    Ports::InputTypedPort* get_typedAsyncAssert_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncBlockPriority[portNum]
-    InputTypedPort* get_typedAsyncBlockPriority_InputPort(
+    Ports::InputTypedPort* get_typedAsyncBlockPriority_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncDropPriority[portNum]
-    InputTypedPort* get_typedAsyncDropPriority_InputPort(
+    Ports::InputTypedPort* get_typedAsyncDropPriority_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedGuarded[portNum]
-    InputTypedPort* get_typedGuarded_InputPort(
+    Ports::InputTypedPort* get_typedGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnGuarded[portNum]
-    InputTypedReturnPort* get_typedReturnGuarded_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnSync[portNum]
-    InputTypedReturnPort* get_typedReturnSync_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedSync[portNum]
-    InputTypedPort* get_typedSync_InputPort(
+    Ports::InputTypedPort* get_typedSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -297,13 +297,13 @@ class ActiveTelemetryComponentBase :
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnOut[portNum]
     void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
 #if FW_PORT_SERIALIZATION
@@ -663,7 +663,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -675,7 +675,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -687,7 +687,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -699,7 +699,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -711,7 +711,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -723,7 +723,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -735,7 +735,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -747,7 +747,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -792,7 +792,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -804,7 +804,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -816,7 +816,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -828,7 +828,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -840,7 +840,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -852,7 +852,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -864,7 +864,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -876,7 +876,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -903,7 +903,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -915,7 +915,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -927,7 +927,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -939,7 +939,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -957,7 +957,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -969,7 +969,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1162,7 +1162,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1175,7 +1175,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1188,7 +1188,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1201,7 +1201,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1214,7 +1214,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1227,7 +1227,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1240,7 +1240,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1253,7 +1253,7 @@ class ActiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1290,28 +1290,28 @@ class ActiveTelemetryComponentBase :
     Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedAsync
-    InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];
 
     //! Input port typedAsyncAssert
-    InputTypedPort m_typedAsyncAssert_InputPort[NUM_TYPEDASYNCASSERT_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncAssert_InputPort[NUM_TYPEDASYNCASSERT_INPUT_PORTS];
 
     //! Input port typedAsyncBlockPriority
-    InputTypedPort m_typedAsyncBlockPriority_InputPort[NUM_TYPEDASYNCBLOCKPRIORITY_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncBlockPriority_InputPort[NUM_TYPEDASYNCBLOCKPRIORITY_INPUT_PORTS];
 
     //! Input port typedAsyncDropPriority
-    InputTypedPort m_typedAsyncDropPriority_InputPort[NUM_TYPEDASYNCDROPPRIORITY_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncDropPriority_InputPort[NUM_TYPEDASYNCDROPPRIORITY_INPUT_PORTS];
 
     //! Input port typedGuarded
-    InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
+    Ports::InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnGuarded
-    InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnSync
-    InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
 
     //! Input port typedSync
-    InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
 
   PRIVATE:
 
@@ -1354,10 +1354,10 @@ class ActiveTelemetryComponentBase :
     // ----------------------------------------------------------------------
 
     //! Output port typedOut
-    OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
+    Ports::OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
 
     //! Output port typedReturnOut
-    OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
+    Ports::OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
 
   PRIVATE:
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTelemetryComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTelemetryComponentAc.ref.hpp
@@ -142,35 +142,35 @@ class ActiveTelemetryComponentBase :
     //! Get typed input port at index
     //!
     //! \return noArgsAsync[portNum]
-    InputNoArgsPort* get_noArgsAsync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsAsync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsGuarded[portNum]
-    InputNoArgsPort* get_noArgsGuarded_InputPort(
+    Ports::InputNoArgsPort* get_noArgsGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnGuarded[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnSync[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsSync[portNum]
-    InputNoArgsPort* get_noArgsSync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -1275,19 +1275,19 @@ class ActiveTelemetryComponentBase :
     // ----------------------------------------------------------------------
 
     //! Input port noArgsAsync
-    InputNoArgsPort m_noArgsAsync_InputPort[NUM_NOARGSASYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsAsync_InputPort[NUM_NOARGSASYNC_INPUT_PORTS];
 
     //! Input port noArgsGuarded
-    InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnGuarded
-    InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnSync
-    InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
 
     //! Input port noArgsSync
-    InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedAsync
     InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTelemetryTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTelemetryTesterBase.ref.cpp
@@ -418,7 +418,7 @@ void ActiveTelemetryTesterBase ::
 void ActiveTelemetryTesterBase ::
   connect_to_noArgsAsync(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsPort* port
+      Ports::InputNoArgsPort* port
   )
 {
   FW_ASSERT(
@@ -432,7 +432,7 @@ void ActiveTelemetryTesterBase ::
 void ActiveTelemetryTesterBase ::
   connect_to_noArgsGuarded(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsPort* port
+      Ports::InputNoArgsPort* port
   )
 {
   FW_ASSERT(
@@ -446,7 +446,7 @@ void ActiveTelemetryTesterBase ::
 void ActiveTelemetryTesterBase ::
   connect_to_noArgsReturnGuarded(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsReturnPort* port
+      Ports::InputNoArgsReturnPort* port
   )
 {
   FW_ASSERT(
@@ -460,7 +460,7 @@ void ActiveTelemetryTesterBase ::
 void ActiveTelemetryTesterBase ::
   connect_to_noArgsReturnSync(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsReturnPort* port
+      Ports::InputNoArgsReturnPort* port
   )
 {
   FW_ASSERT(
@@ -474,7 +474,7 @@ void ActiveTelemetryTesterBase ::
 void ActiveTelemetryTesterBase ::
   connect_to_noArgsSync(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsPort* port
+      Ports::InputNoArgsPort* port
   )
 {
   FW_ASSERT(

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTelemetryTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTelemetryTesterBase.ref.cpp
@@ -488,7 +488,7 @@ void ActiveTelemetryTesterBase ::
 void ActiveTelemetryTesterBase ::
   connect_to_typedAsync(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -502,7 +502,7 @@ void ActiveTelemetryTesterBase ::
 void ActiveTelemetryTesterBase ::
   connect_to_typedAsyncAssert(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -516,7 +516,7 @@ void ActiveTelemetryTesterBase ::
 void ActiveTelemetryTesterBase ::
   connect_to_typedAsyncBlockPriority(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -530,7 +530,7 @@ void ActiveTelemetryTesterBase ::
 void ActiveTelemetryTesterBase ::
   connect_to_typedAsyncDropPriority(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -544,7 +544,7 @@ void ActiveTelemetryTesterBase ::
 void ActiveTelemetryTesterBase ::
   connect_to_typedGuarded(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -558,7 +558,7 @@ void ActiveTelemetryTesterBase ::
 void ActiveTelemetryTesterBase ::
   connect_to_typedReturnGuarded(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -572,7 +572,7 @@ void ActiveTelemetryTesterBase ::
 void ActiveTelemetryTesterBase ::
   connect_to_typedReturnSync(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -586,7 +586,7 @@ void ActiveTelemetryTesterBase ::
 void ActiveTelemetryTesterBase ::
   connect_to_typedSync(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -693,7 +693,7 @@ Fw::InputTlmPort* ActiveTelemetryTesterBase ::
   return &this->m_from_tlmOut[portNum];
 }
 
-InputTypedPort* ActiveTelemetryTesterBase ::
+Ports::InputTypedPort* ActiveTelemetryTesterBase ::
   get_from_typedOut(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -704,7 +704,7 @@ InputTypedPort* ActiveTelemetryTesterBase ::
   return &this->m_from_typedOut[portNum];
 }
 
-InputTypedReturnPort* ActiveTelemetryTesterBase ::
+Ports::InputTypedReturnPort* ActiveTelemetryTesterBase ::
   get_from_typedReturnOut(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -778,7 +778,7 @@ void ActiveTelemetryTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -807,7 +807,7 @@ F32 ActiveTelemetryTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -895,7 +895,7 @@ void ActiveTelemetryTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -923,7 +923,7 @@ void ActiveTelemetryTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -951,7 +951,7 @@ void ActiveTelemetryTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -979,7 +979,7 @@ void ActiveTelemetryTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1007,7 +1007,7 @@ void ActiveTelemetryTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1035,7 +1035,7 @@ F32 ActiveTelemetryTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1063,7 +1063,7 @@ F32 ActiveTelemetryTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1091,7 +1091,7 @@ void ActiveTelemetryTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1745,7 +1745,7 @@ void ActiveTelemetryTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1769,7 +1769,7 @@ void ActiveTelemetryTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1840,7 +1840,7 @@ void ActiveTelemetryTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1867,7 +1867,7 @@ F32 ActiveTelemetryTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTelemetryTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTelemetryTesterBase.ref.hpp
@@ -220,31 +220,31 @@ class ActiveTelemetryTesterBase :
     //! Connect port to noArgsAsync[portNum]
     void connect_to_noArgsAsync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsPort* port //!< The input port
+        Ports::InputNoArgsPort* port //!< The input port
     );
 
     //! Connect port to noArgsGuarded[portNum]
     void connect_to_noArgsGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsPort* port //!< The input port
+        Ports::InputNoArgsPort* port //!< The input port
     );
 
     //! Connect port to noArgsReturnGuarded[portNum]
     void connect_to_noArgsReturnGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsReturnPort* port //!< The input port
+        Ports::InputNoArgsReturnPort* port //!< The input port
     );
 
     //! Connect port to noArgsReturnSync[portNum]
     void connect_to_noArgsReturnSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsReturnPort* port //!< The input port
+        Ports::InputNoArgsReturnPort* port //!< The input port
     );
 
     //! Connect port to noArgsSync[portNum]
     void connect_to_noArgsSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsPort* port //!< The input port
+        Ports::InputNoArgsPort* port //!< The input port
     );
 
     //! Connect port to typedAsync[portNum]
@@ -1047,19 +1047,19 @@ class ActiveTelemetryTesterBase :
     Fw::OutputCmdPort m_to_cmdIn[1];
 
     //! To port connected to noArgsAsync
-    OutputNoArgsPort m_to_noArgsAsync[1];
+    Ports::OutputNoArgsPort m_to_noArgsAsync[1];
 
     //! To port connected to noArgsGuarded
-    OutputNoArgsPort m_to_noArgsGuarded[1];
+    Ports::OutputNoArgsPort m_to_noArgsGuarded[1];
 
     //! To port connected to noArgsReturnGuarded
-    OutputNoArgsReturnPort m_to_noArgsReturnGuarded[1];
+    Ports::OutputNoArgsReturnPort m_to_noArgsReturnGuarded[1];
 
     //! To port connected to noArgsReturnSync
-    OutputNoArgsReturnPort m_to_noArgsReturnSync[3];
+    Ports::OutputNoArgsReturnPort m_to_noArgsReturnSync[3];
 
     //! To port connected to noArgsSync
-    OutputNoArgsPort m_to_noArgsSync[3];
+    Ports::OutputNoArgsPort m_to_noArgsSync[3];
 
     //! To port connected to typedAsync
     OutputTypedPort m_to_typedAsync[1];

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTelemetryTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTelemetryTesterBase.ref.hpp
@@ -111,7 +111,7 @@ class ActiveTelemetryTesterBase :
       U32 u32;
       F32 f32;
       bool b;
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       E e;
       A a;
       S s;
@@ -122,7 +122,7 @@ class ActiveTelemetryTesterBase :
       U32 u32;
       F32 f32;
       bool b;
-      TypedReturnPortStrings::StringSize80 str2;
+      Ports::TypedReturnPortStrings::StringSize80 str2;
       E e;
       A a;
       S s;
@@ -250,49 +250,49 @@ class ActiveTelemetryTesterBase :
     //! Connect port to typedAsync[portNum]
     void connect_to_typedAsync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedAsyncAssert[portNum]
     void connect_to_typedAsyncAssert(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedAsyncBlockPriority[portNum]
     void connect_to_typedAsyncBlockPriority(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedAsyncDropPriority[portNum]
     void connect_to_typedAsyncDropPriority(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedGuarded[portNum]
     void connect_to_typedGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnGuarded[portNum]
     void connect_to_typedReturnGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
     //! Connect port to typedReturnSync[portNum]
     void connect_to_typedReturnSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
     //! Connect port to typedSync[portNum]
     void connect_to_typedSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
   public:
@@ -364,14 +364,14 @@ class ActiveTelemetryTesterBase :
     //! Get from port at index
     //!
     //! \return from_typedOut[portNum]
-    InputTypedPort* get_from_typedOut(
+    Ports::InputTypedPort* get_from_typedOut(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get from port at index
     //!
     //! \return from_typedReturnOut[portNum]
-    InputTypedReturnPort* get_from_typedReturnOut(
+    Ports::InputTypedReturnPort* get_from_typedReturnOut(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -402,7 +402,7 @@ class ActiveTelemetryTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -414,7 +414,7 @@ class ActiveTelemetryTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -432,7 +432,7 @@ class ActiveTelemetryTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -444,7 +444,7 @@ class ActiveTelemetryTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -487,7 +487,7 @@ class ActiveTelemetryTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -499,7 +499,7 @@ class ActiveTelemetryTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -511,7 +511,7 @@ class ActiveTelemetryTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -523,7 +523,7 @@ class ActiveTelemetryTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -535,7 +535,7 @@ class ActiveTelemetryTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -547,7 +547,7 @@ class ActiveTelemetryTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -559,7 +559,7 @@ class ActiveTelemetryTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -571,7 +571,7 @@ class ActiveTelemetryTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -918,7 +918,7 @@ class ActiveTelemetryTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -929,7 +929,7 @@ class ActiveTelemetryTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -967,7 +967,7 @@ class ActiveTelemetryTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -980,7 +980,7 @@ class ActiveTelemetryTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1062,28 +1062,28 @@ class ActiveTelemetryTesterBase :
     Ports::OutputNoArgsPort m_to_noArgsSync[3];
 
     //! To port connected to typedAsync
-    OutputTypedPort m_to_typedAsync[1];
+    Ports::OutputTypedPort m_to_typedAsync[1];
 
     //! To port connected to typedAsyncAssert
-    OutputTypedPort m_to_typedAsyncAssert[1];
+    Ports::OutputTypedPort m_to_typedAsyncAssert[1];
 
     //! To port connected to typedAsyncBlockPriority
-    OutputTypedPort m_to_typedAsyncBlockPriority[1];
+    Ports::OutputTypedPort m_to_typedAsyncBlockPriority[1];
 
     //! To port connected to typedAsyncDropPriority
-    OutputTypedPort m_to_typedAsyncDropPriority[1];
+    Ports::OutputTypedPort m_to_typedAsyncDropPriority[1];
 
     //! To port connected to typedGuarded
-    OutputTypedPort m_to_typedGuarded[1];
+    Ports::OutputTypedPort m_to_typedGuarded[1];
 
     //! To port connected to typedReturnGuarded
-    OutputTypedReturnPort m_to_typedReturnGuarded[1];
+    Ports::OutputTypedReturnPort m_to_typedReturnGuarded[1];
 
     //! To port connected to typedReturnSync
-    OutputTypedReturnPort m_to_typedReturnSync[3];
+    Ports::OutputTypedReturnPort m_to_typedReturnSync[3];
 
     //! To port connected to typedSync
-    OutputTypedPort m_to_typedSync[3];
+    Ports::OutputTypedPort m_to_typedSync[3];
 
   private:
 
@@ -1120,10 +1120,10 @@ class ActiveTelemetryTesterBase :
     Fw::InputTlmPort m_from_tlmOut[1];
 
     //! From port connected to typedOut
-    InputTypedPort m_from_typedOut[1];
+    Ports::InputTypedPort m_from_typedOut[1];
 
     //! From port connected to typedReturnOut
-    InputTypedReturnPort m_from_typedReturnOut[1];
+    Ports::InputTypedReturnPort m_from_typedReturnOut[1];
 
   private:
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestComponentAc.ref.cpp
@@ -37,11 +37,11 @@ namespace M {
 
     // Get the max size by doing a union of the input and internal port serialization sizes
     union BuffUnion {
-      BYTE noArgsAsyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-      BYTE noArgsGuardedPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-      BYTE noArgsReturnGuardedPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-      BYTE noArgsReturnSyncPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-      BYTE noArgsSyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
+      BYTE noArgsAsyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+      BYTE noArgsGuardedPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+      BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+      BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+      BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
       BYTE typedAsyncPortSize[InputTypedPort::SERIALIZED_SIZE];
       BYTE typedAsyncAssertPortSize[InputTypedPort::SERIALIZED_SIZE];
       BYTE typedAsyncBlockPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
@@ -731,7 +731,7 @@ namespace M {
   // Getters for typed input ports
   // ----------------------------------------------------------------------
 
-  InputNoArgsPort* ActiveTestComponentBase ::
+  Ports::InputNoArgsPort* ActiveTestComponentBase ::
     get_noArgsAsync_InputPort(NATIVE_INT_TYPE portNum)
   {
     FW_ASSERT(
@@ -742,7 +742,7 @@ namespace M {
     return &this->m_noArgsAsync_InputPort[portNum];
   }
 
-  InputNoArgsPort* ActiveTestComponentBase ::
+  Ports::InputNoArgsPort* ActiveTestComponentBase ::
     get_noArgsGuarded_InputPort(NATIVE_INT_TYPE portNum)
   {
     FW_ASSERT(
@@ -753,7 +753,7 @@ namespace M {
     return &this->m_noArgsGuarded_InputPort[portNum];
   }
 
-  InputNoArgsReturnPort* ActiveTestComponentBase ::
+  Ports::InputNoArgsReturnPort* ActiveTestComponentBase ::
     get_noArgsReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
   {
     FW_ASSERT(
@@ -764,7 +764,7 @@ namespace M {
     return &this->m_noArgsReturnGuarded_InputPort[portNum];
   }
 
-  InputNoArgsReturnPort* ActiveTestComponentBase ::
+  Ports::InputNoArgsReturnPort* ActiveTestComponentBase ::
     get_noArgsReturnSync_InputPort(NATIVE_INT_TYPE portNum)
   {
     FW_ASSERT(
@@ -775,7 +775,7 @@ namespace M {
     return &this->m_noArgsReturnSync_InputPort[portNum];
   }
 
-  InputNoArgsPort* ActiveTestComponentBase ::
+  Ports::InputNoArgsPort* ActiveTestComponentBase ::
     get_noArgsSync_InputPort(NATIVE_INT_TYPE portNum)
   {
     FW_ASSERT(

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestComponentAc.ref.cpp
@@ -42,14 +42,14 @@ namespace M {
       BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
       BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
       BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
-      BYTE typedAsyncPortSize[InputTypedPort::SERIALIZED_SIZE];
-      BYTE typedAsyncAssertPortSize[InputTypedPort::SERIALIZED_SIZE];
-      BYTE typedAsyncBlockPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
-      BYTE typedAsyncDropPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
-      BYTE typedGuardedPortSize[InputTypedPort::SERIALIZED_SIZE];
-      BYTE typedReturnGuardedPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-      BYTE typedReturnSyncPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-      BYTE typedSyncPortSize[InputTypedPort::SERIALIZED_SIZE];
+      BYTE typedAsyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+      BYTE typedAsyncAssertPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+      BYTE typedAsyncBlockPriorityPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+      BYTE typedAsyncDropPriorityPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+      BYTE typedGuardedPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+      BYTE typedReturnGuardedPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+      BYTE typedReturnSyncPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+      BYTE typedSyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
       BYTE cmdPortSize[Fw::InputCmdPort::SERIALIZED_SIZE];
       // Size of internalArray argument list
       BYTE internalArrayIntIfSize[
@@ -786,7 +786,7 @@ namespace M {
     return &this->m_noArgsSync_InputPort[portNum];
   }
 
-  InputTypedPort* ActiveTestComponentBase ::
+  Ports::InputTypedPort* ActiveTestComponentBase ::
     get_typedAsync_InputPort(NATIVE_INT_TYPE portNum)
   {
     FW_ASSERT(
@@ -797,7 +797,7 @@ namespace M {
     return &this->m_typedAsync_InputPort[portNum];
   }
 
-  InputTypedPort* ActiveTestComponentBase ::
+  Ports::InputTypedPort* ActiveTestComponentBase ::
     get_typedAsyncAssert_InputPort(NATIVE_INT_TYPE portNum)
   {
     FW_ASSERT(
@@ -808,7 +808,7 @@ namespace M {
     return &this->m_typedAsyncAssert_InputPort[portNum];
   }
 
-  InputTypedPort* ActiveTestComponentBase ::
+  Ports::InputTypedPort* ActiveTestComponentBase ::
     get_typedAsyncBlockPriority_InputPort(NATIVE_INT_TYPE portNum)
   {
     FW_ASSERT(
@@ -819,7 +819,7 @@ namespace M {
     return &this->m_typedAsyncBlockPriority_InputPort[portNum];
   }
 
-  InputTypedPort* ActiveTestComponentBase ::
+  Ports::InputTypedPort* ActiveTestComponentBase ::
     get_typedAsyncDropPriority_InputPort(NATIVE_INT_TYPE portNum)
   {
     FW_ASSERT(
@@ -830,7 +830,7 @@ namespace M {
     return &this->m_typedAsyncDropPriority_InputPort[portNum];
   }
 
-  InputTypedPort* ActiveTestComponentBase ::
+  Ports::InputTypedPort* ActiveTestComponentBase ::
     get_typedGuarded_InputPort(NATIVE_INT_TYPE portNum)
   {
     FW_ASSERT(
@@ -841,7 +841,7 @@ namespace M {
     return &this->m_typedGuarded_InputPort[portNum];
   }
 
-  InputTypedReturnPort* ActiveTestComponentBase ::
+  Ports::InputTypedReturnPort* ActiveTestComponentBase ::
     get_typedReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
   {
     FW_ASSERT(
@@ -852,7 +852,7 @@ namespace M {
     return &this->m_typedReturnGuarded_InputPort[portNum];
   }
 
-  InputTypedReturnPort* ActiveTestComponentBase ::
+  Ports::InputTypedReturnPort* ActiveTestComponentBase ::
     get_typedReturnSync_InputPort(NATIVE_INT_TYPE portNum)
   {
     FW_ASSERT(
@@ -863,7 +863,7 @@ namespace M {
     return &this->m_typedReturnSync_InputPort[portNum];
   }
 
-  InputTypedPort* ActiveTestComponentBase ::
+  Ports::InputTypedPort* ActiveTestComponentBase ::
     get_typedSync_InputPort(NATIVE_INT_TYPE portNum)
   {
     FW_ASSERT(
@@ -1001,7 +1001,7 @@ namespace M {
   void ActiveTestComponentBase ::
     set_typedOut_OutputPort(
         NATIVE_INT_TYPE portNum,
-        InputTypedPort* port
+        Ports::InputTypedPort* port
     )
   {
     FW_ASSERT(
@@ -1015,7 +1015,7 @@ namespace M {
   void ActiveTestComponentBase ::
     set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum,
-        InputTypedReturnPort* port
+        Ports::InputTypedReturnPort* port
     )
   {
     FW_ASSERT(
@@ -1902,7 +1902,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s
@@ -2009,7 +2009,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s
@@ -2116,7 +2116,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s
@@ -2223,7 +2223,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s
@@ -2335,7 +2335,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s
@@ -2372,7 +2372,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedReturnPortStrings::StringSize80& str2,
+        const Ports::TypedReturnPortStrings::StringSize80& str2,
         const E& e,
         const A& a,
         const S& s
@@ -2413,7 +2413,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedReturnPortStrings::StringSize80& str2,
+        const Ports::TypedReturnPortStrings::StringSize80& str2,
         const E& e,
         const A& a,
         const S& s
@@ -2448,7 +2448,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s
@@ -2493,7 +2493,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s
@@ -2508,7 +2508,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s
@@ -2523,7 +2523,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s
@@ -2538,7 +2538,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s
@@ -2557,7 +2557,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s
@@ -2584,7 +2584,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedReturnPortStrings::StringSize80& str2,
+        const Ports::TypedReturnPortStrings::StringSize80& str2,
         const E& e,
         const A& a,
         const S& s
@@ -5154,7 +5154,7 @@ namespace M {
         );
 
         // Deserialize argument str1
-        TypedPortStrings::StringSize80 str1;
+        Ports::TypedPortStrings::StringSize80 str1;
         deserStatus = msg.deserialize(str1);
         FW_ASSERT(
           deserStatus == Fw::FW_SERIALIZE_OK,
@@ -5226,7 +5226,7 @@ namespace M {
         );
 
         // Deserialize argument str1
-        TypedPortStrings::StringSize80 str1;
+        Ports::TypedPortStrings::StringSize80 str1;
         deserStatus = msg.deserialize(str1);
         FW_ASSERT(
           deserStatus == Fw::FW_SERIALIZE_OK,
@@ -5298,7 +5298,7 @@ namespace M {
         );
 
         // Deserialize argument str1
-        TypedPortStrings::StringSize80 str1;
+        Ports::TypedPortStrings::StringSize80 str1;
         deserStatus = msg.deserialize(str1);
         FW_ASSERT(
           deserStatus == Fw::FW_SERIALIZE_OK,
@@ -5370,7 +5370,7 @@ namespace M {
         );
 
         // Deserialize argument str1
-        TypedPortStrings::StringSize80 str1;
+        Ports::TypedPortStrings::StringSize80 str1;
         deserStatus = msg.deserialize(str1);
         FW_ASSERT(
           deserStatus == Fw::FW_SERIALIZE_OK,
@@ -6230,7 +6230,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s
@@ -6257,7 +6257,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s
@@ -6284,7 +6284,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s
@@ -6311,7 +6311,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s
@@ -6338,7 +6338,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s
@@ -6365,7 +6365,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedReturnPortStrings::StringSize80& str2,
+        const Ports::TypedReturnPortStrings::StringSize80& str2,
         const E& e,
         const A& a,
         const S& s
@@ -6392,7 +6392,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedReturnPortStrings::StringSize80& str2,
+        const Ports::TypedReturnPortStrings::StringSize80& str2,
         const E& e,
         const A& a,
         const S& s
@@ -6419,7 +6419,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestComponentAc.ref.hpp
@@ -245,56 +245,56 @@ namespace M {
       //! Get typed input port at index
       //!
       //! \return typedAsync[portNum]
-      InputTypedPort* get_typedAsync_InputPort(
+      Ports::InputTypedPort* get_typedAsync_InputPort(
           NATIVE_INT_TYPE portNum //!< The port number
       );
 
       //! Get typed input port at index
       //!
       //! \return typedAsyncAssert[portNum]
-      InputTypedPort* get_typedAsyncAssert_InputPort(
+      Ports::InputTypedPort* get_typedAsyncAssert_InputPort(
           NATIVE_INT_TYPE portNum //!< The port number
       );
 
       //! Get typed input port at index
       //!
       //! \return typedAsyncBlockPriority[portNum]
-      InputTypedPort* get_typedAsyncBlockPriority_InputPort(
+      Ports::InputTypedPort* get_typedAsyncBlockPriority_InputPort(
           NATIVE_INT_TYPE portNum //!< The port number
       );
 
       //! Get typed input port at index
       //!
       //! \return typedAsyncDropPriority[portNum]
-      InputTypedPort* get_typedAsyncDropPriority_InputPort(
+      Ports::InputTypedPort* get_typedAsyncDropPriority_InputPort(
           NATIVE_INT_TYPE portNum //!< The port number
       );
 
       //! Get typed input port at index
       //!
       //! \return typedGuarded[portNum]
-      InputTypedPort* get_typedGuarded_InputPort(
+      Ports::InputTypedPort* get_typedGuarded_InputPort(
           NATIVE_INT_TYPE portNum //!< The port number
       );
 
       //! Get typed input port at index
       //!
       //! \return typedReturnGuarded[portNum]
-      InputTypedReturnPort* get_typedReturnGuarded_InputPort(
+      Ports::InputTypedReturnPort* get_typedReturnGuarded_InputPort(
           NATIVE_INT_TYPE portNum //!< The port number
       );
 
       //! Get typed input port at index
       //!
       //! \return typedReturnSync[portNum]
-      InputTypedReturnPort* get_typedReturnSync_InputPort(
+      Ports::InputTypedReturnPort* get_typedReturnSync_InputPort(
           NATIVE_INT_TYPE portNum //!< The port number
       );
 
       //! Get typed input port at index
       //!
       //! \return typedSync[portNum]
-      InputTypedPort* get_typedSync_InputPort(
+      Ports::InputTypedPort* get_typedSync_InputPort(
           NATIVE_INT_TYPE portNum //!< The port number
       );
 
@@ -365,13 +365,13 @@ namespace M {
       //! Connect port to typedOut[portNum]
       void set_typedOut_OutputPort(
           NATIVE_INT_TYPE portNum, //!< The port number
-          InputTypedPort* port //!< The input port
+          Ports::InputTypedPort* port //!< The input port
       );
 
       //! Connect port to typedReturnOut[portNum]
       void set_typedReturnOut_OutputPort(
           NATIVE_INT_TYPE portNum, //!< The port number
-          InputTypedReturnPort* port //!< The input port
+          Ports::InputTypedReturnPort* port //!< The input port
       );
 
 #if FW_PORT_SERIALIZATION
@@ -753,7 +753,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -765,7 +765,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -777,7 +777,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -789,7 +789,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -801,7 +801,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -813,7 +813,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedReturnPortStrings::StringSize80& str2, //!< A string
+          const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -825,7 +825,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedReturnPortStrings::StringSize80& str2, //!< A string
+          const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -837,7 +837,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -882,7 +882,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -894,7 +894,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -906,7 +906,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -918,7 +918,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -930,7 +930,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -942,7 +942,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedReturnPortStrings::StringSize80& str2, //!< A string
+          const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -954,7 +954,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedReturnPortStrings::StringSize80& str2, //!< A string
+          const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -966,7 +966,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -993,7 +993,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -1005,7 +1005,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -1017,7 +1017,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -1029,7 +1029,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -1047,7 +1047,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -1059,7 +1059,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedReturnPortStrings::StringSize80& str2, //!< A string
+          const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -1852,7 +1852,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -1865,7 +1865,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -1878,7 +1878,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -1891,7 +1891,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -1904,7 +1904,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -1917,7 +1917,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedReturnPortStrings::StringSize80& str2, //!< A string
+          const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -1930,7 +1930,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedReturnPortStrings::StringSize80& str2, //!< A string
+          const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -1943,7 +1943,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -2064,28 +2064,28 @@ namespace M {
       Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
       //! Input port typedAsync
-      InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];
+      Ports::InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];
 
       //! Input port typedAsyncAssert
-      InputTypedPort m_typedAsyncAssert_InputPort[NUM_TYPEDASYNCASSERT_INPUT_PORTS];
+      Ports::InputTypedPort m_typedAsyncAssert_InputPort[NUM_TYPEDASYNCASSERT_INPUT_PORTS];
 
       //! Input port typedAsyncBlockPriority
-      InputTypedPort m_typedAsyncBlockPriority_InputPort[NUM_TYPEDASYNCBLOCKPRIORITY_INPUT_PORTS];
+      Ports::InputTypedPort m_typedAsyncBlockPriority_InputPort[NUM_TYPEDASYNCBLOCKPRIORITY_INPUT_PORTS];
 
       //! Input port typedAsyncDropPriority
-      InputTypedPort m_typedAsyncDropPriority_InputPort[NUM_TYPEDASYNCDROPPRIORITY_INPUT_PORTS];
+      Ports::InputTypedPort m_typedAsyncDropPriority_InputPort[NUM_TYPEDASYNCDROPPRIORITY_INPUT_PORTS];
 
       //! Input port typedGuarded
-      InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
+      Ports::InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
 
       //! Input port typedReturnGuarded
-      InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
+      Ports::InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
 
       //! Input port typedReturnSync
-      InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
+      Ports::InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
 
       //! Input port typedSync
-      InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
+      Ports::InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
 
     PRIVATE:
 
@@ -2128,10 +2128,10 @@ namespace M {
       // ----------------------------------------------------------------------
 
       //! Output port typedOut
-      OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
+      Ports::OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
 
       //! Output port typedReturnOut
-      OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
+      Ports::OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
 
     PRIVATE:
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestComponentAc.ref.hpp
@@ -210,35 +210,35 @@ namespace M {
       //! Get typed input port at index
       //!
       //! \return noArgsAsync[portNum]
-      InputNoArgsPort* get_noArgsAsync_InputPort(
+      Ports::InputNoArgsPort* get_noArgsAsync_InputPort(
           NATIVE_INT_TYPE portNum //!< The port number
       );
 
       //! Get typed input port at index
       //!
       //! \return noArgsGuarded[portNum]
-      InputNoArgsPort* get_noArgsGuarded_InputPort(
+      Ports::InputNoArgsPort* get_noArgsGuarded_InputPort(
           NATIVE_INT_TYPE portNum //!< The port number
       );
 
       //! Get typed input port at index
       //!
       //! \return noArgsReturnGuarded[portNum]
-      InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
+      Ports::InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
           NATIVE_INT_TYPE portNum //!< The port number
       );
 
       //! Get typed input port at index
       //!
       //! \return noArgsReturnSync[portNum]
-      InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
+      Ports::InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
           NATIVE_INT_TYPE portNum //!< The port number
       );
 
       //! Get typed input port at index
       //!
       //! \return noArgsSync[portNum]
-      InputNoArgsPort* get_noArgsSync_InputPort(
+      Ports::InputNoArgsPort* get_noArgsSync_InputPort(
           NATIVE_INT_TYPE portNum //!< The port number
       );
 
@@ -2049,19 +2049,19 @@ namespace M {
       // ----------------------------------------------------------------------
 
       //! Input port noArgsAsync
-      InputNoArgsPort m_noArgsAsync_InputPort[NUM_NOARGSASYNC_INPUT_PORTS];
+      Ports::InputNoArgsPort m_noArgsAsync_InputPort[NUM_NOARGSASYNC_INPUT_PORTS];
 
       //! Input port noArgsGuarded
-      InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
+      Ports::InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
 
       //! Input port noArgsReturnGuarded
-      InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
+      Ports::InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
 
       //! Input port noArgsReturnSync
-      InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
+      Ports::InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
 
       //! Input port noArgsSync
-      InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
+      Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
       //! Input port typedAsync
       InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.cpp
@@ -599,7 +599,7 @@ namespace M {
   void ActiveTestTesterBase ::
     connect_to_noArgsAsync(
         NATIVE_INT_TYPE portNum,
-        InputNoArgsPort* port
+        Ports::InputNoArgsPort* port
     )
   {
     FW_ASSERT(
@@ -613,7 +613,7 @@ namespace M {
   void ActiveTestTesterBase ::
     connect_to_noArgsGuarded(
         NATIVE_INT_TYPE portNum,
-        InputNoArgsPort* port
+        Ports::InputNoArgsPort* port
     )
   {
     FW_ASSERT(
@@ -627,7 +627,7 @@ namespace M {
   void ActiveTestTesterBase ::
     connect_to_noArgsReturnGuarded(
         NATIVE_INT_TYPE portNum,
-        InputNoArgsReturnPort* port
+        Ports::InputNoArgsReturnPort* port
     )
   {
     FW_ASSERT(
@@ -641,7 +641,7 @@ namespace M {
   void ActiveTestTesterBase ::
     connect_to_noArgsReturnSync(
         NATIVE_INT_TYPE portNum,
-        InputNoArgsReturnPort* port
+        Ports::InputNoArgsReturnPort* port
     )
   {
     FW_ASSERT(
@@ -655,7 +655,7 @@ namespace M {
   void ActiveTestTesterBase ::
     connect_to_noArgsSync(
         NATIVE_INT_TYPE portNum,
-        InputNoArgsPort* port
+        Ports::InputNoArgsPort* port
     )
   {
     FW_ASSERT(

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.cpp
@@ -669,7 +669,7 @@ namespace M {
   void ActiveTestTesterBase ::
     connect_to_typedAsync(
         NATIVE_INT_TYPE portNum,
-        InputTypedPort* port
+        Ports::InputTypedPort* port
     )
   {
     FW_ASSERT(
@@ -683,7 +683,7 @@ namespace M {
   void ActiveTestTesterBase ::
     connect_to_typedAsyncAssert(
         NATIVE_INT_TYPE portNum,
-        InputTypedPort* port
+        Ports::InputTypedPort* port
     )
   {
     FW_ASSERT(
@@ -697,7 +697,7 @@ namespace M {
   void ActiveTestTesterBase ::
     connect_to_typedAsyncBlockPriority(
         NATIVE_INT_TYPE portNum,
-        InputTypedPort* port
+        Ports::InputTypedPort* port
     )
   {
     FW_ASSERT(
@@ -711,7 +711,7 @@ namespace M {
   void ActiveTestTesterBase ::
     connect_to_typedAsyncDropPriority(
         NATIVE_INT_TYPE portNum,
-        InputTypedPort* port
+        Ports::InputTypedPort* port
     )
   {
     FW_ASSERT(
@@ -725,7 +725,7 @@ namespace M {
   void ActiveTestTesterBase ::
     connect_to_typedGuarded(
         NATIVE_INT_TYPE portNum,
-        InputTypedPort* port
+        Ports::InputTypedPort* port
     )
   {
     FW_ASSERT(
@@ -739,7 +739,7 @@ namespace M {
   void ActiveTestTesterBase ::
     connect_to_typedReturnGuarded(
         NATIVE_INT_TYPE portNum,
-        InputTypedReturnPort* port
+        Ports::InputTypedReturnPort* port
     )
   {
     FW_ASSERT(
@@ -753,7 +753,7 @@ namespace M {
   void ActiveTestTesterBase ::
     connect_to_typedReturnSync(
         NATIVE_INT_TYPE portNum,
-        InputTypedReturnPort* port
+        Ports::InputTypedReturnPort* port
     )
   {
     FW_ASSERT(
@@ -767,7 +767,7 @@ namespace M {
   void ActiveTestTesterBase ::
     connect_to_typedSync(
         NATIVE_INT_TYPE portNum,
-        InputTypedPort* port
+        Ports::InputTypedPort* port
     )
   {
     FW_ASSERT(
@@ -874,7 +874,7 @@ namespace M {
     return &this->m_from_tlmOut[portNum];
   }
 
-  InputTypedPort* ActiveTestTesterBase ::
+  Ports::InputTypedPort* ActiveTestTesterBase ::
     get_from_typedOut(NATIVE_INT_TYPE portNum)
   {
     FW_ASSERT(
@@ -885,7 +885,7 @@ namespace M {
     return &this->m_from_typedOut[portNum];
   }
 
-  InputTypedReturnPort* ActiveTestTesterBase ::
+  Ports::InputTypedReturnPort* ActiveTestTesterBase ::
     get_from_typedReturnOut(NATIVE_INT_TYPE portNum)
   {
     FW_ASSERT(
@@ -991,7 +991,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s
@@ -1020,7 +1020,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedReturnPortStrings::StringSize80& str2,
+        const Ports::TypedReturnPortStrings::StringSize80& str2,
         const E& e,
         const A& a,
         const S& s
@@ -1108,7 +1108,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s
@@ -1136,7 +1136,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s
@@ -1164,7 +1164,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s
@@ -1192,7 +1192,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s
@@ -1220,7 +1220,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s
@@ -1248,7 +1248,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedReturnPortStrings::StringSize80& str2,
+        const Ports::TypedReturnPortStrings::StringSize80& str2,
         const E& e,
         const A& a,
         const S& s
@@ -1276,7 +1276,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedReturnPortStrings::StringSize80& str2,
+        const Ports::TypedReturnPortStrings::StringSize80& str2,
         const E& e,
         const A& a,
         const S& s
@@ -1304,7 +1304,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s
@@ -3336,7 +3336,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s
@@ -3360,7 +3360,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedReturnPortStrings::StringSize80& str2,
+        const Ports::TypedReturnPortStrings::StringSize80& str2,
         const E& e,
         const A& a,
         const S& s
@@ -3754,7 +3754,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s
@@ -3781,7 +3781,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedReturnPortStrings::StringSize80& str2,
+        const Ports::TypedReturnPortStrings::StringSize80& str2,
         const E& e,
         const A& a,
         const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.hpp
@@ -269,31 +269,31 @@ namespace M {
       //! Connect port to noArgsAsync[portNum]
       void connect_to_noArgsAsync(
           NATIVE_INT_TYPE portNum, //!< The port number
-          InputNoArgsPort* port //!< The input port
+          Ports::InputNoArgsPort* port //!< The input port
       );
 
       //! Connect port to noArgsGuarded[portNum]
       void connect_to_noArgsGuarded(
           NATIVE_INT_TYPE portNum, //!< The port number
-          InputNoArgsPort* port //!< The input port
+          Ports::InputNoArgsPort* port //!< The input port
       );
 
       //! Connect port to noArgsReturnGuarded[portNum]
       void connect_to_noArgsReturnGuarded(
           NATIVE_INT_TYPE portNum, //!< The port number
-          InputNoArgsReturnPort* port //!< The input port
+          Ports::InputNoArgsReturnPort* port //!< The input port
       );
 
       //! Connect port to noArgsReturnSync[portNum]
       void connect_to_noArgsReturnSync(
           NATIVE_INT_TYPE portNum, //!< The port number
-          InputNoArgsReturnPort* port //!< The input port
+          Ports::InputNoArgsReturnPort* port //!< The input port
       );
 
       //! Connect port to noArgsSync[portNum]
       void connect_to_noArgsSync(
           NATIVE_INT_TYPE portNum, //!< The port number
-          InputNoArgsPort* port //!< The input port
+          Ports::InputNoArgsPort* port //!< The input port
       );
 
       //! Connect port to typedAsync[portNum]
@@ -1516,19 +1516,19 @@ namespace M {
       Fw::OutputCmdPort m_to_cmdIn[1];
 
       //! To port connected to noArgsAsync
-      OutputNoArgsPort m_to_noArgsAsync[1];
+      Ports::OutputNoArgsPort m_to_noArgsAsync[1];
 
       //! To port connected to noArgsGuarded
-      OutputNoArgsPort m_to_noArgsGuarded[1];
+      Ports::OutputNoArgsPort m_to_noArgsGuarded[1];
 
       //! To port connected to noArgsReturnGuarded
-      OutputNoArgsReturnPort m_to_noArgsReturnGuarded[1];
+      Ports::OutputNoArgsReturnPort m_to_noArgsReturnGuarded[1];
 
       //! To port connected to noArgsReturnSync
-      OutputNoArgsReturnPort m_to_noArgsReturnSync[3];
+      Ports::OutputNoArgsReturnPort m_to_noArgsReturnSync[3];
 
       //! To port connected to noArgsSync
-      OutputNoArgsPort m_to_noArgsSync[3];
+      Ports::OutputNoArgsPort m_to_noArgsSync[3];
 
       //! To port connected to typedAsync
       OutputTypedPort m_to_typedAsync[1];

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.hpp
@@ -113,7 +113,7 @@ namespace M {
         U32 u32;
         F32 f32;
         bool b;
-        TypedPortStrings::StringSize80 str1;
+        Ports::TypedPortStrings::StringSize80 str1;
         E e;
         A a;
         S s;
@@ -124,7 +124,7 @@ namespace M {
         U32 u32;
         F32 f32;
         bool b;
-        TypedReturnPortStrings::StringSize80 str2;
+        Ports::TypedReturnPortStrings::StringSize80 str2;
         E e;
         A a;
         S s;
@@ -299,49 +299,49 @@ namespace M {
       //! Connect port to typedAsync[portNum]
       void connect_to_typedAsync(
           NATIVE_INT_TYPE portNum, //!< The port number
-          InputTypedPort* port //!< The input port
+          Ports::InputTypedPort* port //!< The input port
       );
 
       //! Connect port to typedAsyncAssert[portNum]
       void connect_to_typedAsyncAssert(
           NATIVE_INT_TYPE portNum, //!< The port number
-          InputTypedPort* port //!< The input port
+          Ports::InputTypedPort* port //!< The input port
       );
 
       //! Connect port to typedAsyncBlockPriority[portNum]
       void connect_to_typedAsyncBlockPriority(
           NATIVE_INT_TYPE portNum, //!< The port number
-          InputTypedPort* port //!< The input port
+          Ports::InputTypedPort* port //!< The input port
       );
 
       //! Connect port to typedAsyncDropPriority[portNum]
       void connect_to_typedAsyncDropPriority(
           NATIVE_INT_TYPE portNum, //!< The port number
-          InputTypedPort* port //!< The input port
+          Ports::InputTypedPort* port //!< The input port
       );
 
       //! Connect port to typedGuarded[portNum]
       void connect_to_typedGuarded(
           NATIVE_INT_TYPE portNum, //!< The port number
-          InputTypedPort* port //!< The input port
+          Ports::InputTypedPort* port //!< The input port
       );
 
       //! Connect port to typedReturnGuarded[portNum]
       void connect_to_typedReturnGuarded(
           NATIVE_INT_TYPE portNum, //!< The port number
-          InputTypedReturnPort* port //!< The input port
+          Ports::InputTypedReturnPort* port //!< The input port
       );
 
       //! Connect port to typedReturnSync[portNum]
       void connect_to_typedReturnSync(
           NATIVE_INT_TYPE portNum, //!< The port number
-          InputTypedReturnPort* port //!< The input port
+          Ports::InputTypedReturnPort* port //!< The input port
       );
 
       //! Connect port to typedSync[portNum]
       void connect_to_typedSync(
           NATIVE_INT_TYPE portNum, //!< The port number
-          InputTypedPort* port //!< The input port
+          Ports::InputTypedPort* port //!< The input port
       );
 
     public:
@@ -413,14 +413,14 @@ namespace M {
       //! Get from port at index
       //!
       //! \return from_typedOut[portNum]
-      InputTypedPort* get_from_typedOut(
+      Ports::InputTypedPort* get_from_typedOut(
           NATIVE_INT_TYPE portNum //!< The port number
       );
 
       //! Get from port at index
       //!
       //! \return from_typedReturnOut[portNum]
-      InputTypedReturnPort* get_from_typedReturnOut(
+      Ports::InputTypedReturnPort* get_from_typedReturnOut(
           NATIVE_INT_TYPE portNum //!< The port number
       );
 
@@ -451,7 +451,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -463,7 +463,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedReturnPortStrings::StringSize80& str2, //!< A string
+          const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -481,7 +481,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -493,7 +493,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedReturnPortStrings::StringSize80& str2, //!< A string
+          const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -536,7 +536,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -548,7 +548,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -560,7 +560,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -572,7 +572,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -584,7 +584,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -596,7 +596,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedReturnPortStrings::StringSize80& str2, //!< A string
+          const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -608,7 +608,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedReturnPortStrings::StringSize80& str2, //!< A string
+          const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -620,7 +620,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -1281,7 +1281,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -1292,7 +1292,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedReturnPortStrings::StringSize80& str2, //!< A string
+          const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -1402,7 +1402,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -1415,7 +1415,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedReturnPortStrings::StringSize80& str2, //!< A string
+          const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -1531,28 +1531,28 @@ namespace M {
       Ports::OutputNoArgsPort m_to_noArgsSync[3];
 
       //! To port connected to typedAsync
-      OutputTypedPort m_to_typedAsync[1];
+      Ports::OutputTypedPort m_to_typedAsync[1];
 
       //! To port connected to typedAsyncAssert
-      OutputTypedPort m_to_typedAsyncAssert[1];
+      Ports::OutputTypedPort m_to_typedAsyncAssert[1];
 
       //! To port connected to typedAsyncBlockPriority
-      OutputTypedPort m_to_typedAsyncBlockPriority[1];
+      Ports::OutputTypedPort m_to_typedAsyncBlockPriority[1];
 
       //! To port connected to typedAsyncDropPriority
-      OutputTypedPort m_to_typedAsyncDropPriority[1];
+      Ports::OutputTypedPort m_to_typedAsyncDropPriority[1];
 
       //! To port connected to typedGuarded
-      OutputTypedPort m_to_typedGuarded[1];
+      Ports::OutputTypedPort m_to_typedGuarded[1];
 
       //! To port connected to typedReturnGuarded
-      OutputTypedReturnPort m_to_typedReturnGuarded[1];
+      Ports::OutputTypedReturnPort m_to_typedReturnGuarded[1];
 
       //! To port connected to typedReturnSync
-      OutputTypedReturnPort m_to_typedReturnSync[3];
+      Ports::OutputTypedReturnPort m_to_typedReturnSync[3];
 
       //! To port connected to typedSync
-      OutputTypedPort m_to_typedSync[3];
+      Ports::OutputTypedPort m_to_typedSync[3];
 
     private:
 
@@ -1589,10 +1589,10 @@ namespace M {
       Fw::InputTlmPort m_from_tlmOut[1];
 
       //! From port connected to typedOut
-      InputTypedPort m_from_typedOut[1];
+      Ports::InputTypedPort m_from_typedOut[1];
 
       //! From port connected to typedReturnOut
-      InputTypedReturnPort m_from_typedReturnOut[1];
+      Ports::InputTypedReturnPort m_from_typedReturnOut[1];
 
     private:
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/NoArgsPortAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/NoArgsPortAc.ref.cpp
@@ -8,151 +8,155 @@
 #include "Fw/Types/StringUtils.hpp"
 #include "test-base/NoArgsPortAc.hpp"
 
-namespace {
+namespace Ports {
+
+  namespace {
+
+    // ----------------------------------------------------------------------
+    // Port buffer class
+    // ----------------------------------------------------------------------
+
+    class NoArgsPortBuffer : public Fw::SerializeBufferBase {
+
+      public:
+
+        NATIVE_UINT_TYPE getBuffCapacity() const {
+          return InputNoArgsPort::SERIALIZED_SIZE;
+        }
+
+        U8* getBuffAddr() {
+          return nullptr;
+        }
+
+        const U8* getBuffAddr() const {
+          return nullptr;
+        }
+
+    };
+
+  }
 
   // ----------------------------------------------------------------------
-  // Port buffer class
+  // Input Port Member functions
   // ----------------------------------------------------------------------
 
-  class NoArgsPortBuffer : public Fw::SerializeBufferBase {
+  InputNoArgsPort ::
+    InputNoArgsPort() :
+      Fw::InputPortBase(),
+      m_func(nullptr)
+  {
 
-    public:
+  }
 
-      NATIVE_UINT_TYPE getBuffCapacity() const {
-        return InputNoArgsPort::SERIALIZED_SIZE;
-      }
+  void InputNoArgsPort ::
+    init()
+  {
+    Fw::InputPortBase::init();
+  }
 
-      U8* getBuffAddr() {
-        return nullptr;
-      }
+  void InputNoArgsPort ::
+    addCallComp(
+        Fw::PassiveComponentBase* callComp,
+        CompFuncPtr funcPtr
+    )
+  {
+    FW_ASSERT(callComp != nullptr);
+    FW_ASSERT(funcPtr != nullptr);
 
-      const U8* getBuffAddr() const {
-        return nullptr;
-      }
+    this->m_comp = callComp;
+    this->m_func = funcPtr;
+    this->m_connObj = callComp;
+  }
 
-  };
-
-}
-
-// ----------------------------------------------------------------------
-// Input Port Member functions
-// ----------------------------------------------------------------------
-
-InputNoArgsPort ::
-  InputNoArgsPort() :
-    Fw::InputPortBase(),
-    m_func(nullptr)
-{
-
-}
-
-void InputNoArgsPort ::
-  init()
-{
-  Fw::InputPortBase::init();
-}
-
-void InputNoArgsPort ::
-  addCallComp(
-      Fw::PassiveComponentBase* callComp,
-      CompFuncPtr funcPtr
-  )
-{
-  FW_ASSERT(callComp != nullptr);
-  FW_ASSERT(funcPtr != nullptr);
-
-  this->m_comp = callComp;
-  this->m_func = funcPtr;
-  this->m_connObj = callComp;
-}
-
-void InputNoArgsPort ::
-  invoke()
-{
+  void InputNoArgsPort ::
+    invoke()
+  {
 #if FW_PORT_TRACING == 1
-  this->trace();
+    this->trace();
 #endif
 
-  FW_ASSERT(this->m_comp != nullptr);
-  FW_ASSERT(this->m_func != nullptr);
+    FW_ASSERT(this->m_comp != nullptr);
+    FW_ASSERT(this->m_func != nullptr);
 
-  return this->m_func(this->m_comp, this->m_portNum);
-}
+    return this->m_func(this->m_comp, this->m_portNum);
+  }
 
 #if FW_PORT_SERIALIZATION == 1
 
-Fw::SerializeStatus InputNoArgsPort ::
-  invokeSerial(Fw::SerializeBufferBase& _buffer)
-{
-  (void) _buffer;
+  Fw::SerializeStatus InputNoArgsPort ::
+    invokeSerial(Fw::SerializeBufferBase& _buffer)
+  {
+    (void) _buffer;
 
 #if FW_PORT_TRACING == 1
-  this->trace();
+    this->trace();
 #endif
 
-  FW_ASSERT(this->m_comp != nullptr);
-  FW_ASSERT(this->m_func != nullptr);
+    FW_ASSERT(this->m_comp != nullptr);
+    FW_ASSERT(this->m_func != nullptr);
 
-  this->m_func(this->m_comp, this->m_portNum);
+    this->m_func(this->m_comp, this->m_portNum);
 
-  return Fw::FW_SERIALIZE_OK;
-}
+    return Fw::FW_SERIALIZE_OK;
+  }
 
 #endif
 
-// ----------------------------------------------------------------------
-// Output Port Member functions
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Output Port Member functions
+  // ----------------------------------------------------------------------
 
-OutputNoArgsPort ::
-  OutputNoArgsPort() :
-    Fw::OutputPortBase(),
-    m_port(nullptr)
-{
+  OutputNoArgsPort ::
+    OutputNoArgsPort() :
+      Fw::OutputPortBase(),
+      m_port(nullptr)
+  {
 
-}
+  }
 
-void OutputNoArgsPort ::
-  init()
-{
-  Fw::OutputPortBase::init();
-}
+  void OutputNoArgsPort ::
+    init()
+  {
+    Fw::OutputPortBase::init();
+  }
 
-void OutputNoArgsPort ::
-  addCallPort(InputNoArgsPort* callPort)
-{
-  FW_ASSERT(callPort != nullptr);
+  void OutputNoArgsPort ::
+    addCallPort(InputNoArgsPort* callPort)
+  {
+    FW_ASSERT(callPort != nullptr);
 
-  this->m_port = callPort;
-  this->m_connObj = callPort;
+    this->m_port = callPort;
+    this->m_connObj = callPort;
 
 #if FW_PORT_SERIALIZATION == 1
-  this->m_serPort = nullptr;
+    this->m_serPort = nullptr;
 #endif
-}
+  }
 
-void OutputNoArgsPort ::
-  invoke()
-{
+  void OutputNoArgsPort ::
+    invoke()
+  {
 #if FW_PORT_TRACING == 1
-  this->trace();
+    this->trace();
 #endif
 
 #if FW_PORT_SERIALIZATION
-  FW_ASSERT((this->m_port != nullptr) || (this->m_serPort != nullptr));
+    FW_ASSERT((this->m_port != nullptr) || (this->m_serPort != nullptr));
 
-  if (this->m_port != nullptr) {
-    this->m_port->invoke();
-  }
-  else {
-    Fw::SerializeStatus _status;
-    NoArgsPortBuffer _buffer;
+    if (this->m_port != nullptr) {
+      this->m_port->invoke();
+    }
+    else {
+      Fw::SerializeStatus _status;
+      NoArgsPortBuffer _buffer;
 
-    _status = this->m_serPort->invokeSerial(_buffer);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-  }
+      _status = this->m_serPort->invokeSerial(_buffer);
+      FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    }
 #else
-  FW_ASSERT(this->m_port != nullptr);
-  this->m_port->invoke();
+    FW_ASSERT(this->m_port != nullptr);
+    this->m_port->invoke();
 #endif
+  }
+
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/NoArgsPortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/NoArgsPortAc.ref.hpp
@@ -4,8 +4,8 @@
 // \brief  hpp file for NoArgs port
 // ======================================================================
 
-#ifndef NoArgsPortAc_HPP
-#define NoArgsPortAc_HPP
+#ifndef Ports_NoArgsPortAc_HPP
+#define Ports_NoArgsPortAc_HPP
 
 #include <cstdio>
 #include <cstring>
@@ -17,111 +17,115 @@
 #include "Fw/Types/Serializable.hpp"
 #include "Fw/Types/StringType.hpp"
 
-//! Input NoArgs port
-//! A typed port with no arguments
-class InputNoArgsPort :
-  public Fw::InputPortBase
-{
+namespace Ports {
 
-  public:
+  //! Input NoArgs port
+  //! A typed port with no arguments
+  class InputNoArgsPort :
+    public Fw::InputPortBase
+  {
 
-    // ----------------------------------------------------------------------
-    // Constants
-    // ----------------------------------------------------------------------
+    public:
 
-    enum {
-      //! The size of the serial representations of the port arguments
-      SERIALIZED_SIZE = 0
-    };
+      // ----------------------------------------------------------------------
+      // Constants
+      // ----------------------------------------------------------------------
 
-  public:
+      enum {
+        //! The size of the serial representations of the port arguments
+        SERIALIZED_SIZE = 0
+      };
 
-    // ----------------------------------------------------------------------
-    // Types
-    // ----------------------------------------------------------------------
+    public:
 
-    //! The port callback function type
-    typedef void (*CompFuncPtr)(
-      Fw::PassiveComponentBase* callComp,
-      NATIVE_INT_TYPE portNum
-    );
+      // ----------------------------------------------------------------------
+      // Types
+      // ----------------------------------------------------------------------
 
-  public:
+      //! The port callback function type
+      typedef void (*CompFuncPtr)(
+        Fw::PassiveComponentBase* callComp,
+        NATIVE_INT_TYPE portNum
+      );
 
-    // ----------------------------------------------------------------------
-    // Input Port Member functions
-    // ----------------------------------------------------------------------
+    public:
 
-    //! Constructor
-    InputNoArgsPort();
+      // ----------------------------------------------------------------------
+      // Input Port Member functions
+      // ----------------------------------------------------------------------
 
-    //! Initialization function
-    void init();
+      //! Constructor
+      InputNoArgsPort();
 
-    //! Register a component
-    void addCallComp(
-        Fw::PassiveComponentBase* callComp, //!< The containing component
-        CompFuncPtr funcPtr //!< The port callback function
-    );
+      //! Initialization function
+      void init();
 
-    //! Invoke a port interface
-    void invoke();
+      //! Register a component
+      void addCallComp(
+          Fw::PassiveComponentBase* callComp, //!< The containing component
+          CompFuncPtr funcPtr //!< The port callback function
+      );
 
-  private:
+      //! Invoke a port interface
+      void invoke();
+
+    private:
 
 #if FW_PORT_SERIALIZATION == 1
 
-    //! Invoke the port with serialized arguments
-    Fw::SerializeStatus invokeSerial(Fw::SerializeBufferBase& _buffer);
+      //! Invoke the port with serialized arguments
+      Fw::SerializeStatus invokeSerial(Fw::SerializeBufferBase& _buffer);
 
 #endif
 
-  private:
+    private:
 
-    // ----------------------------------------------------------------------
-    // Member variables
-    // ----------------------------------------------------------------------
+      // ----------------------------------------------------------------------
+      // Member variables
+      // ----------------------------------------------------------------------
 
-    //! The pointer to the port callback function
-    CompFuncPtr m_func;
+      //! The pointer to the port callback function
+      CompFuncPtr m_func;
 
-};
+  };
 
-//! Output NoArgs port
-//! A typed port with no arguments
-class OutputNoArgsPort :
-  public Fw::OutputPortBase
-{
+  //! Output NoArgs port
+  //! A typed port with no arguments
+  class OutputNoArgsPort :
+    public Fw::OutputPortBase
+  {
 
-  public:
+    public:
 
-    // ----------------------------------------------------------------------
-    // Output Port Member functions
-    // ----------------------------------------------------------------------
+      // ----------------------------------------------------------------------
+      // Output Port Member functions
+      // ----------------------------------------------------------------------
 
-    //! Constructor
-    OutputNoArgsPort();
+      //! Constructor
+      OutputNoArgsPort();
 
-    //! Initialization function
-    void init();
+      //! Initialization function
+      void init();
 
-    //! Register an input port
-    void addCallPort(
-        InputNoArgsPort* callPort //!< The input port
-    );
+      //! Register an input port
+      void addCallPort(
+          InputNoArgsPort* callPort //!< The input port
+      );
 
-    //! Invoke a port interface
-    void invoke();
+      //! Invoke a port interface
+      void invoke();
 
-  private:
+    private:
 
-    // ----------------------------------------------------------------------
-    // Member variables
-    // ----------------------------------------------------------------------
+      // ----------------------------------------------------------------------
+      // Member variables
+      // ----------------------------------------------------------------------
 
-    //! The pointer to the input port
-    InputNoArgsPort* m_port;
+      //! The pointer to the input port
+      InputNoArgsPort* m_port;
 
-};
+  };
+
+}
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/NoArgsReturnPortAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/NoArgsReturnPortAc.ref.cpp
@@ -8,103 +8,107 @@
 #include "Fw/Types/StringUtils.hpp"
 #include "test-base/NoArgsReturnPortAc.hpp"
 
-// ----------------------------------------------------------------------
-// Input Port Member functions
-// ----------------------------------------------------------------------
+namespace Ports {
 
-InputNoArgsReturnPort ::
-  InputNoArgsReturnPort() :
-    Fw::InputPortBase(),
-    m_func(nullptr)
-{
+  // ----------------------------------------------------------------------
+  // Input Port Member functions
+  // ----------------------------------------------------------------------
 
-}
+  InputNoArgsReturnPort ::
+    InputNoArgsReturnPort() :
+      Fw::InputPortBase(),
+      m_func(nullptr)
+  {
 
-void InputNoArgsReturnPort ::
-  init()
-{
-  Fw::InputPortBase::init();
-}
+  }
 
-void InputNoArgsReturnPort ::
-  addCallComp(
-      Fw::PassiveComponentBase* callComp,
-      CompFuncPtr funcPtr
-  )
-{
-  FW_ASSERT(callComp != nullptr);
-  FW_ASSERT(funcPtr != nullptr);
+  void InputNoArgsReturnPort ::
+    init()
+  {
+    Fw::InputPortBase::init();
+  }
 
-  this->m_comp = callComp;
-  this->m_func = funcPtr;
-  this->m_connObj = callComp;
-}
+  void InputNoArgsReturnPort ::
+    addCallComp(
+        Fw::PassiveComponentBase* callComp,
+        CompFuncPtr funcPtr
+    )
+  {
+    FW_ASSERT(callComp != nullptr);
+    FW_ASSERT(funcPtr != nullptr);
 
-U32 InputNoArgsReturnPort ::
-  invoke()
-{
+    this->m_comp = callComp;
+    this->m_func = funcPtr;
+    this->m_connObj = callComp;
+  }
+
+  U32 InputNoArgsReturnPort ::
+    invoke()
+  {
 #if FW_PORT_TRACING == 1
-  this->trace();
+    this->trace();
 #endif
 
-  FW_ASSERT(this->m_comp != nullptr);
-  FW_ASSERT(this->m_func != nullptr);
+    FW_ASSERT(this->m_comp != nullptr);
+    FW_ASSERT(this->m_func != nullptr);
 
-  return this->m_func(this->m_comp, this->m_portNum);
-}
+    return this->m_func(this->m_comp, this->m_portNum);
+  }
 
 #if FW_PORT_SERIALIZATION == 1
 
-Fw::SerializeStatus InputNoArgsReturnPort ::
-  invokeSerial(Fw::SerializeBufferBase& _buffer)
-{
-  // For ports with a return type, invokeSerial is not used
-  (void) _buffer;
+  Fw::SerializeStatus InputNoArgsReturnPort ::
+    invokeSerial(Fw::SerializeBufferBase& _buffer)
+  {
+    // For ports with a return type, invokeSerial is not used
+    (void) _buffer;
 
-  FW_ASSERT(0);
-  return Fw::FW_SERIALIZE_OK;
-}
+    FW_ASSERT(0);
+    return Fw::FW_SERIALIZE_OK;
+  }
 
 #endif
 
-// ----------------------------------------------------------------------
-// Output Port Member functions
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Output Port Member functions
+  // ----------------------------------------------------------------------
 
-OutputNoArgsReturnPort ::
-  OutputNoArgsReturnPort() :
-    Fw::OutputPortBase(),
-    m_port(nullptr)
-{
+  OutputNoArgsReturnPort ::
+    OutputNoArgsReturnPort() :
+      Fw::OutputPortBase(),
+      m_port(nullptr)
+  {
 
-}
+  }
 
-void OutputNoArgsReturnPort ::
-  init()
-{
-  Fw::OutputPortBase::init();
-}
+  void OutputNoArgsReturnPort ::
+    init()
+  {
+    Fw::OutputPortBase::init();
+  }
 
-void OutputNoArgsReturnPort ::
-  addCallPort(InputNoArgsReturnPort* callPort)
-{
-  FW_ASSERT(callPort != nullptr);
+  void OutputNoArgsReturnPort ::
+    addCallPort(InputNoArgsReturnPort* callPort)
+  {
+    FW_ASSERT(callPort != nullptr);
 
-  this->m_port = callPort;
-  this->m_connObj = callPort;
+    this->m_port = callPort;
+    this->m_connObj = callPort;
 
 #if FW_PORT_SERIALIZATION == 1
-  this->m_serPort = nullptr;
+    this->m_serPort = nullptr;
 #endif
-}
+  }
 
-U32 OutputNoArgsReturnPort ::
-  invoke()
-{
+  U32 OutputNoArgsReturnPort ::
+    invoke()
+  {
 #if FW_PORT_TRACING == 1
-  this->trace();
+    this->trace();
 #endif
 
-  FW_ASSERT(this->m_port != nullptr);
-  return this->m_port->invoke();
+    FW_ASSERT(this->m_port != nullptr);
+    return this->m_port->invoke();
+  }
+
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/NoArgsReturnPortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/NoArgsReturnPortAc.ref.hpp
@@ -4,8 +4,8 @@
 // \brief  hpp file for NoArgsReturn port
 // ======================================================================
 
-#ifndef NoArgsReturnPortAc_HPP
-#define NoArgsReturnPortAc_HPP
+#ifndef Ports_NoArgsReturnPortAc_HPP
+#define Ports_NoArgsReturnPortAc_HPP
 
 #include <cstdio>
 #include <cstring>
@@ -16,111 +16,115 @@
 #include "Fw/Port/OutputPortBase.hpp"
 #include "Fw/Types/StringType.hpp"
 
-//! Input NoArgsReturn port
-//! A type port with no arguments and a return type
-class InputNoArgsReturnPort :
-  public Fw::InputPortBase
-{
+namespace Ports {
 
-  public:
+  //! Input NoArgsReturn port
+  //! A type port with no arguments and a return type
+  class InputNoArgsReturnPort :
+    public Fw::InputPortBase
+  {
 
-    // ----------------------------------------------------------------------
-    // Constants
-    // ----------------------------------------------------------------------
+    public:
 
-    enum {
-      //! The size of the serial representations of the port arguments
-      SERIALIZED_SIZE = 0
-    };
+      // ----------------------------------------------------------------------
+      // Constants
+      // ----------------------------------------------------------------------
 
-  public:
+      enum {
+        //! The size of the serial representations of the port arguments
+        SERIALIZED_SIZE = 0
+      };
 
-    // ----------------------------------------------------------------------
-    // Types
-    // ----------------------------------------------------------------------
+    public:
 
-    //! The port callback function type
-    typedef U32 (*CompFuncPtr)(
-      Fw::PassiveComponentBase* callComp,
-      NATIVE_INT_TYPE portNum
-    );
+      // ----------------------------------------------------------------------
+      // Types
+      // ----------------------------------------------------------------------
 
-  public:
+      //! The port callback function type
+      typedef U32 (*CompFuncPtr)(
+        Fw::PassiveComponentBase* callComp,
+        NATIVE_INT_TYPE portNum
+      );
 
-    // ----------------------------------------------------------------------
-    // Input Port Member functions
-    // ----------------------------------------------------------------------
+    public:
 
-    //! Constructor
-    InputNoArgsReturnPort();
+      // ----------------------------------------------------------------------
+      // Input Port Member functions
+      // ----------------------------------------------------------------------
 
-    //! Initialization function
-    void init();
+      //! Constructor
+      InputNoArgsReturnPort();
 
-    //! Register a component
-    void addCallComp(
-        Fw::PassiveComponentBase* callComp, //!< The containing component
-        CompFuncPtr funcPtr //!< The port callback function
-    );
+      //! Initialization function
+      void init();
 
-    //! Invoke a port interface
-    U32 invoke();
+      //! Register a component
+      void addCallComp(
+          Fw::PassiveComponentBase* callComp, //!< The containing component
+          CompFuncPtr funcPtr //!< The port callback function
+      );
 
-  private:
+      //! Invoke a port interface
+      U32 invoke();
+
+    private:
 
 #if FW_PORT_SERIALIZATION == 1
 
-    //! Invoke the port with serialized arguments
-    Fw::SerializeStatus invokeSerial(Fw::SerializeBufferBase& _buffer);
+      //! Invoke the port with serialized arguments
+      Fw::SerializeStatus invokeSerial(Fw::SerializeBufferBase& _buffer);
 
 #endif
 
-  private:
+    private:
 
-    // ----------------------------------------------------------------------
-    // Member variables
-    // ----------------------------------------------------------------------
+      // ----------------------------------------------------------------------
+      // Member variables
+      // ----------------------------------------------------------------------
 
-    //! The pointer to the port callback function
-    CompFuncPtr m_func;
+      //! The pointer to the port callback function
+      CompFuncPtr m_func;
 
-};
+  };
 
-//! Output NoArgsReturn port
-//! A type port with no arguments and a return type
-class OutputNoArgsReturnPort :
-  public Fw::OutputPortBase
-{
+  //! Output NoArgsReturn port
+  //! A type port with no arguments and a return type
+  class OutputNoArgsReturnPort :
+    public Fw::OutputPortBase
+  {
 
-  public:
+    public:
 
-    // ----------------------------------------------------------------------
-    // Output Port Member functions
-    // ----------------------------------------------------------------------
+      // ----------------------------------------------------------------------
+      // Output Port Member functions
+      // ----------------------------------------------------------------------
 
-    //! Constructor
-    OutputNoArgsReturnPort();
+      //! Constructor
+      OutputNoArgsReturnPort();
 
-    //! Initialization function
-    void init();
+      //! Initialization function
+      void init();
 
-    //! Register an input port
-    void addCallPort(
-        InputNoArgsReturnPort* callPort //!< The input port
-    );
+      //! Register an input port
+      void addCallPort(
+          InputNoArgsReturnPort* callPort //!< The input port
+      );
 
-    //! Invoke a port interface
-    U32 invoke();
+      //! Invoke a port interface
+      U32 invoke();
 
-  private:
+    private:
 
-    // ----------------------------------------------------------------------
-    // Member variables
-    // ----------------------------------------------------------------------
+      // ----------------------------------------------------------------------
+      // Member variables
+      // ----------------------------------------------------------------------
 
-    //! The pointer to the input port
-    InputNoArgsReturnPort* m_port;
+      //! The pointer to the input port
+      InputNoArgsReturnPort* m_port;
 
-};
+  };
+
+}
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveCommandsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveCommandsComponentAc.ref.cpp
@@ -19,10 +19,10 @@ namespace {
     BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
     BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
     BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE typedGuardedPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedReturnGuardedPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedReturnSyncPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedSyncPortSize[InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedGuardedPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedReturnGuardedPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedReturnSyncPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedSyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
     BYTE cmdPortSize[Fw::InputCmdPort::SERIALIZED_SIZE];
   };
 
@@ -581,7 +581,7 @@ Ports::InputNoArgsPort* PassiveCommandsComponentBase ::
   return &this->m_noArgsSync_InputPort[portNum];
 }
 
-InputTypedPort* PassiveCommandsComponentBase ::
+Ports::InputTypedPort* PassiveCommandsComponentBase ::
   get_typedGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -592,7 +592,7 @@ InputTypedPort* PassiveCommandsComponentBase ::
   return &this->m_typedGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* PassiveCommandsComponentBase ::
+Ports::InputTypedReturnPort* PassiveCommandsComponentBase ::
   get_typedReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -603,7 +603,7 @@ InputTypedReturnPort* PassiveCommandsComponentBase ::
   return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* PassiveCommandsComponentBase ::
+Ports::InputTypedReturnPort* PassiveCommandsComponentBase ::
   get_typedReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -614,7 +614,7 @@ InputTypedReturnPort* PassiveCommandsComponentBase ::
   return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-InputTypedPort* PassiveCommandsComponentBase ::
+Ports::InputTypedPort* PassiveCommandsComponentBase ::
   get_typedSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -752,7 +752,7 @@ void PassiveCommandsComponentBase ::
 void PassiveCommandsComponentBase ::
   set_typedOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -766,7 +766,7 @@ void PassiveCommandsComponentBase ::
 void PassiveCommandsComponentBase ::
   set_typedReturnOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -1324,7 +1324,7 @@ void PassiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1361,7 +1361,7 @@ F32 PassiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1402,7 +1402,7 @@ F32 PassiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1437,7 +1437,7 @@ void PassiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1472,7 +1472,7 @@ void PassiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1499,7 +1499,7 @@ F32 PassiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2391,7 +2391,7 @@ void PassiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2418,7 +2418,7 @@ F32 PassiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2445,7 +2445,7 @@ F32 PassiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2472,7 +2472,7 @@ void PassiveCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveCommandsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveCommandsComponentAc.ref.cpp
@@ -15,10 +15,10 @@
 namespace {
   // Get the max size by doing a union of the input and internal port serialization sizes
   union BuffUnion {
-    BYTE noArgsGuardedPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnGuardedPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnSyncPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsSyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsGuardedPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
     BYTE typedGuardedPortSize[InputTypedPort::SERIALIZED_SIZE];
     BYTE typedReturnGuardedPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
     BYTE typedReturnSyncPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
@@ -537,7 +537,7 @@ Fw::InputCmdPort* PassiveCommandsComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-InputNoArgsPort* PassiveCommandsComponentBase ::
+Ports::InputNoArgsPort* PassiveCommandsComponentBase ::
   get_noArgsGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -548,7 +548,7 @@ InputNoArgsPort* PassiveCommandsComponentBase ::
   return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* PassiveCommandsComponentBase ::
+Ports::InputNoArgsReturnPort* PassiveCommandsComponentBase ::
   get_noArgsReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -559,7 +559,7 @@ InputNoArgsReturnPort* PassiveCommandsComponentBase ::
   return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* PassiveCommandsComponentBase ::
+Ports::InputNoArgsReturnPort* PassiveCommandsComponentBase ::
   get_noArgsReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -570,7 +570,7 @@ InputNoArgsReturnPort* PassiveCommandsComponentBase ::
   return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-InputNoArgsPort* PassiveCommandsComponentBase ::
+Ports::InputNoArgsPort* PassiveCommandsComponentBase ::
   get_noArgsSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveCommandsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveCommandsComponentAc.ref.hpp
@@ -137,28 +137,28 @@ class PassiveCommandsComponentBase :
     //! Get typed input port at index
     //!
     //! \return noArgsGuarded[portNum]
-    InputNoArgsPort* get_noArgsGuarded_InputPort(
+    Ports::InputNoArgsPort* get_noArgsGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnGuarded[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnSync[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsSync[portNum]
-    InputNoArgsPort* get_noArgsSync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -1138,16 +1138,16 @@ class PassiveCommandsComponentBase :
     // ----------------------------------------------------------------------
 
     //! Input port noArgsGuarded
-    InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnGuarded
-    InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnSync
-    InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
 
     //! Input port noArgsSync
-    InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedGuarded
     InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveCommandsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveCommandsComponentAc.ref.hpp
@@ -165,28 +165,28 @@ class PassiveCommandsComponentBase :
     //! Get typed input port at index
     //!
     //! \return typedGuarded[portNum]
-    InputTypedPort* get_typedGuarded_InputPort(
+    Ports::InputTypedPort* get_typedGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnGuarded[portNum]
-    InputTypedReturnPort* get_typedReturnGuarded_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnSync[portNum]
-    InputTypedReturnPort* get_typedReturnSync_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedSync[portNum]
-    InputTypedPort* get_typedSync_InputPort(
+    Ports::InputTypedPort* get_typedSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -257,13 +257,13 @@ class PassiveCommandsComponentBase :
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnOut[portNum]
     void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
 #if FW_PORT_SERIALIZATION
@@ -604,7 +604,7 @@ class PassiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -616,7 +616,7 @@ class PassiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -628,7 +628,7 @@ class PassiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -640,7 +640,7 @@ class PassiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -680,7 +680,7 @@ class PassiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -692,7 +692,7 @@ class PassiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -704,7 +704,7 @@ class PassiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -716,7 +716,7 @@ class PassiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -734,7 +734,7 @@ class PassiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -746,7 +746,7 @@ class PassiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1077,7 +1077,7 @@ class PassiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1090,7 +1090,7 @@ class PassiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1103,7 +1103,7 @@ class PassiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1116,7 +1116,7 @@ class PassiveCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1150,16 +1150,16 @@ class PassiveCommandsComponentBase :
     Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedGuarded
-    InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
+    Ports::InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnGuarded
-    InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnSync
-    InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
 
     //! Input port typedSync
-    InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
 
   PRIVATE:
 
@@ -1202,10 +1202,10 @@ class PassiveCommandsComponentBase :
     // ----------------------------------------------------------------------
 
     //! Output port typedOut
-    OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
+    Ports::OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
 
     //! Output port typedReturnOut
-    OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
+    Ports::OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
 
   PRIVATE:
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveCommandsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveCommandsTesterBase.ref.cpp
@@ -416,7 +416,7 @@ void PassiveCommandsTesterBase ::
 void PassiveCommandsTesterBase ::
   connect_to_typedGuarded(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -430,7 +430,7 @@ void PassiveCommandsTesterBase ::
 void PassiveCommandsTesterBase ::
   connect_to_typedReturnGuarded(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -444,7 +444,7 @@ void PassiveCommandsTesterBase ::
 void PassiveCommandsTesterBase ::
   connect_to_typedReturnSync(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -458,7 +458,7 @@ void PassiveCommandsTesterBase ::
 void PassiveCommandsTesterBase ::
   connect_to_typedSync(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -565,7 +565,7 @@ Fw::InputTlmPort* PassiveCommandsTesterBase ::
   return &this->m_from_tlmOut[portNum];
 }
 
-InputTypedPort* PassiveCommandsTesterBase ::
+Ports::InputTypedPort* PassiveCommandsTesterBase ::
   get_from_typedOut(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -576,7 +576,7 @@ InputTypedPort* PassiveCommandsTesterBase ::
   return &this->m_from_typedOut[portNum];
 }
 
-InputTypedReturnPort* PassiveCommandsTesterBase ::
+Ports::InputTypedReturnPort* PassiveCommandsTesterBase ::
   get_from_typedReturnOut(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -630,7 +630,7 @@ void PassiveCommandsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -659,7 +659,7 @@ F32 PassiveCommandsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -736,7 +736,7 @@ void PassiveCommandsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -764,7 +764,7 @@ F32 PassiveCommandsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -792,7 +792,7 @@ F32 PassiveCommandsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -820,7 +820,7 @@ void PassiveCommandsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1569,7 +1569,7 @@ void PassiveCommandsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1593,7 +1593,7 @@ void PassiveCommandsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1657,7 +1657,7 @@ void PassiveCommandsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1684,7 +1684,7 @@ F32 PassiveCommandsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveCommandsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveCommandsTesterBase.ref.cpp
@@ -360,7 +360,7 @@ void PassiveCommandsTesterBase ::
 void PassiveCommandsTesterBase ::
   connect_to_noArgsGuarded(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsPort* port
+      Ports::InputNoArgsPort* port
   )
 {
   FW_ASSERT(
@@ -374,7 +374,7 @@ void PassiveCommandsTesterBase ::
 void PassiveCommandsTesterBase ::
   connect_to_noArgsReturnGuarded(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsReturnPort* port
+      Ports::InputNoArgsReturnPort* port
   )
 {
   FW_ASSERT(
@@ -388,7 +388,7 @@ void PassiveCommandsTesterBase ::
 void PassiveCommandsTesterBase ::
   connect_to_noArgsReturnSync(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsReturnPort* port
+      Ports::InputNoArgsReturnPort* port
   )
 {
   FW_ASSERT(
@@ -402,7 +402,7 @@ void PassiveCommandsTesterBase ::
 void PassiveCommandsTesterBase ::
   connect_to_noArgsSync(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsPort* port
+      Ports::InputNoArgsPort* port
   )
 {
   FW_ASSERT(

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveCommandsTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveCommandsTesterBase.ref.hpp
@@ -111,7 +111,7 @@ class PassiveCommandsTesterBase :
       U32 u32;
       F32 f32;
       bool b;
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       E e;
       A a;
       S s;
@@ -122,7 +122,7 @@ class PassiveCommandsTesterBase :
       U32 u32;
       F32 f32;
       bool b;
-      TypedReturnPortStrings::StringSize80 str2;
+      Ports::TypedReturnPortStrings::StringSize80 str2;
       E e;
       A a;
       S s;
@@ -185,25 +185,25 @@ class PassiveCommandsTesterBase :
     //! Connect port to typedGuarded[portNum]
     void connect_to_typedGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnGuarded[portNum]
     void connect_to_typedReturnGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
     //! Connect port to typedReturnSync[portNum]
     void connect_to_typedReturnSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
     //! Connect port to typedSync[portNum]
     void connect_to_typedSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
   public:
@@ -275,14 +275,14 @@ class PassiveCommandsTesterBase :
     //! Get from port at index
     //!
     //! \return from_typedOut[portNum]
-    InputTypedPort* get_from_typedOut(
+    Ports::InputTypedPort* get_from_typedOut(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get from port at index
     //!
     //! \return from_typedReturnOut[portNum]
-    InputTypedReturnPort* get_from_typedReturnOut(
+    Ports::InputTypedReturnPort* get_from_typedReturnOut(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -313,7 +313,7 @@ class PassiveCommandsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -325,7 +325,7 @@ class PassiveCommandsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -343,7 +343,7 @@ class PassiveCommandsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -355,7 +355,7 @@ class PassiveCommandsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -393,7 +393,7 @@ class PassiveCommandsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -405,7 +405,7 @@ class PassiveCommandsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -417,7 +417,7 @@ class PassiveCommandsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -429,7 +429,7 @@ class PassiveCommandsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -745,7 +745,7 @@ class PassiveCommandsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -756,7 +756,7 @@ class PassiveCommandsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -798,7 +798,7 @@ class PassiveCommandsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -811,7 +811,7 @@ class PassiveCommandsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -857,16 +857,16 @@ class PassiveCommandsTesterBase :
     Ports::OutputNoArgsPort m_to_noArgsSync[3];
 
     //! To port connected to typedGuarded
-    OutputTypedPort m_to_typedGuarded[1];
+    Ports::OutputTypedPort m_to_typedGuarded[1];
 
     //! To port connected to typedReturnGuarded
-    OutputTypedReturnPort m_to_typedReturnGuarded[1];
+    Ports::OutputTypedReturnPort m_to_typedReturnGuarded[1];
 
     //! To port connected to typedReturnSync
-    OutputTypedReturnPort m_to_typedReturnSync[3];
+    Ports::OutputTypedReturnPort m_to_typedReturnSync[3];
 
     //! To port connected to typedSync
-    OutputTypedPort m_to_typedSync[3];
+    Ports::OutputTypedPort m_to_typedSync[3];
 
   private:
 
@@ -903,10 +903,10 @@ class PassiveCommandsTesterBase :
     Fw::InputTlmPort m_from_tlmOut[1];
 
     //! From port connected to typedOut
-    InputTypedPort m_from_typedOut[1];
+    Ports::InputTypedPort m_from_typedOut[1];
 
     //! From port connected to typedReturnOut
-    InputTypedReturnPort m_from_typedReturnOut[1];
+    Ports::InputTypedReturnPort m_from_typedReturnOut[1];
 
   private:
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveCommandsTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveCommandsTesterBase.ref.hpp
@@ -161,25 +161,25 @@ class PassiveCommandsTesterBase :
     //! Connect port to noArgsGuarded[portNum]
     void connect_to_noArgsGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsPort* port //!< The input port
+        Ports::InputNoArgsPort* port //!< The input port
     );
 
     //! Connect port to noArgsReturnGuarded[portNum]
     void connect_to_noArgsReturnGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsReturnPort* port //!< The input port
+        Ports::InputNoArgsReturnPort* port //!< The input port
     );
 
     //! Connect port to noArgsReturnSync[portNum]
     void connect_to_noArgsReturnSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsReturnPort* port //!< The input port
+        Ports::InputNoArgsReturnPort* port //!< The input port
     );
 
     //! Connect port to noArgsSync[portNum]
     void connect_to_noArgsSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsPort* port //!< The input port
+        Ports::InputNoArgsPort* port //!< The input port
     );
 
     //! Connect port to typedGuarded[portNum]
@@ -845,16 +845,16 @@ class PassiveCommandsTesterBase :
     Fw::OutputCmdPort m_to_cmdIn[1];
 
     //! To port connected to noArgsGuarded
-    OutputNoArgsPort m_to_noArgsGuarded[1];
+    Ports::OutputNoArgsPort m_to_noArgsGuarded[1];
 
     //! To port connected to noArgsReturnGuarded
-    OutputNoArgsReturnPort m_to_noArgsReturnGuarded[1];
+    Ports::OutputNoArgsReturnPort m_to_noArgsReturnGuarded[1];
 
     //! To port connected to noArgsReturnSync
-    OutputNoArgsReturnPort m_to_noArgsReturnSync[3];
+    Ports::OutputNoArgsReturnPort m_to_noArgsReturnSync[3];
 
     //! To port connected to noArgsSync
-    OutputNoArgsPort m_to_noArgsSync[3];
+    Ports::OutputNoArgsPort m_to_noArgsSync[3];
 
     //! To port connected to typedGuarded
     OutputTypedPort m_to_typedGuarded[1];

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveEventsComponentAc.ref.cpp
@@ -19,10 +19,10 @@ namespace {
     BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
     BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
     BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE typedGuardedPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedReturnGuardedPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedReturnSyncPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedSyncPortSize[InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedGuardedPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedReturnGuardedPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedReturnSyncPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedSyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
     BYTE cmdPortSize[Fw::InputCmdPort::SERIALIZED_SIZE];
   };
 
@@ -581,7 +581,7 @@ Ports::InputNoArgsPort* PassiveEventsComponentBase ::
   return &this->m_noArgsSync_InputPort[portNum];
 }
 
-InputTypedPort* PassiveEventsComponentBase ::
+Ports::InputTypedPort* PassiveEventsComponentBase ::
   get_typedGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -592,7 +592,7 @@ InputTypedPort* PassiveEventsComponentBase ::
   return &this->m_typedGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* PassiveEventsComponentBase ::
+Ports::InputTypedReturnPort* PassiveEventsComponentBase ::
   get_typedReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -603,7 +603,7 @@ InputTypedReturnPort* PassiveEventsComponentBase ::
   return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* PassiveEventsComponentBase ::
+Ports::InputTypedReturnPort* PassiveEventsComponentBase ::
   get_typedReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -614,7 +614,7 @@ InputTypedReturnPort* PassiveEventsComponentBase ::
   return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-InputTypedPort* PassiveEventsComponentBase ::
+Ports::InputTypedPort* PassiveEventsComponentBase ::
   get_typedSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -752,7 +752,7 @@ void PassiveEventsComponentBase ::
 void PassiveEventsComponentBase ::
   set_typedOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -766,7 +766,7 @@ void PassiveEventsComponentBase ::
 void PassiveEventsComponentBase ::
   set_typedReturnOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -1268,7 +1268,7 @@ void PassiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1305,7 +1305,7 @@ F32 PassiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1346,7 +1346,7 @@ F32 PassiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1381,7 +1381,7 @@ void PassiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1416,7 +1416,7 @@ void PassiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1443,7 +1443,7 @@ F32 PassiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2269,7 +2269,7 @@ void PassiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2296,7 +2296,7 @@ F32 PassiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2323,7 +2323,7 @@ F32 PassiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2350,7 +2350,7 @@ void PassiveEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveEventsComponentAc.ref.cpp
@@ -15,10 +15,10 @@
 namespace {
   // Get the max size by doing a union of the input and internal port serialization sizes
   union BuffUnion {
-    BYTE noArgsGuardedPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnGuardedPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnSyncPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsSyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsGuardedPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
     BYTE typedGuardedPortSize[InputTypedPort::SERIALIZED_SIZE];
     BYTE typedReturnGuardedPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
     BYTE typedReturnSyncPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
@@ -537,7 +537,7 @@ Fw::InputCmdPort* PassiveEventsComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-InputNoArgsPort* PassiveEventsComponentBase ::
+Ports::InputNoArgsPort* PassiveEventsComponentBase ::
   get_noArgsGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -548,7 +548,7 @@ InputNoArgsPort* PassiveEventsComponentBase ::
   return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* PassiveEventsComponentBase ::
+Ports::InputNoArgsReturnPort* PassiveEventsComponentBase ::
   get_noArgsReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -559,7 +559,7 @@ InputNoArgsReturnPort* PassiveEventsComponentBase ::
   return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* PassiveEventsComponentBase ::
+Ports::InputNoArgsReturnPort* PassiveEventsComponentBase ::
   get_noArgsReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -570,7 +570,7 @@ InputNoArgsReturnPort* PassiveEventsComponentBase ::
   return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-InputNoArgsPort* PassiveEventsComponentBase ::
+Ports::InputNoArgsPort* PassiveEventsComponentBase ::
   get_noArgsSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveEventsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveEventsComponentAc.ref.hpp
@@ -139,28 +139,28 @@ class PassiveEventsComponentBase :
     //! Get typed input port at index
     //!
     //! \return noArgsGuarded[portNum]
-    InputNoArgsPort* get_noArgsGuarded_InputPort(
+    Ports::InputNoArgsPort* get_noArgsGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnGuarded[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnSync[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsSync[portNum]
-    InputNoArgsPort* get_noArgsSync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -951,16 +951,16 @@ class PassiveEventsComponentBase :
     // ----------------------------------------------------------------------
 
     //! Input port noArgsGuarded
-    InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnGuarded
-    InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnSync
-    InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
 
     //! Input port noArgsSync
-    InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedGuarded
     InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveEventsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveEventsComponentAc.ref.hpp
@@ -167,28 +167,28 @@ class PassiveEventsComponentBase :
     //! Get typed input port at index
     //!
     //! \return typedGuarded[portNum]
-    InputTypedPort* get_typedGuarded_InputPort(
+    Ports::InputTypedPort* get_typedGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnGuarded[portNum]
-    InputTypedReturnPort* get_typedReturnGuarded_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnSync[portNum]
-    InputTypedReturnPort* get_typedReturnSync_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedSync[portNum]
-    InputTypedPort* get_typedSync_InputPort(
+    Ports::InputTypedPort* get_typedSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -259,13 +259,13 @@ class PassiveEventsComponentBase :
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnOut[portNum]
     void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
 #if FW_PORT_SERIALIZATION
@@ -595,7 +595,7 @@ class PassiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -607,7 +607,7 @@ class PassiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -619,7 +619,7 @@ class PassiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -631,7 +631,7 @@ class PassiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -671,7 +671,7 @@ class PassiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -683,7 +683,7 @@ class PassiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -695,7 +695,7 @@ class PassiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -707,7 +707,7 @@ class PassiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -725,7 +725,7 @@ class PassiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -737,7 +737,7 @@ class PassiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -890,7 +890,7 @@ class PassiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -903,7 +903,7 @@ class PassiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -916,7 +916,7 @@ class PassiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -929,7 +929,7 @@ class PassiveEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -963,16 +963,16 @@ class PassiveEventsComponentBase :
     Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedGuarded
-    InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
+    Ports::InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnGuarded
-    InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnSync
-    InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
 
     //! Input port typedSync
-    InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
 
   PRIVATE:
 
@@ -1015,10 +1015,10 @@ class PassiveEventsComponentBase :
     // ----------------------------------------------------------------------
 
     //! Output port typedOut
-    OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
+    Ports::OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
 
     //! Output port typedReturnOut
-    OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
+    Ports::OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
 
   PRIVATE:
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveEventsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveEventsTesterBase.ref.cpp
@@ -341,7 +341,7 @@ void PassiveEventsTesterBase ::
 void PassiveEventsTesterBase ::
   connect_to_noArgsGuarded(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsPort* port
+      Ports::InputNoArgsPort* port
   )
 {
   FW_ASSERT(
@@ -355,7 +355,7 @@ void PassiveEventsTesterBase ::
 void PassiveEventsTesterBase ::
   connect_to_noArgsReturnGuarded(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsReturnPort* port
+      Ports::InputNoArgsReturnPort* port
   )
 {
   FW_ASSERT(
@@ -369,7 +369,7 @@ void PassiveEventsTesterBase ::
 void PassiveEventsTesterBase ::
   connect_to_noArgsReturnSync(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsReturnPort* port
+      Ports::InputNoArgsReturnPort* port
   )
 {
   FW_ASSERT(
@@ -383,7 +383,7 @@ void PassiveEventsTesterBase ::
 void PassiveEventsTesterBase ::
   connect_to_noArgsSync(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsPort* port
+      Ports::InputNoArgsPort* port
   )
 {
   FW_ASSERT(

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveEventsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveEventsTesterBase.ref.cpp
@@ -397,7 +397,7 @@ void PassiveEventsTesterBase ::
 void PassiveEventsTesterBase ::
   connect_to_typedGuarded(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -411,7 +411,7 @@ void PassiveEventsTesterBase ::
 void PassiveEventsTesterBase ::
   connect_to_typedReturnGuarded(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -425,7 +425,7 @@ void PassiveEventsTesterBase ::
 void PassiveEventsTesterBase ::
   connect_to_typedReturnSync(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -439,7 +439,7 @@ void PassiveEventsTesterBase ::
 void PassiveEventsTesterBase ::
   connect_to_typedSync(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -546,7 +546,7 @@ Fw::InputTlmPort* PassiveEventsTesterBase ::
   return &this->m_from_tlmOut[portNum];
 }
 
-InputTypedPort* PassiveEventsTesterBase ::
+Ports::InputTypedPort* PassiveEventsTesterBase ::
   get_from_typedOut(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -557,7 +557,7 @@ InputTypedPort* PassiveEventsTesterBase ::
   return &this->m_from_typedOut[portNum];
 }
 
-InputTypedReturnPort* PassiveEventsTesterBase ::
+Ports::InputTypedReturnPort* PassiveEventsTesterBase ::
   get_from_typedReturnOut(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -625,7 +625,7 @@ void PassiveEventsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -654,7 +654,7 @@ F32 PassiveEventsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -731,7 +731,7 @@ void PassiveEventsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -759,7 +759,7 @@ F32 PassiveEventsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -787,7 +787,7 @@ F32 PassiveEventsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -815,7 +815,7 @@ void PassiveEventsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1503,7 +1503,7 @@ void PassiveEventsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1527,7 +1527,7 @@ void PassiveEventsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1675,7 +1675,7 @@ void PassiveEventsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1702,7 +1702,7 @@ F32 PassiveEventsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveEventsTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveEventsTesterBase.ref.hpp
@@ -194,25 +194,25 @@ class PassiveEventsTesterBase :
     //! Connect port to noArgsGuarded[portNum]
     void connect_to_noArgsGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsPort* port //!< The input port
+        Ports::InputNoArgsPort* port //!< The input port
     );
 
     //! Connect port to noArgsReturnGuarded[portNum]
     void connect_to_noArgsReturnGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsReturnPort* port //!< The input port
+        Ports::InputNoArgsReturnPort* port //!< The input port
     );
 
     //! Connect port to noArgsReturnSync[portNum]
     void connect_to_noArgsReturnSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsReturnPort* port //!< The input port
+        Ports::InputNoArgsReturnPort* port //!< The input port
     );
 
     //! Connect port to noArgsSync[portNum]
     void connect_to_noArgsSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsPort* port //!< The input port
+        Ports::InputNoArgsPort* port //!< The input port
     );
 
     //! Connect port to typedGuarded[portNum]
@@ -882,16 +882,16 @@ class PassiveEventsTesterBase :
     Fw::OutputCmdPort m_to_cmdIn[1];
 
     //! To port connected to noArgsGuarded
-    OutputNoArgsPort m_to_noArgsGuarded[1];
+    Ports::OutputNoArgsPort m_to_noArgsGuarded[1];
 
     //! To port connected to noArgsReturnGuarded
-    OutputNoArgsReturnPort m_to_noArgsReturnGuarded[1];
+    Ports::OutputNoArgsReturnPort m_to_noArgsReturnGuarded[1];
 
     //! To port connected to noArgsReturnSync
-    OutputNoArgsReturnPort m_to_noArgsReturnSync[3];
+    Ports::OutputNoArgsReturnPort m_to_noArgsReturnSync[3];
 
     //! To port connected to noArgsSync
-    OutputNoArgsPort m_to_noArgsSync[3];
+    Ports::OutputNoArgsPort m_to_noArgsSync[3];
 
     //! To port connected to typedGuarded
     OutputTypedPort m_to_typedGuarded[1];

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveEventsTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveEventsTesterBase.ref.hpp
@@ -111,7 +111,7 @@ class PassiveEventsTesterBase :
       U32 u32;
       F32 f32;
       bool b;
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       E e;
       A a;
       S s;
@@ -122,7 +122,7 @@ class PassiveEventsTesterBase :
       U32 u32;
       F32 f32;
       bool b;
-      TypedReturnPortStrings::StringSize80 str2;
+      Ports::TypedReturnPortStrings::StringSize80 str2;
       E e;
       A a;
       S s;
@@ -218,25 +218,25 @@ class PassiveEventsTesterBase :
     //! Connect port to typedGuarded[portNum]
     void connect_to_typedGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnGuarded[portNum]
     void connect_to_typedReturnGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
     //! Connect port to typedReturnSync[portNum]
     void connect_to_typedReturnSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
     //! Connect port to typedSync[portNum]
     void connect_to_typedSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
   public:
@@ -308,14 +308,14 @@ class PassiveEventsTesterBase :
     //! Get from port at index
     //!
     //! \return from_typedOut[portNum]
-    InputTypedPort* get_from_typedOut(
+    Ports::InputTypedPort* get_from_typedOut(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get from port at index
     //!
     //! \return from_typedReturnOut[portNum]
-    InputTypedReturnPort* get_from_typedReturnOut(
+    Ports::InputTypedReturnPort* get_from_typedReturnOut(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -346,7 +346,7 @@ class PassiveEventsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -358,7 +358,7 @@ class PassiveEventsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -376,7 +376,7 @@ class PassiveEventsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -388,7 +388,7 @@ class PassiveEventsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -426,7 +426,7 @@ class PassiveEventsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -438,7 +438,7 @@ class PassiveEventsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -450,7 +450,7 @@ class PassiveEventsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -462,7 +462,7 @@ class PassiveEventsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -730,7 +730,7 @@ class PassiveEventsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -741,7 +741,7 @@ class PassiveEventsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -807,7 +807,7 @@ class PassiveEventsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -820,7 +820,7 @@ class PassiveEventsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -894,16 +894,16 @@ class PassiveEventsTesterBase :
     Ports::OutputNoArgsPort m_to_noArgsSync[3];
 
     //! To port connected to typedGuarded
-    OutputTypedPort m_to_typedGuarded[1];
+    Ports::OutputTypedPort m_to_typedGuarded[1];
 
     //! To port connected to typedReturnGuarded
-    OutputTypedReturnPort m_to_typedReturnGuarded[1];
+    Ports::OutputTypedReturnPort m_to_typedReturnGuarded[1];
 
     //! To port connected to typedReturnSync
-    OutputTypedReturnPort m_to_typedReturnSync[3];
+    Ports::OutputTypedReturnPort m_to_typedReturnSync[3];
 
     //! To port connected to typedSync
-    OutputTypedPort m_to_typedSync[3];
+    Ports::OutputTypedPort m_to_typedSync[3];
 
   private:
 
@@ -940,10 +940,10 @@ class PassiveEventsTesterBase :
     Fw::InputTlmPort m_from_tlmOut[1];
 
     //! From port connected to typedOut
-    InputTypedPort m_from_typedOut[1];
+    Ports::InputTypedPort m_from_typedOut[1];
 
     //! From port connected to typedReturnOut
-    InputTypedReturnPort m_from_typedReturnOut[1];
+    Ports::InputTypedReturnPort m_from_typedReturnOut[1];
 
   private:
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveParamsComponentAc.ref.cpp
@@ -15,10 +15,10 @@
 namespace {
   // Get the max size by doing a union of the input and internal port serialization sizes
   union BuffUnion {
-    BYTE noArgsGuardedPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnGuardedPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnSyncPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsSyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsGuardedPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
     BYTE typedGuardedPortSize[InputTypedPort::SERIALIZED_SIZE];
     BYTE typedReturnGuardedPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
     BYTE typedReturnSyncPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
@@ -537,7 +537,7 @@ Fw::InputCmdPort* PassiveParamsComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-InputNoArgsPort* PassiveParamsComponentBase ::
+Ports::InputNoArgsPort* PassiveParamsComponentBase ::
   get_noArgsGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -548,7 +548,7 @@ InputNoArgsPort* PassiveParamsComponentBase ::
   return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* PassiveParamsComponentBase ::
+Ports::InputNoArgsReturnPort* PassiveParamsComponentBase ::
   get_noArgsReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -559,7 +559,7 @@ InputNoArgsReturnPort* PassiveParamsComponentBase ::
   return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* PassiveParamsComponentBase ::
+Ports::InputNoArgsReturnPort* PassiveParamsComponentBase ::
   get_noArgsReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -570,7 +570,7 @@ InputNoArgsReturnPort* PassiveParamsComponentBase ::
   return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-InputNoArgsPort* PassiveParamsComponentBase ::
+Ports::InputNoArgsPort* PassiveParamsComponentBase ::
   get_noArgsSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveParamsComponentAc.ref.cpp
@@ -19,10 +19,10 @@ namespace {
     BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
     BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
     BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE typedGuardedPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedReturnGuardedPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedReturnSyncPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedSyncPortSize[InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedGuardedPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedReturnGuardedPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedReturnSyncPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedSyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
     BYTE cmdPortSize[Fw::InputCmdPort::SERIALIZED_SIZE];
   };
 
@@ -581,7 +581,7 @@ Ports::InputNoArgsPort* PassiveParamsComponentBase ::
   return &this->m_noArgsSync_InputPort[portNum];
 }
 
-InputTypedPort* PassiveParamsComponentBase ::
+Ports::InputTypedPort* PassiveParamsComponentBase ::
   get_typedGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -592,7 +592,7 @@ InputTypedPort* PassiveParamsComponentBase ::
   return &this->m_typedGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* PassiveParamsComponentBase ::
+Ports::InputTypedReturnPort* PassiveParamsComponentBase ::
   get_typedReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -603,7 +603,7 @@ InputTypedReturnPort* PassiveParamsComponentBase ::
   return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* PassiveParamsComponentBase ::
+Ports::InputTypedReturnPort* PassiveParamsComponentBase ::
   get_typedReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -614,7 +614,7 @@ InputTypedReturnPort* PassiveParamsComponentBase ::
   return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-InputTypedPort* PassiveParamsComponentBase ::
+Ports::InputTypedPort* PassiveParamsComponentBase ::
   get_typedSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -752,7 +752,7 @@ void PassiveParamsComponentBase ::
 void PassiveParamsComponentBase ::
   set_typedOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -766,7 +766,7 @@ void PassiveParamsComponentBase ::
 void PassiveParamsComponentBase ::
   set_typedReturnOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -1504,7 +1504,7 @@ void PassiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1541,7 +1541,7 @@ F32 PassiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1582,7 +1582,7 @@ F32 PassiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1617,7 +1617,7 @@ void PassiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1652,7 +1652,7 @@ void PassiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1679,7 +1679,7 @@ F32 PassiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2035,7 +2035,7 @@ void PassiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2062,7 +2062,7 @@ F32 PassiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2089,7 +2089,7 @@ F32 PassiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2116,7 +2116,7 @@ void PassiveParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveParamsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveParamsComponentAc.ref.hpp
@@ -177,28 +177,28 @@ class PassiveParamsComponentBase :
     //! Get typed input port at index
     //!
     //! \return typedGuarded[portNum]
-    InputTypedPort* get_typedGuarded_InputPort(
+    Ports::InputTypedPort* get_typedGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnGuarded[portNum]
-    InputTypedReturnPort* get_typedReturnGuarded_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnSync[portNum]
-    InputTypedReturnPort* get_typedReturnSync_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedSync[portNum]
-    InputTypedPort* get_typedSync_InputPort(
+    Ports::InputTypedPort* get_typedSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -269,13 +269,13 @@ class PassiveParamsComponentBase :
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnOut[portNum]
     void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
 #if FW_PORT_SERIALIZATION
@@ -627,7 +627,7 @@ class PassiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -639,7 +639,7 @@ class PassiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -651,7 +651,7 @@ class PassiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -663,7 +663,7 @@ class PassiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -703,7 +703,7 @@ class PassiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -715,7 +715,7 @@ class PassiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -727,7 +727,7 @@ class PassiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -739,7 +739,7 @@ class PassiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -757,7 +757,7 @@ class PassiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -769,7 +769,7 @@ class PassiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -949,7 +949,7 @@ class PassiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -962,7 +962,7 @@ class PassiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -975,7 +975,7 @@ class PassiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -988,7 +988,7 @@ class PassiveParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1106,16 +1106,16 @@ class PassiveParamsComponentBase :
     Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedGuarded
-    InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
+    Ports::InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnGuarded
-    InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnSync
-    InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
 
     //! Input port typedSync
-    InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
 
   PRIVATE:
 
@@ -1158,10 +1158,10 @@ class PassiveParamsComponentBase :
     // ----------------------------------------------------------------------
 
     //! Output port typedOut
-    OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
+    Ports::OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
 
     //! Output port typedReturnOut
-    OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
+    Ports::OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
 
   PRIVATE:
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveParamsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveParamsComponentAc.ref.hpp
@@ -149,28 +149,28 @@ class PassiveParamsComponentBase :
     //! Get typed input port at index
     //!
     //! \return noArgsGuarded[portNum]
-    InputNoArgsPort* get_noArgsGuarded_InputPort(
+    Ports::InputNoArgsPort* get_noArgsGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnGuarded[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnSync[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsSync[portNum]
-    InputNoArgsPort* get_noArgsSync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -1094,16 +1094,16 @@ class PassiveParamsComponentBase :
     // ----------------------------------------------------------------------
 
     //! Input port noArgsGuarded
-    InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnGuarded
-    InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnSync
-    InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
 
     //! Input port noArgsSync
-    InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedGuarded
     InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveParamsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveParamsTesterBase.ref.cpp
@@ -468,7 +468,7 @@ void PassiveParamsTesterBase ::
 void PassiveParamsTesterBase ::
   connect_to_typedGuarded(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -482,7 +482,7 @@ void PassiveParamsTesterBase ::
 void PassiveParamsTesterBase ::
   connect_to_typedReturnGuarded(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -496,7 +496,7 @@ void PassiveParamsTesterBase ::
 void PassiveParamsTesterBase ::
   connect_to_typedReturnSync(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -510,7 +510,7 @@ void PassiveParamsTesterBase ::
 void PassiveParamsTesterBase ::
   connect_to_typedSync(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -617,7 +617,7 @@ Fw::InputTlmPort* PassiveParamsTesterBase ::
   return &this->m_from_tlmOut[portNum];
 }
 
-InputTypedPort* PassiveParamsTesterBase ::
+Ports::InputTypedPort* PassiveParamsTesterBase ::
   get_from_typedOut(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -628,7 +628,7 @@ InputTypedPort* PassiveParamsTesterBase ::
   return &this->m_from_typedOut[portNum];
 }
 
-InputTypedReturnPort* PassiveParamsTesterBase ::
+Ports::InputTypedReturnPort* PassiveParamsTesterBase ::
   get_from_typedReturnOut(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -688,7 +688,7 @@ void PassiveParamsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -717,7 +717,7 @@ F32 PassiveParamsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -794,7 +794,7 @@ void PassiveParamsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -822,7 +822,7 @@ F32 PassiveParamsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -850,7 +850,7 @@ F32 PassiveParamsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -878,7 +878,7 @@ void PassiveParamsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1553,7 +1553,7 @@ void PassiveParamsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1577,7 +1577,7 @@ void PassiveParamsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1834,7 +1834,7 @@ void PassiveParamsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1861,7 +1861,7 @@ F32 PassiveParamsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveParamsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveParamsTesterBase.ref.cpp
@@ -412,7 +412,7 @@ void PassiveParamsTesterBase ::
 void PassiveParamsTesterBase ::
   connect_to_noArgsGuarded(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsPort* port
+      Ports::InputNoArgsPort* port
   )
 {
   FW_ASSERT(
@@ -426,7 +426,7 @@ void PassiveParamsTesterBase ::
 void PassiveParamsTesterBase ::
   connect_to_noArgsReturnGuarded(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsReturnPort* port
+      Ports::InputNoArgsReturnPort* port
   )
 {
   FW_ASSERT(
@@ -440,7 +440,7 @@ void PassiveParamsTesterBase ::
 void PassiveParamsTesterBase ::
   connect_to_noArgsReturnSync(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsReturnPort* port
+      Ports::InputNoArgsReturnPort* port
   )
 {
   FW_ASSERT(
@@ -454,7 +454,7 @@ void PassiveParamsTesterBase ::
 void PassiveParamsTesterBase ::
   connect_to_noArgsSync(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsPort* port
+      Ports::InputNoArgsPort* port
   )
 {
   FW_ASSERT(

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveParamsTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveParamsTesterBase.ref.hpp
@@ -161,25 +161,25 @@ class PassiveParamsTesterBase :
     //! Connect port to noArgsGuarded[portNum]
     void connect_to_noArgsGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsPort* port //!< The input port
+        Ports::InputNoArgsPort* port //!< The input port
     );
 
     //! Connect port to noArgsReturnGuarded[portNum]
     void connect_to_noArgsReturnGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsReturnPort* port //!< The input port
+        Ports::InputNoArgsReturnPort* port //!< The input port
     );
 
     //! Connect port to noArgsReturnSync[portNum]
     void connect_to_noArgsReturnSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsReturnPort* port //!< The input port
+        Ports::InputNoArgsReturnPort* port //!< The input port
     );
 
     //! Connect port to noArgsSync[portNum]
     void connect_to_noArgsSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsPort* port //!< The input port
+        Ports::InputNoArgsPort* port //!< The input port
     );
 
     //! Connect port to typedGuarded[portNum]
@@ -887,16 +887,16 @@ class PassiveParamsTesterBase :
     Fw::OutputCmdPort m_to_cmdIn[1];
 
     //! To port connected to noArgsGuarded
-    OutputNoArgsPort m_to_noArgsGuarded[1];
+    Ports::OutputNoArgsPort m_to_noArgsGuarded[1];
 
     //! To port connected to noArgsReturnGuarded
-    OutputNoArgsReturnPort m_to_noArgsReturnGuarded[1];
+    Ports::OutputNoArgsReturnPort m_to_noArgsReturnGuarded[1];
 
     //! To port connected to noArgsReturnSync
-    OutputNoArgsReturnPort m_to_noArgsReturnSync[3];
+    Ports::OutputNoArgsReturnPort m_to_noArgsReturnSync[3];
 
     //! To port connected to noArgsSync
-    OutputNoArgsPort m_to_noArgsSync[3];
+    Ports::OutputNoArgsPort m_to_noArgsSync[3];
 
     //! To port connected to typedGuarded
     OutputTypedPort m_to_typedGuarded[1];

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveParamsTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveParamsTesterBase.ref.hpp
@@ -111,7 +111,7 @@ class PassiveParamsTesterBase :
       U32 u32;
       F32 f32;
       bool b;
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       E e;
       A a;
       S s;
@@ -122,7 +122,7 @@ class PassiveParamsTesterBase :
       U32 u32;
       F32 f32;
       bool b;
-      TypedReturnPortStrings::StringSize80 str2;
+      Ports::TypedReturnPortStrings::StringSize80 str2;
       E e;
       A a;
       S s;
@@ -185,25 +185,25 @@ class PassiveParamsTesterBase :
     //! Connect port to typedGuarded[portNum]
     void connect_to_typedGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnGuarded[portNum]
     void connect_to_typedReturnGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
     //! Connect port to typedReturnSync[portNum]
     void connect_to_typedReturnSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
     //! Connect port to typedSync[portNum]
     void connect_to_typedSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
   public:
@@ -275,14 +275,14 @@ class PassiveParamsTesterBase :
     //! Get from port at index
     //!
     //! \return from_typedOut[portNum]
-    InputTypedPort* get_from_typedOut(
+    Ports::InputTypedPort* get_from_typedOut(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get from port at index
     //!
     //! \return from_typedReturnOut[portNum]
-    InputTypedReturnPort* get_from_typedReturnOut(
+    Ports::InputTypedReturnPort* get_from_typedReturnOut(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -313,7 +313,7 @@ class PassiveParamsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -325,7 +325,7 @@ class PassiveParamsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -343,7 +343,7 @@ class PassiveParamsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -355,7 +355,7 @@ class PassiveParamsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -393,7 +393,7 @@ class PassiveParamsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -405,7 +405,7 @@ class PassiveParamsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -417,7 +417,7 @@ class PassiveParamsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -429,7 +429,7 @@ class PassiveParamsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -771,7 +771,7 @@ class PassiveParamsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -782,7 +782,7 @@ class PassiveParamsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -840,7 +840,7 @@ class PassiveParamsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -853,7 +853,7 @@ class PassiveParamsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -899,16 +899,16 @@ class PassiveParamsTesterBase :
     Ports::OutputNoArgsPort m_to_noArgsSync[3];
 
     //! To port connected to typedGuarded
-    OutputTypedPort m_to_typedGuarded[1];
+    Ports::OutputTypedPort m_to_typedGuarded[1];
 
     //! To port connected to typedReturnGuarded
-    OutputTypedReturnPort m_to_typedReturnGuarded[1];
+    Ports::OutputTypedReturnPort m_to_typedReturnGuarded[1];
 
     //! To port connected to typedReturnSync
-    OutputTypedReturnPort m_to_typedReturnSync[3];
+    Ports::OutputTypedReturnPort m_to_typedReturnSync[3];
 
     //! To port connected to typedSync
-    OutputTypedPort m_to_typedSync[3];
+    Ports::OutputTypedPort m_to_typedSync[3];
 
   private:
 
@@ -945,10 +945,10 @@ class PassiveParamsTesterBase :
     Fw::InputTlmPort m_from_tlmOut[1];
 
     //! From port connected to typedOut
-    InputTypedPort m_from_typedOut[1];
+    Ports::InputTypedPort m_from_typedOut[1];
 
     //! From port connected to typedReturnOut
-    InputTypedReturnPort m_from_typedReturnOut[1];
+    Ports::InputTypedReturnPort m_from_typedReturnOut[1];
 
   private:
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialComponentAc.ref.cpp
@@ -19,10 +19,10 @@ namespace {
     BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
     BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
     BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE typedGuardedPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedReturnGuardedPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedReturnSyncPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedSyncPortSize[InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedGuardedPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedReturnGuardedPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedReturnSyncPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedSyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
     BYTE cmdPortSize[Fw::InputCmdPort::SERIALIZED_SIZE];
   };
 
@@ -654,7 +654,7 @@ Ports::InputNoArgsPort* PassiveSerialComponentBase ::
   return &this->m_noArgsSync_InputPort[portNum];
 }
 
-InputTypedPort* PassiveSerialComponentBase ::
+Ports::InputTypedPort* PassiveSerialComponentBase ::
   get_typedGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -665,7 +665,7 @@ InputTypedPort* PassiveSerialComponentBase ::
   return &this->m_typedGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* PassiveSerialComponentBase ::
+Ports::InputTypedReturnPort* PassiveSerialComponentBase ::
   get_typedReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -676,7 +676,7 @@ InputTypedReturnPort* PassiveSerialComponentBase ::
   return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* PassiveSerialComponentBase ::
+Ports::InputTypedReturnPort* PassiveSerialComponentBase ::
   get_typedReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -687,7 +687,7 @@ InputTypedReturnPort* PassiveSerialComponentBase ::
   return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-InputTypedPort* PassiveSerialComponentBase ::
+Ports::InputTypedPort* PassiveSerialComponentBase ::
   get_typedSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -851,7 +851,7 @@ void PassiveSerialComponentBase ::
 void PassiveSerialComponentBase ::
   set_typedOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -865,7 +865,7 @@ void PassiveSerialComponentBase ::
 void PassiveSerialComponentBase ::
   set_typedReturnOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -1725,7 +1725,7 @@ void PassiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1762,7 +1762,7 @@ F32 PassiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1803,7 +1803,7 @@ F32 PassiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1838,7 +1838,7 @@ void PassiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1923,7 +1923,7 @@ void PassiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1950,7 +1950,7 @@ F32 PassiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -4159,7 +4159,7 @@ void PassiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -4186,7 +4186,7 @@ F32 PassiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -4213,7 +4213,7 @@ F32 PassiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -4240,7 +4240,7 @@ void PassiveSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialComponentAc.ref.cpp
@@ -15,10 +15,10 @@
 namespace {
   // Get the max size by doing a union of the input and internal port serialization sizes
   union BuffUnion {
-    BYTE noArgsGuardedPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnGuardedPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnSyncPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsSyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsGuardedPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
     BYTE typedGuardedPortSize[InputTypedPort::SERIALIZED_SIZE];
     BYTE typedReturnGuardedPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
     BYTE typedReturnSyncPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
@@ -610,7 +610,7 @@ Fw::InputCmdPort* PassiveSerialComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-InputNoArgsPort* PassiveSerialComponentBase ::
+Ports::InputNoArgsPort* PassiveSerialComponentBase ::
   get_noArgsGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -621,7 +621,7 @@ InputNoArgsPort* PassiveSerialComponentBase ::
   return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* PassiveSerialComponentBase ::
+Ports::InputNoArgsReturnPort* PassiveSerialComponentBase ::
   get_noArgsReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -632,7 +632,7 @@ InputNoArgsReturnPort* PassiveSerialComponentBase ::
   return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* PassiveSerialComponentBase ::
+Ports::InputNoArgsReturnPort* PassiveSerialComponentBase ::
   get_noArgsReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -643,7 +643,7 @@ InputNoArgsReturnPort* PassiveSerialComponentBase ::
   return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-InputNoArgsPort* PassiveSerialComponentBase ::
+Ports::InputNoArgsPort* PassiveSerialComponentBase ::
   get_noArgsSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialComponentAc.ref.hpp
@@ -240,28 +240,28 @@ class PassiveSerialComponentBase :
     //! Get typed input port at index
     //!
     //! \return typedGuarded[portNum]
-    InputTypedPort* get_typedGuarded_InputPort(
+    Ports::InputTypedPort* get_typedGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnGuarded[portNum]
-    InputTypedReturnPort* get_typedReturnGuarded_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnSync[portNum]
-    InputTypedReturnPort* get_typedReturnSync_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedSync[portNum]
-    InputTypedPort* get_typedSync_InputPort(
+    Ports::InputTypedPort* get_typedSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -352,13 +352,13 @@ class PassiveSerialComponentBase :
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnOut[portNum]
     void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
 #if FW_PORT_SERIALIZATION
@@ -766,7 +766,7 @@ class PassiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -778,7 +778,7 @@ class PassiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -790,7 +790,7 @@ class PassiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -802,7 +802,7 @@ class PassiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -842,7 +842,7 @@ class PassiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -854,7 +854,7 @@ class PassiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -866,7 +866,7 @@ class PassiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -878,7 +878,7 @@ class PassiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -934,7 +934,7 @@ class PassiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -946,7 +946,7 @@ class PassiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1535,7 +1535,7 @@ class PassiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1548,7 +1548,7 @@ class PassiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1561,7 +1561,7 @@ class PassiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1574,7 +1574,7 @@ class PassiveSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1716,16 +1716,16 @@ class PassiveSerialComponentBase :
     Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedGuarded
-    InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
+    Ports::InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnGuarded
-    InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnSync
-    InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
 
     //! Input port typedSync
-    InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
 
   PRIVATE:
 
@@ -1780,10 +1780,10 @@ class PassiveSerialComponentBase :
     // ----------------------------------------------------------------------
 
     //! Output port typedOut
-    OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
+    Ports::OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
 
     //! Output port typedReturnOut
-    OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
+    Ports::OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
 
   PRIVATE:
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialComponentAc.ref.hpp
@@ -212,28 +212,28 @@ class PassiveSerialComponentBase :
     //! Get typed input port at index
     //!
     //! \return noArgsGuarded[portNum]
-    InputNoArgsPort* get_noArgsGuarded_InputPort(
+    Ports::InputNoArgsPort* get_noArgsGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnGuarded[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnSync[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsSync[portNum]
-    InputNoArgsPort* get_noArgsSync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -1704,16 +1704,16 @@ class PassiveSerialComponentBase :
     // ----------------------------------------------------------------------
 
     //! Input port noArgsGuarded
-    InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnGuarded
-    InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnSync
-    InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
 
     //! Input port noArgsSync
-    InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedGuarded
     InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.cpp
@@ -616,7 +616,7 @@ void PassiveSerialTesterBase ::
 void PassiveSerialTesterBase ::
   connect_to_typedGuarded(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -630,7 +630,7 @@ void PassiveSerialTesterBase ::
 void PassiveSerialTesterBase ::
   connect_to_typedReturnGuarded(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -644,7 +644,7 @@ void PassiveSerialTesterBase ::
 void PassiveSerialTesterBase ::
   connect_to_typedReturnSync(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -658,7 +658,7 @@ void PassiveSerialTesterBase ::
 void PassiveSerialTesterBase ::
   connect_to_typedSync(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -793,7 +793,7 @@ Fw::InputTlmPort* PassiveSerialTesterBase ::
   return &this->m_from_tlmOut[portNum];
 }
 
-InputTypedPort* PassiveSerialTesterBase ::
+Ports::InputTypedPort* PassiveSerialTesterBase ::
   get_from_typedOut(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -804,7 +804,7 @@ InputTypedPort* PassiveSerialTesterBase ::
   return &this->m_from_typedOut[portNum];
 }
 
-InputTypedReturnPort* PassiveSerialTesterBase ::
+Ports::InputTypedReturnPort* PassiveSerialTesterBase ::
   get_from_typedReturnOut(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -921,7 +921,7 @@ void PassiveSerialTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -950,7 +950,7 @@ F32 PassiveSerialTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1044,7 +1044,7 @@ void PassiveSerialTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1072,7 +1072,7 @@ F32 PassiveSerialTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1100,7 +1100,7 @@ F32 PassiveSerialTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1128,7 +1128,7 @@ void PassiveSerialTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3004,7 +3004,7 @@ void PassiveSerialTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3028,7 +3028,7 @@ void PassiveSerialTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -3422,7 +3422,7 @@ void PassiveSerialTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3449,7 +3449,7 @@ F32 PassiveSerialTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.cpp
@@ -560,7 +560,7 @@ void PassiveSerialTesterBase ::
 void PassiveSerialTesterBase ::
   connect_to_noArgsGuarded(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsPort* port
+      Ports::InputNoArgsPort* port
   )
 {
   FW_ASSERT(
@@ -574,7 +574,7 @@ void PassiveSerialTesterBase ::
 void PassiveSerialTesterBase ::
   connect_to_noArgsReturnGuarded(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsReturnPort* port
+      Ports::InputNoArgsReturnPort* port
   )
 {
   FW_ASSERT(
@@ -588,7 +588,7 @@ void PassiveSerialTesterBase ::
 void PassiveSerialTesterBase ::
   connect_to_noArgsReturnSync(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsReturnPort* port
+      Ports::InputNoArgsReturnPort* port
   )
 {
   FW_ASSERT(
@@ -602,7 +602,7 @@ void PassiveSerialTesterBase ::
 void PassiveSerialTesterBase ::
   connect_to_noArgsSync(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsPort* port
+      Ports::InputNoArgsPort* port
   )
 {
   FW_ASSERT(

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.hpp
@@ -111,7 +111,7 @@ class PassiveSerialTesterBase :
       U32 u32;
       F32 f32;
       bool b;
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       E e;
       A a;
       S s;
@@ -122,7 +122,7 @@ class PassiveSerialTesterBase :
       U32 u32;
       F32 f32;
       bool b;
-      TypedReturnPortStrings::StringSize80 str2;
+      Ports::TypedReturnPortStrings::StringSize80 str2;
       E e;
       A a;
       S s;
@@ -291,25 +291,25 @@ class PassiveSerialTesterBase :
     //! Connect port to typedGuarded[portNum]
     void connect_to_typedGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnGuarded[portNum]
     void connect_to_typedReturnGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
     //! Connect port to typedReturnSync[portNum]
     void connect_to_typedReturnSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
     //! Connect port to typedSync[portNum]
     void connect_to_typedSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to serialGuarded[portNum]
@@ -393,14 +393,14 @@ class PassiveSerialTesterBase :
     //! Get from port at index
     //!
     //! \return from_typedOut[portNum]
-    InputTypedPort* get_from_typedOut(
+    Ports::InputTypedPort* get_from_typedOut(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get from port at index
     //!
     //! \return from_typedReturnOut[portNum]
-    InputTypedReturnPort* get_from_typedReturnOut(
+    Ports::InputTypedReturnPort* get_from_typedReturnOut(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -438,7 +438,7 @@ class PassiveSerialTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -450,7 +450,7 @@ class PassiveSerialTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -474,7 +474,7 @@ class PassiveSerialTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -486,7 +486,7 @@ class PassiveSerialTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -530,7 +530,7 @@ class PassiveSerialTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -542,7 +542,7 @@ class PassiveSerialTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -554,7 +554,7 @@ class PassiveSerialTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -566,7 +566,7 @@ class PassiveSerialTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1176,7 +1176,7 @@ class PassiveSerialTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1187,7 +1187,7 @@ class PassiveSerialTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1297,7 +1297,7 @@ class PassiveSerialTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1310,7 +1310,7 @@ class PassiveSerialTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1430,16 +1430,16 @@ class PassiveSerialTesterBase :
     Ports::OutputNoArgsPort m_to_noArgsSync[3];
 
     //! To port connected to typedGuarded
-    OutputTypedPort m_to_typedGuarded[1];
+    Ports::OutputTypedPort m_to_typedGuarded[1];
 
     //! To port connected to typedReturnGuarded
-    OutputTypedReturnPort m_to_typedReturnGuarded[1];
+    Ports::OutputTypedReturnPort m_to_typedReturnGuarded[1];
 
     //! To port connected to typedReturnSync
-    OutputTypedReturnPort m_to_typedReturnSync[3];
+    Ports::OutputTypedReturnPort m_to_typedReturnSync[3];
 
     //! To port connected to typedSync
-    OutputTypedPort m_to_typedSync[3];
+    Ports::OutputTypedPort m_to_typedSync[3];
 
     //! To port connected to serialGuarded
     Fw::OutputSerializePort m_to_serialGuarded[1];
@@ -1482,10 +1482,10 @@ class PassiveSerialTesterBase :
     Fw::InputTlmPort m_from_tlmOut[1];
 
     //! From port connected to typedOut
-    InputTypedPort m_from_typedOut[1];
+    Ports::InputTypedPort m_from_typedOut[1];
 
     //! From port connected to typedReturnOut
-    InputTypedReturnPort m_from_typedReturnOut[1];
+    Ports::InputTypedReturnPort m_from_typedReturnOut[1];
 
     //! From port connected to serialOut
     Fw::InputSerializePort m_from_serialOut[5];

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.hpp
@@ -267,25 +267,25 @@ class PassiveSerialTesterBase :
     //! Connect port to noArgsGuarded[portNum]
     void connect_to_noArgsGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsPort* port //!< The input port
+        Ports::InputNoArgsPort* port //!< The input port
     );
 
     //! Connect port to noArgsReturnGuarded[portNum]
     void connect_to_noArgsReturnGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsReturnPort* port //!< The input port
+        Ports::InputNoArgsReturnPort* port //!< The input port
     );
 
     //! Connect port to noArgsReturnSync[portNum]
     void connect_to_noArgsReturnSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsReturnPort* port //!< The input port
+        Ports::InputNoArgsReturnPort* port //!< The input port
     );
 
     //! Connect port to noArgsSync[portNum]
     void connect_to_noArgsSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsPort* port //!< The input port
+        Ports::InputNoArgsPort* port //!< The input port
     );
 
     //! Connect port to typedGuarded[portNum]
@@ -1418,16 +1418,16 @@ class PassiveSerialTesterBase :
     Fw::OutputCmdPort m_to_cmdIn[1];
 
     //! To port connected to noArgsGuarded
-    OutputNoArgsPort m_to_noArgsGuarded[1];
+    Ports::OutputNoArgsPort m_to_noArgsGuarded[1];
 
     //! To port connected to noArgsReturnGuarded
-    OutputNoArgsReturnPort m_to_noArgsReturnGuarded[1];
+    Ports::OutputNoArgsReturnPort m_to_noArgsReturnGuarded[1];
 
     //! To port connected to noArgsReturnSync
-    OutputNoArgsReturnPort m_to_noArgsReturnSync[3];
+    Ports::OutputNoArgsReturnPort m_to_noArgsReturnSync[3];
 
     //! To port connected to noArgsSync
-    OutputNoArgsPort m_to_noArgsSync[3];
+    Ports::OutputNoArgsPort m_to_noArgsSync[3];
 
     //! To port connected to typedGuarded
     OutputTypedPort m_to_typedGuarded[1];

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTelemetryComponentAc.ref.cpp
@@ -19,10 +19,10 @@ namespace {
     BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
     BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
     BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE typedGuardedPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedReturnGuardedPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedReturnSyncPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedSyncPortSize[InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedGuardedPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedReturnGuardedPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedReturnSyncPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedSyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
     BYTE cmdPortSize[Fw::InputCmdPort::SERIALIZED_SIZE];
   };
 
@@ -581,7 +581,7 @@ Ports::InputNoArgsPort* PassiveTelemetryComponentBase ::
   return &this->m_noArgsSync_InputPort[portNum];
 }
 
-InputTypedPort* PassiveTelemetryComponentBase ::
+Ports::InputTypedPort* PassiveTelemetryComponentBase ::
   get_typedGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -592,7 +592,7 @@ InputTypedPort* PassiveTelemetryComponentBase ::
   return &this->m_typedGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* PassiveTelemetryComponentBase ::
+Ports::InputTypedReturnPort* PassiveTelemetryComponentBase ::
   get_typedReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -603,7 +603,7 @@ InputTypedReturnPort* PassiveTelemetryComponentBase ::
   return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* PassiveTelemetryComponentBase ::
+Ports::InputTypedReturnPort* PassiveTelemetryComponentBase ::
   get_typedReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -614,7 +614,7 @@ InputTypedReturnPort* PassiveTelemetryComponentBase ::
   return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-InputTypedPort* PassiveTelemetryComponentBase ::
+Ports::InputTypedPort* PassiveTelemetryComponentBase ::
   get_typedSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -752,7 +752,7 @@ void PassiveTelemetryComponentBase ::
 void PassiveTelemetryComponentBase ::
   set_typedOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -766,7 +766,7 @@ void PassiveTelemetryComponentBase ::
 void PassiveTelemetryComponentBase ::
   set_typedReturnOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -1271,7 +1271,7 @@ void PassiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1308,7 +1308,7 @@ F32 PassiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1349,7 +1349,7 @@ F32 PassiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1384,7 +1384,7 @@ void PassiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1419,7 +1419,7 @@ void PassiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1446,7 +1446,7 @@ F32 PassiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1974,7 +1974,7 @@ void PassiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2001,7 +2001,7 @@ F32 PassiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2028,7 +2028,7 @@ F32 PassiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2055,7 +2055,7 @@ void PassiveTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTelemetryComponentAc.ref.cpp
@@ -15,10 +15,10 @@
 namespace {
   // Get the max size by doing a union of the input and internal port serialization sizes
   union BuffUnion {
-    BYTE noArgsGuardedPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnGuardedPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnSyncPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsSyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsGuardedPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
     BYTE typedGuardedPortSize[InputTypedPort::SERIALIZED_SIZE];
     BYTE typedReturnGuardedPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
     BYTE typedReturnSyncPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
@@ -537,7 +537,7 @@ Fw::InputCmdPort* PassiveTelemetryComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-InputNoArgsPort* PassiveTelemetryComponentBase ::
+Ports::InputNoArgsPort* PassiveTelemetryComponentBase ::
   get_noArgsGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -548,7 +548,7 @@ InputNoArgsPort* PassiveTelemetryComponentBase ::
   return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* PassiveTelemetryComponentBase ::
+Ports::InputNoArgsReturnPort* PassiveTelemetryComponentBase ::
   get_noArgsReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -559,7 +559,7 @@ InputNoArgsReturnPort* PassiveTelemetryComponentBase ::
   return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* PassiveTelemetryComponentBase ::
+Ports::InputNoArgsReturnPort* PassiveTelemetryComponentBase ::
   get_noArgsReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -570,7 +570,7 @@ InputNoArgsReturnPort* PassiveTelemetryComponentBase ::
   return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-InputNoArgsPort* PassiveTelemetryComponentBase ::
+Ports::InputNoArgsPort* PassiveTelemetryComponentBase ::
   get_noArgsSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTelemetryComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTelemetryComponentAc.ref.hpp
@@ -164,28 +164,28 @@ class PassiveTelemetryComponentBase :
     //! Get typed input port at index
     //!
     //! \return typedGuarded[portNum]
-    InputTypedPort* get_typedGuarded_InputPort(
+    Ports::InputTypedPort* get_typedGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnGuarded[portNum]
-    InputTypedReturnPort* get_typedReturnGuarded_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnSync[portNum]
-    InputTypedReturnPort* get_typedReturnSync_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedSync[portNum]
-    InputTypedPort* get_typedSync_InputPort(
+    Ports::InputTypedPort* get_typedSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -256,13 +256,13 @@ class PassiveTelemetryComponentBase :
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnOut[portNum]
     void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
 #if FW_PORT_SERIALIZATION
@@ -592,7 +592,7 @@ class PassiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -604,7 +604,7 @@ class PassiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -616,7 +616,7 @@ class PassiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -628,7 +628,7 @@ class PassiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -668,7 +668,7 @@ class PassiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -680,7 +680,7 @@ class PassiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -692,7 +692,7 @@ class PassiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -704,7 +704,7 @@ class PassiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -722,7 +722,7 @@ class PassiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -734,7 +734,7 @@ class PassiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -912,7 +912,7 @@ class PassiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -925,7 +925,7 @@ class PassiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -938,7 +938,7 @@ class PassiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -951,7 +951,7 @@ class PassiveTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -985,16 +985,16 @@ class PassiveTelemetryComponentBase :
     Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedGuarded
-    InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
+    Ports::InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnGuarded
-    InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnSync
-    InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
 
     //! Input port typedSync
-    InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
 
   PRIVATE:
 
@@ -1037,10 +1037,10 @@ class PassiveTelemetryComponentBase :
     // ----------------------------------------------------------------------
 
     //! Output port typedOut
-    OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
+    Ports::OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
 
     //! Output port typedReturnOut
-    OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
+    Ports::OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
 
   PRIVATE:
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTelemetryComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTelemetryComponentAc.ref.hpp
@@ -136,28 +136,28 @@ class PassiveTelemetryComponentBase :
     //! Get typed input port at index
     //!
     //! \return noArgsGuarded[portNum]
-    InputNoArgsPort* get_noArgsGuarded_InputPort(
+    Ports::InputNoArgsPort* get_noArgsGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnGuarded[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnSync[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsSync[portNum]
-    InputNoArgsPort* get_noArgsSync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -973,16 +973,16 @@ class PassiveTelemetryComponentBase :
     // ----------------------------------------------------------------------
 
     //! Input port noArgsGuarded
-    InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnGuarded
-    InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnSync
-    InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
 
     //! Input port noArgsSync
-    InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedGuarded
     InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTelemetryTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTelemetryTesterBase.ref.cpp
@@ -369,7 +369,7 @@ void PassiveTelemetryTesterBase ::
 void PassiveTelemetryTesterBase ::
   connect_to_typedGuarded(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -383,7 +383,7 @@ void PassiveTelemetryTesterBase ::
 void PassiveTelemetryTesterBase ::
   connect_to_typedReturnGuarded(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -397,7 +397,7 @@ void PassiveTelemetryTesterBase ::
 void PassiveTelemetryTesterBase ::
   connect_to_typedReturnSync(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -411,7 +411,7 @@ void PassiveTelemetryTesterBase ::
 void PassiveTelemetryTesterBase ::
   connect_to_typedSync(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -518,7 +518,7 @@ Fw::InputTlmPort* PassiveTelemetryTesterBase ::
   return &this->m_from_tlmOut[portNum];
 }
 
-InputTypedPort* PassiveTelemetryTesterBase ::
+Ports::InputTypedPort* PassiveTelemetryTesterBase ::
   get_from_typedOut(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -529,7 +529,7 @@ InputTypedPort* PassiveTelemetryTesterBase ::
   return &this->m_from_typedOut[portNum];
 }
 
-InputTypedReturnPort* PassiveTelemetryTesterBase ::
+Ports::InputTypedReturnPort* PassiveTelemetryTesterBase ::
   get_from_typedReturnOut(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -603,7 +603,7 @@ void PassiveTelemetryTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -632,7 +632,7 @@ F32 PassiveTelemetryTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -709,7 +709,7 @@ void PassiveTelemetryTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -737,7 +737,7 @@ F32 PassiveTelemetryTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -765,7 +765,7 @@ F32 PassiveTelemetryTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -793,7 +793,7 @@ void PassiveTelemetryTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1362,7 +1362,7 @@ void PassiveTelemetryTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1386,7 +1386,7 @@ void PassiveTelemetryTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1457,7 +1457,7 @@ void PassiveTelemetryTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1484,7 +1484,7 @@ F32 PassiveTelemetryTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTelemetryTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTelemetryTesterBase.ref.cpp
@@ -313,7 +313,7 @@ void PassiveTelemetryTesterBase ::
 void PassiveTelemetryTesterBase ::
   connect_to_noArgsGuarded(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsPort* port
+      Ports::InputNoArgsPort* port
   )
 {
   FW_ASSERT(
@@ -327,7 +327,7 @@ void PassiveTelemetryTesterBase ::
 void PassiveTelemetryTesterBase ::
   connect_to_noArgsReturnGuarded(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsReturnPort* port
+      Ports::InputNoArgsReturnPort* port
   )
 {
   FW_ASSERT(
@@ -341,7 +341,7 @@ void PassiveTelemetryTesterBase ::
 void PassiveTelemetryTesterBase ::
   connect_to_noArgsReturnSync(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsReturnPort* port
+      Ports::InputNoArgsReturnPort* port
   )
 {
   FW_ASSERT(
@@ -355,7 +355,7 @@ void PassiveTelemetryTesterBase ::
 void PassiveTelemetryTesterBase ::
   connect_to_noArgsSync(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsPort* port
+      Ports::InputNoArgsPort* port
   )
 {
   FW_ASSERT(

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTelemetryTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTelemetryTesterBase.ref.hpp
@@ -111,7 +111,7 @@ class PassiveTelemetryTesterBase :
       U32 u32;
       F32 f32;
       bool b;
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       E e;
       A a;
       S s;
@@ -122,7 +122,7 @@ class PassiveTelemetryTesterBase :
       U32 u32;
       F32 f32;
       bool b;
-      TypedReturnPortStrings::StringSize80 str2;
+      Ports::TypedReturnPortStrings::StringSize80 str2;
       E e;
       A a;
       S s;
@@ -244,25 +244,25 @@ class PassiveTelemetryTesterBase :
     //! Connect port to typedGuarded[portNum]
     void connect_to_typedGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnGuarded[portNum]
     void connect_to_typedReturnGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
     //! Connect port to typedReturnSync[portNum]
     void connect_to_typedReturnSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
     //! Connect port to typedSync[portNum]
     void connect_to_typedSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
   public:
@@ -334,14 +334,14 @@ class PassiveTelemetryTesterBase :
     //! Get from port at index
     //!
     //! \return from_typedOut[portNum]
-    InputTypedPort* get_from_typedOut(
+    Ports::InputTypedPort* get_from_typedOut(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get from port at index
     //!
     //! \return from_typedReturnOut[portNum]
-    InputTypedReturnPort* get_from_typedReturnOut(
+    Ports::InputTypedReturnPort* get_from_typedReturnOut(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -372,7 +372,7 @@ class PassiveTelemetryTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -384,7 +384,7 @@ class PassiveTelemetryTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -402,7 +402,7 @@ class PassiveTelemetryTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -414,7 +414,7 @@ class PassiveTelemetryTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -452,7 +452,7 @@ class PassiveTelemetryTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -464,7 +464,7 @@ class PassiveTelemetryTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -476,7 +476,7 @@ class PassiveTelemetryTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -488,7 +488,7 @@ class PassiveTelemetryTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -775,7 +775,7 @@ class PassiveTelemetryTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -786,7 +786,7 @@ class PassiveTelemetryTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -824,7 +824,7 @@ class PassiveTelemetryTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -837,7 +837,7 @@ class PassiveTelemetryTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -916,16 +916,16 @@ class PassiveTelemetryTesterBase :
     Ports::OutputNoArgsPort m_to_noArgsSync[3];
 
     //! To port connected to typedGuarded
-    OutputTypedPort m_to_typedGuarded[1];
+    Ports::OutputTypedPort m_to_typedGuarded[1];
 
     //! To port connected to typedReturnGuarded
-    OutputTypedReturnPort m_to_typedReturnGuarded[1];
+    Ports::OutputTypedReturnPort m_to_typedReturnGuarded[1];
 
     //! To port connected to typedReturnSync
-    OutputTypedReturnPort m_to_typedReturnSync[3];
+    Ports::OutputTypedReturnPort m_to_typedReturnSync[3];
 
     //! To port connected to typedSync
-    OutputTypedPort m_to_typedSync[3];
+    Ports::OutputTypedPort m_to_typedSync[3];
 
   private:
 
@@ -962,10 +962,10 @@ class PassiveTelemetryTesterBase :
     Fw::InputTlmPort m_from_tlmOut[1];
 
     //! From port connected to typedOut
-    InputTypedPort m_from_typedOut[1];
+    Ports::InputTypedPort m_from_typedOut[1];
 
     //! From port connected to typedReturnOut
-    InputTypedReturnPort m_from_typedReturnOut[1];
+    Ports::InputTypedReturnPort m_from_typedReturnOut[1];
 
   private:
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTelemetryTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTelemetryTesterBase.ref.hpp
@@ -220,25 +220,25 @@ class PassiveTelemetryTesterBase :
     //! Connect port to noArgsGuarded[portNum]
     void connect_to_noArgsGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsPort* port //!< The input port
+        Ports::InputNoArgsPort* port //!< The input port
     );
 
     //! Connect port to noArgsReturnGuarded[portNum]
     void connect_to_noArgsReturnGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsReturnPort* port //!< The input port
+        Ports::InputNoArgsReturnPort* port //!< The input port
     );
 
     //! Connect port to noArgsReturnSync[portNum]
     void connect_to_noArgsReturnSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsReturnPort* port //!< The input port
+        Ports::InputNoArgsReturnPort* port //!< The input port
     );
 
     //! Connect port to noArgsSync[portNum]
     void connect_to_noArgsSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsPort* port //!< The input port
+        Ports::InputNoArgsPort* port //!< The input port
     );
 
     //! Connect port to typedGuarded[portNum]
@@ -904,16 +904,16 @@ class PassiveTelemetryTesterBase :
     Fw::OutputCmdPort m_to_cmdIn[1];
 
     //! To port connected to noArgsGuarded
-    OutputNoArgsPort m_to_noArgsGuarded[1];
+    Ports::OutputNoArgsPort m_to_noArgsGuarded[1];
 
     //! To port connected to noArgsReturnGuarded
-    OutputNoArgsReturnPort m_to_noArgsReturnGuarded[1];
+    Ports::OutputNoArgsReturnPort m_to_noArgsReturnGuarded[1];
 
     //! To port connected to noArgsReturnSync
-    OutputNoArgsReturnPort m_to_noArgsReturnSync[3];
+    Ports::OutputNoArgsReturnPort m_to_noArgsReturnSync[3];
 
     //! To port connected to noArgsSync
-    OutputNoArgsPort m_to_noArgsSync[3];
+    Ports::OutputNoArgsPort m_to_noArgsSync[3];
 
     //! To port connected to typedGuarded
     OutputTypedPort m_to_typedGuarded[1];

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestComponentAc.ref.cpp
@@ -19,10 +19,10 @@ namespace {
     BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
     BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
     BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE typedGuardedPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedReturnGuardedPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedReturnSyncPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedSyncPortSize[InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedGuardedPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedReturnGuardedPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedReturnSyncPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedSyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
     BYTE cmdPortSize[Fw::InputCmdPort::SERIALIZED_SIZE];
   };
 
@@ -581,7 +581,7 @@ Ports::InputNoArgsPort* PassiveTestComponentBase ::
   return &this->m_noArgsSync_InputPort[portNum];
 }
 
-InputTypedPort* PassiveTestComponentBase ::
+Ports::InputTypedPort* PassiveTestComponentBase ::
   get_typedGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -592,7 +592,7 @@ InputTypedPort* PassiveTestComponentBase ::
   return &this->m_typedGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* PassiveTestComponentBase ::
+Ports::InputTypedReturnPort* PassiveTestComponentBase ::
   get_typedReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -603,7 +603,7 @@ InputTypedReturnPort* PassiveTestComponentBase ::
   return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* PassiveTestComponentBase ::
+Ports::InputTypedReturnPort* PassiveTestComponentBase ::
   get_typedReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -614,7 +614,7 @@ InputTypedReturnPort* PassiveTestComponentBase ::
   return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-InputTypedPort* PassiveTestComponentBase ::
+Ports::InputTypedPort* PassiveTestComponentBase ::
   get_typedSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -752,7 +752,7 @@ void PassiveTestComponentBase ::
 void PassiveTestComponentBase ::
   set_typedOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -766,7 +766,7 @@ void PassiveTestComponentBase ::
 void PassiveTestComponentBase ::
   set_typedReturnOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -1563,7 +1563,7 @@ void PassiveTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1600,7 +1600,7 @@ F32 PassiveTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1641,7 +1641,7 @@ F32 PassiveTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1676,7 +1676,7 @@ void PassiveTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1711,7 +1711,7 @@ void PassiveTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1738,7 +1738,7 @@ F32 PassiveTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -3928,7 +3928,7 @@ void PassiveTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3955,7 +3955,7 @@ F32 PassiveTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -3982,7 +3982,7 @@ F32 PassiveTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -4009,7 +4009,7 @@ void PassiveTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestComponentAc.ref.cpp
@@ -15,10 +15,10 @@
 namespace {
   // Get the max size by doing a union of the input and internal port serialization sizes
   union BuffUnion {
-    BYTE noArgsGuardedPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnGuardedPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnSyncPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsSyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsGuardedPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
     BYTE typedGuardedPortSize[InputTypedPort::SERIALIZED_SIZE];
     BYTE typedReturnGuardedPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
     BYTE typedReturnSyncPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
@@ -537,7 +537,7 @@ Fw::InputCmdPort* PassiveTestComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-InputNoArgsPort* PassiveTestComponentBase ::
+Ports::InputNoArgsPort* PassiveTestComponentBase ::
   get_noArgsGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -548,7 +548,7 @@ InputNoArgsPort* PassiveTestComponentBase ::
   return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* PassiveTestComponentBase ::
+Ports::InputNoArgsReturnPort* PassiveTestComponentBase ::
   get_noArgsReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -559,7 +559,7 @@ InputNoArgsReturnPort* PassiveTestComponentBase ::
   return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* PassiveTestComponentBase ::
+Ports::InputNoArgsReturnPort* PassiveTestComponentBase ::
   get_noArgsReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -570,7 +570,7 @@ InputNoArgsReturnPort* PassiveTestComponentBase ::
   return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-InputNoArgsPort* PassiveTestComponentBase ::
+Ports::InputNoArgsPort* PassiveTestComponentBase ::
   get_noArgsSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestComponentAc.ref.hpp
@@ -196,28 +196,28 @@ class PassiveTestComponentBase :
     //! Get typed input port at index
     //!
     //! \return noArgsGuarded[portNum]
-    InputNoArgsPort* get_noArgsGuarded_InputPort(
+    Ports::InputNoArgsPort* get_noArgsGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnGuarded[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnSync[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsSync[portNum]
-    InputNoArgsPort* get_noArgsSync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -1538,16 +1538,16 @@ class PassiveTestComponentBase :
     // ----------------------------------------------------------------------
 
     //! Input port noArgsGuarded
-    InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnGuarded
-    InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnSync
-    InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
 
     //! Input port noArgsSync
-    InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedGuarded
     InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestComponentAc.ref.hpp
@@ -224,28 +224,28 @@ class PassiveTestComponentBase :
     //! Get typed input port at index
     //!
     //! \return typedGuarded[portNum]
-    InputTypedPort* get_typedGuarded_InputPort(
+    Ports::InputTypedPort* get_typedGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnGuarded[portNum]
-    InputTypedReturnPort* get_typedReturnGuarded_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnSync[portNum]
-    InputTypedReturnPort* get_typedReturnSync_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedSync[portNum]
-    InputTypedPort* get_typedSync_InputPort(
+    Ports::InputTypedPort* get_typedSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -316,13 +316,13 @@ class PassiveTestComponentBase :
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnOut[portNum]
     void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
 #if FW_PORT_SERIALIZATION
@@ -674,7 +674,7 @@ class PassiveTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -686,7 +686,7 @@ class PassiveTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -698,7 +698,7 @@ class PassiveTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -710,7 +710,7 @@ class PassiveTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -750,7 +750,7 @@ class PassiveTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -762,7 +762,7 @@ class PassiveTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -774,7 +774,7 @@ class PassiveTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -786,7 +786,7 @@ class PassiveTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -804,7 +804,7 @@ class PassiveTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -816,7 +816,7 @@ class PassiveTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1393,7 +1393,7 @@ class PassiveTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1406,7 +1406,7 @@ class PassiveTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1419,7 +1419,7 @@ class PassiveTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1432,7 +1432,7 @@ class PassiveTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1550,16 +1550,16 @@ class PassiveTestComponentBase :
     Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedGuarded
-    InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
+    Ports::InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnGuarded
-    InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnSync
-    InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
 
     //! Input port typedSync
-    InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
 
   PRIVATE:
 
@@ -1602,10 +1602,10 @@ class PassiveTestComponentBase :
     // ----------------------------------------------------------------------
 
     //! Output port typedOut
-    OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
+    Ports::OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
 
     //! Output port typedReturnOut
-    OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
+    Ports::OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
 
   PRIVATE:
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.cpp
@@ -548,7 +548,7 @@ void PassiveTestTesterBase ::
 void PassiveTestTesterBase ::
   connect_to_typedGuarded(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -562,7 +562,7 @@ void PassiveTestTesterBase ::
 void PassiveTestTesterBase ::
   connect_to_typedReturnGuarded(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -576,7 +576,7 @@ void PassiveTestTesterBase ::
 void PassiveTestTesterBase ::
   connect_to_typedReturnSync(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -590,7 +590,7 @@ void PassiveTestTesterBase ::
 void PassiveTestTesterBase ::
   connect_to_typedSync(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -697,7 +697,7 @@ Fw::InputTlmPort* PassiveTestTesterBase ::
   return &this->m_from_tlmOut[portNum];
 }
 
-InputTypedPort* PassiveTestTesterBase ::
+Ports::InputTypedPort* PassiveTestTesterBase ::
   get_from_typedOut(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -708,7 +708,7 @@ InputTypedPort* PassiveTestTesterBase ::
   return &this->m_from_typedOut[portNum];
 }
 
-InputTypedReturnPort* PassiveTestTesterBase ::
+Ports::InputTypedReturnPort* PassiveTestTesterBase ::
   get_from_typedReturnOut(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -814,7 +814,7 @@ void PassiveTestTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -843,7 +843,7 @@ F32 PassiveTestTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -920,7 +920,7 @@ void PassiveTestTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -948,7 +948,7 @@ F32 PassiveTestTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -976,7 +976,7 @@ F32 PassiveTestTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1004,7 +1004,7 @@ void PassiveTestTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2808,7 +2808,7 @@ void PassiveTestTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2832,7 +2832,7 @@ void PassiveTestTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -3226,7 +3226,7 @@ void PassiveTestTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3253,7 +3253,7 @@ F32 PassiveTestTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.cpp
@@ -492,7 +492,7 @@ void PassiveTestTesterBase ::
 void PassiveTestTesterBase ::
   connect_to_noArgsGuarded(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsPort* port
+      Ports::InputNoArgsPort* port
   )
 {
   FW_ASSERT(
@@ -506,7 +506,7 @@ void PassiveTestTesterBase ::
 void PassiveTestTesterBase ::
   connect_to_noArgsReturnGuarded(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsReturnPort* port
+      Ports::InputNoArgsReturnPort* port
   )
 {
   FW_ASSERT(
@@ -520,7 +520,7 @@ void PassiveTestTesterBase ::
 void PassiveTestTesterBase ::
   connect_to_noArgsReturnSync(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsReturnPort* port
+      Ports::InputNoArgsReturnPort* port
   )
 {
   FW_ASSERT(
@@ -534,7 +534,7 @@ void PassiveTestTesterBase ::
 void PassiveTestTesterBase ::
   connect_to_noArgsSync(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsPort* port
+      Ports::InputNoArgsPort* port
   )
 {
   FW_ASSERT(

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.hpp
@@ -267,25 +267,25 @@ class PassiveTestTesterBase :
     //! Connect port to noArgsGuarded[portNum]
     void connect_to_noArgsGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsPort* port //!< The input port
+        Ports::InputNoArgsPort* port //!< The input port
     );
 
     //! Connect port to noArgsReturnGuarded[portNum]
     void connect_to_noArgsReturnGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsReturnPort* port //!< The input port
+        Ports::InputNoArgsReturnPort* port //!< The input port
     );
 
     //! Connect port to noArgsReturnSync[portNum]
     void connect_to_noArgsReturnSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsReturnPort* port //!< The input port
+        Ports::InputNoArgsReturnPort* port //!< The input port
     );
 
     //! Connect port to noArgsSync[portNum]
     void connect_to_noArgsSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsPort* port //!< The input port
+        Ports::InputNoArgsPort* port //!< The input port
     );
 
     //! Connect port to typedGuarded[portNum]
@@ -1339,16 +1339,16 @@ class PassiveTestTesterBase :
     Fw::OutputCmdPort m_to_cmdIn[1];
 
     //! To port connected to noArgsGuarded
-    OutputNoArgsPort m_to_noArgsGuarded[1];
+    Ports::OutputNoArgsPort m_to_noArgsGuarded[1];
 
     //! To port connected to noArgsReturnGuarded
-    OutputNoArgsReturnPort m_to_noArgsReturnGuarded[1];
+    Ports::OutputNoArgsReturnPort m_to_noArgsReturnGuarded[1];
 
     //! To port connected to noArgsReturnSync
-    OutputNoArgsReturnPort m_to_noArgsReturnSync[3];
+    Ports::OutputNoArgsReturnPort m_to_noArgsReturnSync[3];
 
     //! To port connected to noArgsSync
-    OutputNoArgsPort m_to_noArgsSync[3];
+    Ports::OutputNoArgsPort m_to_noArgsSync[3];
 
     //! To port connected to typedGuarded
     OutputTypedPort m_to_typedGuarded[1];

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.hpp
@@ -111,7 +111,7 @@ class PassiveTestTesterBase :
       U32 u32;
       F32 f32;
       bool b;
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       E e;
       A a;
       S s;
@@ -122,7 +122,7 @@ class PassiveTestTesterBase :
       U32 u32;
       F32 f32;
       bool b;
-      TypedReturnPortStrings::StringSize80 str2;
+      Ports::TypedReturnPortStrings::StringSize80 str2;
       E e;
       A a;
       S s;
@@ -291,25 +291,25 @@ class PassiveTestTesterBase :
     //! Connect port to typedGuarded[portNum]
     void connect_to_typedGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnGuarded[portNum]
     void connect_to_typedReturnGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
     //! Connect port to typedReturnSync[portNum]
     void connect_to_typedReturnSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
     //! Connect port to typedSync[portNum]
     void connect_to_typedSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
   public:
@@ -381,14 +381,14 @@ class PassiveTestTesterBase :
     //! Get from port at index
     //!
     //! \return from_typedOut[portNum]
-    InputTypedPort* get_from_typedOut(
+    Ports::InputTypedPort* get_from_typedOut(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get from port at index
     //!
     //! \return from_typedReturnOut[portNum]
-    InputTypedReturnPort* get_from_typedReturnOut(
+    Ports::InputTypedReturnPort* get_from_typedReturnOut(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -419,7 +419,7 @@ class PassiveTestTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -431,7 +431,7 @@ class PassiveTestTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -449,7 +449,7 @@ class PassiveTestTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -461,7 +461,7 @@ class PassiveTestTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -499,7 +499,7 @@ class PassiveTestTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -511,7 +511,7 @@ class PassiveTestTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -523,7 +523,7 @@ class PassiveTestTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -535,7 +535,7 @@ class PassiveTestTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1104,7 +1104,7 @@ class PassiveTestTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1115,7 +1115,7 @@ class PassiveTestTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1225,7 +1225,7 @@ class PassiveTestTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1238,7 +1238,7 @@ class PassiveTestTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1351,16 +1351,16 @@ class PassiveTestTesterBase :
     Ports::OutputNoArgsPort m_to_noArgsSync[3];
 
     //! To port connected to typedGuarded
-    OutputTypedPort m_to_typedGuarded[1];
+    Ports::OutputTypedPort m_to_typedGuarded[1];
 
     //! To port connected to typedReturnGuarded
-    OutputTypedReturnPort m_to_typedReturnGuarded[1];
+    Ports::OutputTypedReturnPort m_to_typedReturnGuarded[1];
 
     //! To port connected to typedReturnSync
-    OutputTypedReturnPort m_to_typedReturnSync[3];
+    Ports::OutputTypedReturnPort m_to_typedReturnSync[3];
 
     //! To port connected to typedSync
-    OutputTypedPort m_to_typedSync[3];
+    Ports::OutputTypedPort m_to_typedSync[3];
 
   private:
 
@@ -1397,10 +1397,10 @@ class PassiveTestTesterBase :
     Fw::InputTlmPort m_from_tlmOut[1];
 
     //! From port connected to typedOut
-    InputTypedPort m_from_typedOut[1];
+    Ports::InputTypedPort m_from_typedOut[1];
 
     //! From port connected to typedReturnOut
-    InputTypedReturnPort m_from_typedReturnOut[1];
+    Ports::InputTypedReturnPort m_from_typedReturnOut[1];
 
   private:
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedCommandsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedCommandsComponentAc.ref.cpp
@@ -34,14 +34,14 @@ namespace {
     BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
     BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
     BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE typedAsyncPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncAssertPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncBlockPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncDropPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedGuardedPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedReturnGuardedPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedReturnSyncPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedSyncPortSize[InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncAssertPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncBlockPriorityPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncDropPriorityPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedGuardedPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedReturnGuardedPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedReturnSyncPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedSyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
     BYTE cmdPortSize[Fw::InputCmdPort::SERIALIZED_SIZE];
   };
 
@@ -753,7 +753,7 @@ Ports::InputNoArgsPort* QueuedCommandsComponentBase ::
   return &this->m_noArgsSync_InputPort[portNum];
 }
 
-InputTypedPort* QueuedCommandsComponentBase ::
+Ports::InputTypedPort* QueuedCommandsComponentBase ::
   get_typedAsync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -764,7 +764,7 @@ InputTypedPort* QueuedCommandsComponentBase ::
   return &this->m_typedAsync_InputPort[portNum];
 }
 
-InputTypedPort* QueuedCommandsComponentBase ::
+Ports::InputTypedPort* QueuedCommandsComponentBase ::
   get_typedAsyncAssert_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -775,7 +775,7 @@ InputTypedPort* QueuedCommandsComponentBase ::
   return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-InputTypedPort* QueuedCommandsComponentBase ::
+Ports::InputTypedPort* QueuedCommandsComponentBase ::
   get_typedAsyncBlockPriority_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -786,7 +786,7 @@ InputTypedPort* QueuedCommandsComponentBase ::
   return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-InputTypedPort* QueuedCommandsComponentBase ::
+Ports::InputTypedPort* QueuedCommandsComponentBase ::
   get_typedAsyncDropPriority_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -797,7 +797,7 @@ InputTypedPort* QueuedCommandsComponentBase ::
   return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-InputTypedPort* QueuedCommandsComponentBase ::
+Ports::InputTypedPort* QueuedCommandsComponentBase ::
   get_typedGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -808,7 +808,7 @@ InputTypedPort* QueuedCommandsComponentBase ::
   return &this->m_typedGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* QueuedCommandsComponentBase ::
+Ports::InputTypedReturnPort* QueuedCommandsComponentBase ::
   get_typedReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -819,7 +819,7 @@ InputTypedReturnPort* QueuedCommandsComponentBase ::
   return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* QueuedCommandsComponentBase ::
+Ports::InputTypedReturnPort* QueuedCommandsComponentBase ::
   get_typedReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -830,7 +830,7 @@ InputTypedReturnPort* QueuedCommandsComponentBase ::
   return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-InputTypedPort* QueuedCommandsComponentBase ::
+Ports::InputTypedPort* QueuedCommandsComponentBase ::
   get_typedSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -968,7 +968,7 @@ void QueuedCommandsComponentBase ::
 void QueuedCommandsComponentBase ::
   set_typedOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -982,7 +982,7 @@ void QueuedCommandsComponentBase ::
 void QueuedCommandsComponentBase ::
   set_typedReturnOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -1630,7 +1630,7 @@ void QueuedCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1737,7 +1737,7 @@ void QueuedCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1844,7 +1844,7 @@ void QueuedCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1951,7 +1951,7 @@ void QueuedCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2063,7 +2063,7 @@ void QueuedCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2100,7 +2100,7 @@ F32 QueuedCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2141,7 +2141,7 @@ F32 QueuedCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2176,7 +2176,7 @@ void QueuedCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2221,7 +2221,7 @@ void QueuedCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2236,7 +2236,7 @@ void QueuedCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2251,7 +2251,7 @@ void QueuedCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2266,7 +2266,7 @@ void QueuedCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2285,7 +2285,7 @@ void QueuedCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2312,7 +2312,7 @@ F32 QueuedCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -3460,7 +3460,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -3532,7 +3532,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -3604,7 +3604,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -3676,7 +3676,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedCommandsComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -4241,7 +4241,7 @@ void QueuedCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -4268,7 +4268,7 @@ void QueuedCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -4295,7 +4295,7 @@ void QueuedCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -4322,7 +4322,7 @@ void QueuedCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -4349,7 +4349,7 @@ void QueuedCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -4376,7 +4376,7 @@ F32 QueuedCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -4403,7 +4403,7 @@ F32 QueuedCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -4430,7 +4430,7 @@ void QueuedCommandsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedCommandsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedCommandsComponentAc.ref.cpp
@@ -29,11 +29,11 @@ namespace {
 
   // Get the max size by doing a union of the input and internal port serialization sizes
   union BuffUnion {
-    BYTE noArgsAsyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsGuardedPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnGuardedPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnSyncPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsSyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsAsyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsGuardedPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
     BYTE typedAsyncPortSize[InputTypedPort::SERIALIZED_SIZE];
     BYTE typedAsyncAssertPortSize[InputTypedPort::SERIALIZED_SIZE];
     BYTE typedAsyncBlockPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
@@ -698,7 +698,7 @@ Fw::InputCmdPort* QueuedCommandsComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-InputNoArgsPort* QueuedCommandsComponentBase ::
+Ports::InputNoArgsPort* QueuedCommandsComponentBase ::
   get_noArgsAsync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -709,7 +709,7 @@ InputNoArgsPort* QueuedCommandsComponentBase ::
   return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-InputNoArgsPort* QueuedCommandsComponentBase ::
+Ports::InputNoArgsPort* QueuedCommandsComponentBase ::
   get_noArgsGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -720,7 +720,7 @@ InputNoArgsPort* QueuedCommandsComponentBase ::
   return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* QueuedCommandsComponentBase ::
+Ports::InputNoArgsReturnPort* QueuedCommandsComponentBase ::
   get_noArgsReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -731,7 +731,7 @@ InputNoArgsReturnPort* QueuedCommandsComponentBase ::
   return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* QueuedCommandsComponentBase ::
+Ports::InputNoArgsReturnPort* QueuedCommandsComponentBase ::
   get_noArgsReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -742,7 +742,7 @@ InputNoArgsReturnPort* QueuedCommandsComponentBase ::
   return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-InputNoArgsPort* QueuedCommandsComponentBase ::
+Ports::InputNoArgsPort* QueuedCommandsComponentBase ::
   get_noArgsSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedCommandsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedCommandsComponentAc.ref.hpp
@@ -183,56 +183,56 @@ class QueuedCommandsComponentBase :
     //! Get typed input port at index
     //!
     //! \return typedAsync[portNum]
-    InputTypedPort* get_typedAsync_InputPort(
+    Ports::InputTypedPort* get_typedAsync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncAssert[portNum]
-    InputTypedPort* get_typedAsyncAssert_InputPort(
+    Ports::InputTypedPort* get_typedAsyncAssert_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncBlockPriority[portNum]
-    InputTypedPort* get_typedAsyncBlockPriority_InputPort(
+    Ports::InputTypedPort* get_typedAsyncBlockPriority_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncDropPriority[portNum]
-    InputTypedPort* get_typedAsyncDropPriority_InputPort(
+    Ports::InputTypedPort* get_typedAsyncDropPriority_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedGuarded[portNum]
-    InputTypedPort* get_typedGuarded_InputPort(
+    Ports::InputTypedPort* get_typedGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnGuarded[portNum]
-    InputTypedReturnPort* get_typedReturnGuarded_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnSync[portNum]
-    InputTypedReturnPort* get_typedReturnSync_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedSync[portNum]
-    InputTypedPort* get_typedSync_InputPort(
+    Ports::InputTypedPort* get_typedSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -303,13 +303,13 @@ class QueuedCommandsComponentBase :
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnOut[portNum]
     void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
 #if FW_PORT_SERIALIZATION
@@ -680,7 +680,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -692,7 +692,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -704,7 +704,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -716,7 +716,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -728,7 +728,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -740,7 +740,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -752,7 +752,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -764,7 +764,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -809,7 +809,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -821,7 +821,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -833,7 +833,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -845,7 +845,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -857,7 +857,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -869,7 +869,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -881,7 +881,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -893,7 +893,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -920,7 +920,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -932,7 +932,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -944,7 +944,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -956,7 +956,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -974,7 +974,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -986,7 +986,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1459,7 +1459,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1472,7 +1472,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1485,7 +1485,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1498,7 +1498,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1511,7 +1511,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1524,7 +1524,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1537,7 +1537,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1550,7 +1550,7 @@ class QueuedCommandsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1587,28 +1587,28 @@ class QueuedCommandsComponentBase :
     Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedAsync
-    InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];
 
     //! Input port typedAsyncAssert
-    InputTypedPort m_typedAsyncAssert_InputPort[NUM_TYPEDASYNCASSERT_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncAssert_InputPort[NUM_TYPEDASYNCASSERT_INPUT_PORTS];
 
     //! Input port typedAsyncBlockPriority
-    InputTypedPort m_typedAsyncBlockPriority_InputPort[NUM_TYPEDASYNCBLOCKPRIORITY_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncBlockPriority_InputPort[NUM_TYPEDASYNCBLOCKPRIORITY_INPUT_PORTS];
 
     //! Input port typedAsyncDropPriority
-    InputTypedPort m_typedAsyncDropPriority_InputPort[NUM_TYPEDASYNCDROPPRIORITY_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncDropPriority_InputPort[NUM_TYPEDASYNCDROPPRIORITY_INPUT_PORTS];
 
     //! Input port typedGuarded
-    InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
+    Ports::InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnGuarded
-    InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnSync
-    InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
 
     //! Input port typedSync
-    InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
 
   PRIVATE:
 
@@ -1651,10 +1651,10 @@ class QueuedCommandsComponentBase :
     // ----------------------------------------------------------------------
 
     //! Output port typedOut
-    OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
+    Ports::OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
 
     //! Output port typedReturnOut
-    OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
+    Ports::OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
 
   PRIVATE:
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedCommandsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedCommandsComponentAc.ref.hpp
@@ -148,35 +148,35 @@ class QueuedCommandsComponentBase :
     //! Get typed input port at index
     //!
     //! \return noArgsAsync[portNum]
-    InputNoArgsPort* get_noArgsAsync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsAsync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsGuarded[portNum]
-    InputNoArgsPort* get_noArgsGuarded_InputPort(
+    Ports::InputNoArgsPort* get_noArgsGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnGuarded[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnSync[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsSync[portNum]
-    InputNoArgsPort* get_noArgsSync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -1572,19 +1572,19 @@ class QueuedCommandsComponentBase :
     // ----------------------------------------------------------------------
 
     //! Input port noArgsAsync
-    InputNoArgsPort m_noArgsAsync_InputPort[NUM_NOARGSASYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsAsync_InputPort[NUM_NOARGSASYNC_INPUT_PORTS];
 
     //! Input port noArgsGuarded
-    InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnGuarded
-    InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnSync
-    InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
 
     //! Input port noArgsSync
-    InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedAsync
     InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedCommandsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedCommandsTesterBase.ref.cpp
@@ -465,7 +465,7 @@ void QueuedCommandsTesterBase ::
 void QueuedCommandsTesterBase ::
   connect_to_noArgsAsync(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsPort* port
+      Ports::InputNoArgsPort* port
   )
 {
   FW_ASSERT(
@@ -479,7 +479,7 @@ void QueuedCommandsTesterBase ::
 void QueuedCommandsTesterBase ::
   connect_to_noArgsGuarded(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsPort* port
+      Ports::InputNoArgsPort* port
   )
 {
   FW_ASSERT(
@@ -493,7 +493,7 @@ void QueuedCommandsTesterBase ::
 void QueuedCommandsTesterBase ::
   connect_to_noArgsReturnGuarded(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsReturnPort* port
+      Ports::InputNoArgsReturnPort* port
   )
 {
   FW_ASSERT(
@@ -507,7 +507,7 @@ void QueuedCommandsTesterBase ::
 void QueuedCommandsTesterBase ::
   connect_to_noArgsReturnSync(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsReturnPort* port
+      Ports::InputNoArgsReturnPort* port
   )
 {
   FW_ASSERT(
@@ -521,7 +521,7 @@ void QueuedCommandsTesterBase ::
 void QueuedCommandsTesterBase ::
   connect_to_noArgsSync(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsPort* port
+      Ports::InputNoArgsPort* port
   )
 {
   FW_ASSERT(

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedCommandsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedCommandsTesterBase.ref.cpp
@@ -535,7 +535,7 @@ void QueuedCommandsTesterBase ::
 void QueuedCommandsTesterBase ::
   connect_to_typedAsync(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -549,7 +549,7 @@ void QueuedCommandsTesterBase ::
 void QueuedCommandsTesterBase ::
   connect_to_typedAsyncAssert(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -563,7 +563,7 @@ void QueuedCommandsTesterBase ::
 void QueuedCommandsTesterBase ::
   connect_to_typedAsyncBlockPriority(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -577,7 +577,7 @@ void QueuedCommandsTesterBase ::
 void QueuedCommandsTesterBase ::
   connect_to_typedAsyncDropPriority(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -591,7 +591,7 @@ void QueuedCommandsTesterBase ::
 void QueuedCommandsTesterBase ::
   connect_to_typedGuarded(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -605,7 +605,7 @@ void QueuedCommandsTesterBase ::
 void QueuedCommandsTesterBase ::
   connect_to_typedReturnGuarded(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -619,7 +619,7 @@ void QueuedCommandsTesterBase ::
 void QueuedCommandsTesterBase ::
   connect_to_typedReturnSync(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -633,7 +633,7 @@ void QueuedCommandsTesterBase ::
 void QueuedCommandsTesterBase ::
   connect_to_typedSync(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -740,7 +740,7 @@ Fw::InputTlmPort* QueuedCommandsTesterBase ::
   return &this->m_from_tlmOut[portNum];
 }
 
-InputTypedPort* QueuedCommandsTesterBase ::
+Ports::InputTypedPort* QueuedCommandsTesterBase ::
   get_from_typedOut(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -751,7 +751,7 @@ InputTypedPort* QueuedCommandsTesterBase ::
   return &this->m_from_typedOut[portNum];
 }
 
-InputTypedReturnPort* QueuedCommandsTesterBase ::
+Ports::InputTypedReturnPort* QueuedCommandsTesterBase ::
   get_from_typedReturnOut(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -805,7 +805,7 @@ void QueuedCommandsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -834,7 +834,7 @@ F32 QueuedCommandsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -922,7 +922,7 @@ void QueuedCommandsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -950,7 +950,7 @@ void QueuedCommandsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -978,7 +978,7 @@ void QueuedCommandsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1006,7 +1006,7 @@ void QueuedCommandsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1034,7 +1034,7 @@ void QueuedCommandsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1062,7 +1062,7 @@ F32 QueuedCommandsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1090,7 +1090,7 @@ F32 QueuedCommandsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1118,7 +1118,7 @@ void QueuedCommandsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2095,7 +2095,7 @@ void QueuedCommandsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2119,7 +2119,7 @@ void QueuedCommandsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2183,7 +2183,7 @@ void QueuedCommandsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2210,7 +2210,7 @@ F32 QueuedCommandsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedCommandsTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedCommandsTesterBase.ref.hpp
@@ -161,31 +161,31 @@ class QueuedCommandsTesterBase :
     //! Connect port to noArgsAsync[portNum]
     void connect_to_noArgsAsync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsPort* port //!< The input port
+        Ports::InputNoArgsPort* port //!< The input port
     );
 
     //! Connect port to noArgsGuarded[portNum]
     void connect_to_noArgsGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsPort* port //!< The input port
+        Ports::InputNoArgsPort* port //!< The input port
     );
 
     //! Connect port to noArgsReturnGuarded[portNum]
     void connect_to_noArgsReturnGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsReturnPort* port //!< The input port
+        Ports::InputNoArgsReturnPort* port //!< The input port
     );
 
     //! Connect port to noArgsReturnSync[portNum]
     void connect_to_noArgsReturnSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsReturnPort* port //!< The input port
+        Ports::InputNoArgsReturnPort* port //!< The input port
     );
 
     //! Connect port to noArgsSync[portNum]
     void connect_to_noArgsSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsPort* port //!< The input port
+        Ports::InputNoArgsPort* port //!< The input port
     );
 
     //! Connect port to typedAsync[portNum]
@@ -1020,19 +1020,19 @@ class QueuedCommandsTesterBase :
     Fw::OutputCmdPort m_to_cmdIn[1];
 
     //! To port connected to noArgsAsync
-    OutputNoArgsPort m_to_noArgsAsync[1];
+    Ports::OutputNoArgsPort m_to_noArgsAsync[1];
 
     //! To port connected to noArgsGuarded
-    OutputNoArgsPort m_to_noArgsGuarded[1];
+    Ports::OutputNoArgsPort m_to_noArgsGuarded[1];
 
     //! To port connected to noArgsReturnGuarded
-    OutputNoArgsReturnPort m_to_noArgsReturnGuarded[1];
+    Ports::OutputNoArgsReturnPort m_to_noArgsReturnGuarded[1];
 
     //! To port connected to noArgsReturnSync
-    OutputNoArgsReturnPort m_to_noArgsReturnSync[3];
+    Ports::OutputNoArgsReturnPort m_to_noArgsReturnSync[3];
 
     //! To port connected to noArgsSync
-    OutputNoArgsPort m_to_noArgsSync[3];
+    Ports::OutputNoArgsPort m_to_noArgsSync[3];
 
     //! To port connected to typedAsync
     OutputTypedPort m_to_typedAsync[1];

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedCommandsTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedCommandsTesterBase.ref.hpp
@@ -111,7 +111,7 @@ class QueuedCommandsTesterBase :
       U32 u32;
       F32 f32;
       bool b;
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       E e;
       A a;
       S s;
@@ -122,7 +122,7 @@ class QueuedCommandsTesterBase :
       U32 u32;
       F32 f32;
       bool b;
-      TypedReturnPortStrings::StringSize80 str2;
+      Ports::TypedReturnPortStrings::StringSize80 str2;
       E e;
       A a;
       S s;
@@ -191,49 +191,49 @@ class QueuedCommandsTesterBase :
     //! Connect port to typedAsync[portNum]
     void connect_to_typedAsync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedAsyncAssert[portNum]
     void connect_to_typedAsyncAssert(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedAsyncBlockPriority[portNum]
     void connect_to_typedAsyncBlockPriority(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedAsyncDropPriority[portNum]
     void connect_to_typedAsyncDropPriority(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedGuarded[portNum]
     void connect_to_typedGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnGuarded[portNum]
     void connect_to_typedReturnGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
     //! Connect port to typedReturnSync[portNum]
     void connect_to_typedReturnSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
     //! Connect port to typedSync[portNum]
     void connect_to_typedSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
   public:
@@ -305,14 +305,14 @@ class QueuedCommandsTesterBase :
     //! Get from port at index
     //!
     //! \return from_typedOut[portNum]
-    InputTypedPort* get_from_typedOut(
+    Ports::InputTypedPort* get_from_typedOut(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get from port at index
     //!
     //! \return from_typedReturnOut[portNum]
-    InputTypedReturnPort* get_from_typedReturnOut(
+    Ports::InputTypedReturnPort* get_from_typedReturnOut(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -343,7 +343,7 @@ class QueuedCommandsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -355,7 +355,7 @@ class QueuedCommandsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -373,7 +373,7 @@ class QueuedCommandsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -385,7 +385,7 @@ class QueuedCommandsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -428,7 +428,7 @@ class QueuedCommandsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -440,7 +440,7 @@ class QueuedCommandsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -452,7 +452,7 @@ class QueuedCommandsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -464,7 +464,7 @@ class QueuedCommandsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -476,7 +476,7 @@ class QueuedCommandsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -488,7 +488,7 @@ class QueuedCommandsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -500,7 +500,7 @@ class QueuedCommandsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -512,7 +512,7 @@ class QueuedCommandsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -920,7 +920,7 @@ class QueuedCommandsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -931,7 +931,7 @@ class QueuedCommandsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -973,7 +973,7 @@ class QueuedCommandsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -986,7 +986,7 @@ class QueuedCommandsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1035,28 +1035,28 @@ class QueuedCommandsTesterBase :
     Ports::OutputNoArgsPort m_to_noArgsSync[3];
 
     //! To port connected to typedAsync
-    OutputTypedPort m_to_typedAsync[1];
+    Ports::OutputTypedPort m_to_typedAsync[1];
 
     //! To port connected to typedAsyncAssert
-    OutputTypedPort m_to_typedAsyncAssert[1];
+    Ports::OutputTypedPort m_to_typedAsyncAssert[1];
 
     //! To port connected to typedAsyncBlockPriority
-    OutputTypedPort m_to_typedAsyncBlockPriority[1];
+    Ports::OutputTypedPort m_to_typedAsyncBlockPriority[1];
 
     //! To port connected to typedAsyncDropPriority
-    OutputTypedPort m_to_typedAsyncDropPriority[1];
+    Ports::OutputTypedPort m_to_typedAsyncDropPriority[1];
 
     //! To port connected to typedGuarded
-    OutputTypedPort m_to_typedGuarded[1];
+    Ports::OutputTypedPort m_to_typedGuarded[1];
 
     //! To port connected to typedReturnGuarded
-    OutputTypedReturnPort m_to_typedReturnGuarded[1];
+    Ports::OutputTypedReturnPort m_to_typedReturnGuarded[1];
 
     //! To port connected to typedReturnSync
-    OutputTypedReturnPort m_to_typedReturnSync[3];
+    Ports::OutputTypedReturnPort m_to_typedReturnSync[3];
 
     //! To port connected to typedSync
-    OutputTypedPort m_to_typedSync[3];
+    Ports::OutputTypedPort m_to_typedSync[3];
 
   private:
 
@@ -1093,10 +1093,10 @@ class QueuedCommandsTesterBase :
     Fw::InputTlmPort m_from_tlmOut[1];
 
     //! From port connected to typedOut
-    InputTypedPort m_from_typedOut[1];
+    Ports::InputTypedPort m_from_typedOut[1];
 
     //! From port connected to typedReturnOut
-    InputTypedReturnPort m_from_typedReturnOut[1];
+    Ports::InputTypedReturnPort m_from_typedReturnOut[1];
 
   private:
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedEventsComponentAc.ref.cpp
@@ -24,11 +24,11 @@ namespace {
 
   // Get the max size by doing a union of the input and internal port serialization sizes
   union BuffUnion {
-    BYTE noArgsAsyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsGuardedPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnGuardedPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnSyncPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsSyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsAsyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsGuardedPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
     BYTE typedAsyncPortSize[InputTypedPort::SERIALIZED_SIZE];
     BYTE typedAsyncAssertPortSize[InputTypedPort::SERIALIZED_SIZE];
     BYTE typedAsyncBlockPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
@@ -693,7 +693,7 @@ Fw::InputCmdPort* QueuedEventsComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-InputNoArgsPort* QueuedEventsComponentBase ::
+Ports::InputNoArgsPort* QueuedEventsComponentBase ::
   get_noArgsAsync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -704,7 +704,7 @@ InputNoArgsPort* QueuedEventsComponentBase ::
   return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-InputNoArgsPort* QueuedEventsComponentBase ::
+Ports::InputNoArgsPort* QueuedEventsComponentBase ::
   get_noArgsGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -715,7 +715,7 @@ InputNoArgsPort* QueuedEventsComponentBase ::
   return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* QueuedEventsComponentBase ::
+Ports::InputNoArgsReturnPort* QueuedEventsComponentBase ::
   get_noArgsReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -726,7 +726,7 @@ InputNoArgsReturnPort* QueuedEventsComponentBase ::
   return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* QueuedEventsComponentBase ::
+Ports::InputNoArgsReturnPort* QueuedEventsComponentBase ::
   get_noArgsReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -737,7 +737,7 @@ InputNoArgsReturnPort* QueuedEventsComponentBase ::
   return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-InputNoArgsPort* QueuedEventsComponentBase ::
+Ports::InputNoArgsPort* QueuedEventsComponentBase ::
   get_noArgsSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedEventsComponentAc.ref.cpp
@@ -29,14 +29,14 @@ namespace {
     BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
     BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
     BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE typedAsyncPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncAssertPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncBlockPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncDropPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedGuardedPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedReturnGuardedPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedReturnSyncPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedSyncPortSize[InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncAssertPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncBlockPriorityPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncDropPriorityPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedGuardedPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedReturnGuardedPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedReturnSyncPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedSyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
     BYTE cmdPortSize[Fw::InputCmdPort::SERIALIZED_SIZE];
   };
 
@@ -748,7 +748,7 @@ Ports::InputNoArgsPort* QueuedEventsComponentBase ::
   return &this->m_noArgsSync_InputPort[portNum];
 }
 
-InputTypedPort* QueuedEventsComponentBase ::
+Ports::InputTypedPort* QueuedEventsComponentBase ::
   get_typedAsync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -759,7 +759,7 @@ InputTypedPort* QueuedEventsComponentBase ::
   return &this->m_typedAsync_InputPort[portNum];
 }
 
-InputTypedPort* QueuedEventsComponentBase ::
+Ports::InputTypedPort* QueuedEventsComponentBase ::
   get_typedAsyncAssert_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -770,7 +770,7 @@ InputTypedPort* QueuedEventsComponentBase ::
   return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-InputTypedPort* QueuedEventsComponentBase ::
+Ports::InputTypedPort* QueuedEventsComponentBase ::
   get_typedAsyncBlockPriority_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -781,7 +781,7 @@ InputTypedPort* QueuedEventsComponentBase ::
   return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-InputTypedPort* QueuedEventsComponentBase ::
+Ports::InputTypedPort* QueuedEventsComponentBase ::
   get_typedAsyncDropPriority_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -792,7 +792,7 @@ InputTypedPort* QueuedEventsComponentBase ::
   return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-InputTypedPort* QueuedEventsComponentBase ::
+Ports::InputTypedPort* QueuedEventsComponentBase ::
   get_typedGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -803,7 +803,7 @@ InputTypedPort* QueuedEventsComponentBase ::
   return &this->m_typedGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* QueuedEventsComponentBase ::
+Ports::InputTypedReturnPort* QueuedEventsComponentBase ::
   get_typedReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -814,7 +814,7 @@ InputTypedReturnPort* QueuedEventsComponentBase ::
   return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* QueuedEventsComponentBase ::
+Ports::InputTypedReturnPort* QueuedEventsComponentBase ::
   get_typedReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -825,7 +825,7 @@ InputTypedReturnPort* QueuedEventsComponentBase ::
   return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-InputTypedPort* QueuedEventsComponentBase ::
+Ports::InputTypedPort* QueuedEventsComponentBase ::
   get_typedSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -963,7 +963,7 @@ void QueuedEventsComponentBase ::
 void QueuedEventsComponentBase ::
   set_typedOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -977,7 +977,7 @@ void QueuedEventsComponentBase ::
 void QueuedEventsComponentBase ::
   set_typedReturnOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -1549,7 +1549,7 @@ void QueuedEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1656,7 +1656,7 @@ void QueuedEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1763,7 +1763,7 @@ void QueuedEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1870,7 +1870,7 @@ void QueuedEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1982,7 +1982,7 @@ void QueuedEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2019,7 +2019,7 @@ F32 QueuedEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2060,7 +2060,7 @@ F32 QueuedEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2095,7 +2095,7 @@ void QueuedEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2140,7 +2140,7 @@ void QueuedEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2155,7 +2155,7 @@ void QueuedEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2170,7 +2170,7 @@ void QueuedEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2185,7 +2185,7 @@ void QueuedEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2204,7 +2204,7 @@ void QueuedEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2231,7 +2231,7 @@ F32 QueuedEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -3067,7 +3067,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -3139,7 +3139,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -3211,7 +3211,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -3283,7 +3283,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedEventsComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -3420,7 +3420,7 @@ void QueuedEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3447,7 +3447,7 @@ void QueuedEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3474,7 +3474,7 @@ void QueuedEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3501,7 +3501,7 @@ void QueuedEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3528,7 +3528,7 @@ void QueuedEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3555,7 +3555,7 @@ F32 QueuedEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -3582,7 +3582,7 @@ F32 QueuedEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -3609,7 +3609,7 @@ void QueuedEventsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedEventsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedEventsComponentAc.ref.hpp
@@ -145,35 +145,35 @@ class QueuedEventsComponentBase :
     //! Get typed input port at index
     //!
     //! \return noArgsAsync[portNum]
-    InputNoArgsPort* get_noArgsAsync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsAsync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsGuarded[portNum]
-    InputNoArgsPort* get_noArgsGuarded_InputPort(
+    Ports::InputNoArgsPort* get_noArgsGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnGuarded[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnSync[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsSync[portNum]
-    InputNoArgsPort* get_noArgsSync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -1253,19 +1253,19 @@ class QueuedEventsComponentBase :
     // ----------------------------------------------------------------------
 
     //! Input port noArgsAsync
-    InputNoArgsPort m_noArgsAsync_InputPort[NUM_NOARGSASYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsAsync_InputPort[NUM_NOARGSASYNC_INPUT_PORTS];
 
     //! Input port noArgsGuarded
-    InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnGuarded
-    InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnSync
-    InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
 
     //! Input port noArgsSync
-    InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedAsync
     InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedEventsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedEventsComponentAc.ref.hpp
@@ -180,56 +180,56 @@ class QueuedEventsComponentBase :
     //! Get typed input port at index
     //!
     //! \return typedAsync[portNum]
-    InputTypedPort* get_typedAsync_InputPort(
+    Ports::InputTypedPort* get_typedAsync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncAssert[portNum]
-    InputTypedPort* get_typedAsyncAssert_InputPort(
+    Ports::InputTypedPort* get_typedAsyncAssert_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncBlockPriority[portNum]
-    InputTypedPort* get_typedAsyncBlockPriority_InputPort(
+    Ports::InputTypedPort* get_typedAsyncBlockPriority_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncDropPriority[portNum]
-    InputTypedPort* get_typedAsyncDropPriority_InputPort(
+    Ports::InputTypedPort* get_typedAsyncDropPriority_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedGuarded[portNum]
-    InputTypedPort* get_typedGuarded_InputPort(
+    Ports::InputTypedPort* get_typedGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnGuarded[portNum]
-    InputTypedReturnPort* get_typedReturnGuarded_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnSync[portNum]
-    InputTypedReturnPort* get_typedReturnSync_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedSync[portNum]
-    InputTypedPort* get_typedSync_InputPort(
+    Ports::InputTypedPort* get_typedSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -300,13 +300,13 @@ class QueuedEventsComponentBase :
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnOut[portNum]
     void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
 #if FW_PORT_SERIALIZATION
@@ -666,7 +666,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -678,7 +678,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -690,7 +690,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -702,7 +702,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -714,7 +714,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -726,7 +726,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -738,7 +738,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -750,7 +750,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -795,7 +795,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -807,7 +807,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -819,7 +819,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -831,7 +831,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -843,7 +843,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -855,7 +855,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -867,7 +867,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -879,7 +879,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -906,7 +906,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -918,7 +918,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -930,7 +930,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -942,7 +942,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -960,7 +960,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -972,7 +972,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1140,7 +1140,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1153,7 +1153,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1166,7 +1166,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1179,7 +1179,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1192,7 +1192,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1205,7 +1205,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1218,7 +1218,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1231,7 +1231,7 @@ class QueuedEventsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1268,28 +1268,28 @@ class QueuedEventsComponentBase :
     Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedAsync
-    InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];
 
     //! Input port typedAsyncAssert
-    InputTypedPort m_typedAsyncAssert_InputPort[NUM_TYPEDASYNCASSERT_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncAssert_InputPort[NUM_TYPEDASYNCASSERT_INPUT_PORTS];
 
     //! Input port typedAsyncBlockPriority
-    InputTypedPort m_typedAsyncBlockPriority_InputPort[NUM_TYPEDASYNCBLOCKPRIORITY_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncBlockPriority_InputPort[NUM_TYPEDASYNCBLOCKPRIORITY_INPUT_PORTS];
 
     //! Input port typedAsyncDropPriority
-    InputTypedPort m_typedAsyncDropPriority_InputPort[NUM_TYPEDASYNCDROPPRIORITY_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncDropPriority_InputPort[NUM_TYPEDASYNCDROPPRIORITY_INPUT_PORTS];
 
     //! Input port typedGuarded
-    InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
+    Ports::InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnGuarded
-    InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnSync
-    InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
 
     //! Input port typedSync
-    InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
 
   PRIVATE:
 
@@ -1332,10 +1332,10 @@ class QueuedEventsComponentBase :
     // ----------------------------------------------------------------------
 
     //! Output port typedOut
-    OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
+    Ports::OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
 
     //! Output port typedReturnOut
-    OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
+    Ports::OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
 
   PRIVATE:
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedEventsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedEventsTesterBase.ref.cpp
@@ -446,7 +446,7 @@ void QueuedEventsTesterBase ::
 void QueuedEventsTesterBase ::
   connect_to_noArgsAsync(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsPort* port
+      Ports::InputNoArgsPort* port
   )
 {
   FW_ASSERT(
@@ -460,7 +460,7 @@ void QueuedEventsTesterBase ::
 void QueuedEventsTesterBase ::
   connect_to_noArgsGuarded(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsPort* port
+      Ports::InputNoArgsPort* port
   )
 {
   FW_ASSERT(
@@ -474,7 +474,7 @@ void QueuedEventsTesterBase ::
 void QueuedEventsTesterBase ::
   connect_to_noArgsReturnGuarded(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsReturnPort* port
+      Ports::InputNoArgsReturnPort* port
   )
 {
   FW_ASSERT(
@@ -488,7 +488,7 @@ void QueuedEventsTesterBase ::
 void QueuedEventsTesterBase ::
   connect_to_noArgsReturnSync(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsReturnPort* port
+      Ports::InputNoArgsReturnPort* port
   )
 {
   FW_ASSERT(
@@ -502,7 +502,7 @@ void QueuedEventsTesterBase ::
 void QueuedEventsTesterBase ::
   connect_to_noArgsSync(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsPort* port
+      Ports::InputNoArgsPort* port
   )
 {
   FW_ASSERT(

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedEventsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedEventsTesterBase.ref.cpp
@@ -516,7 +516,7 @@ void QueuedEventsTesterBase ::
 void QueuedEventsTesterBase ::
   connect_to_typedAsync(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -530,7 +530,7 @@ void QueuedEventsTesterBase ::
 void QueuedEventsTesterBase ::
   connect_to_typedAsyncAssert(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -544,7 +544,7 @@ void QueuedEventsTesterBase ::
 void QueuedEventsTesterBase ::
   connect_to_typedAsyncBlockPriority(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -558,7 +558,7 @@ void QueuedEventsTesterBase ::
 void QueuedEventsTesterBase ::
   connect_to_typedAsyncDropPriority(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -572,7 +572,7 @@ void QueuedEventsTesterBase ::
 void QueuedEventsTesterBase ::
   connect_to_typedGuarded(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -586,7 +586,7 @@ void QueuedEventsTesterBase ::
 void QueuedEventsTesterBase ::
   connect_to_typedReturnGuarded(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -600,7 +600,7 @@ void QueuedEventsTesterBase ::
 void QueuedEventsTesterBase ::
   connect_to_typedReturnSync(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -614,7 +614,7 @@ void QueuedEventsTesterBase ::
 void QueuedEventsTesterBase ::
   connect_to_typedSync(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -721,7 +721,7 @@ Fw::InputTlmPort* QueuedEventsTesterBase ::
   return &this->m_from_tlmOut[portNum];
 }
 
-InputTypedPort* QueuedEventsTesterBase ::
+Ports::InputTypedPort* QueuedEventsTesterBase ::
   get_from_typedOut(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -732,7 +732,7 @@ InputTypedPort* QueuedEventsTesterBase ::
   return &this->m_from_typedOut[portNum];
 }
 
-InputTypedReturnPort* QueuedEventsTesterBase ::
+Ports::InputTypedReturnPort* QueuedEventsTesterBase ::
   get_from_typedReturnOut(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -800,7 +800,7 @@ void QueuedEventsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -829,7 +829,7 @@ F32 QueuedEventsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -917,7 +917,7 @@ void QueuedEventsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -945,7 +945,7 @@ void QueuedEventsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -973,7 +973,7 @@ void QueuedEventsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1001,7 +1001,7 @@ void QueuedEventsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1029,7 +1029,7 @@ void QueuedEventsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1057,7 +1057,7 @@ F32 QueuedEventsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1085,7 +1085,7 @@ F32 QueuedEventsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1113,7 +1113,7 @@ void QueuedEventsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1886,7 +1886,7 @@ void QueuedEventsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1910,7 +1910,7 @@ void QueuedEventsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2058,7 +2058,7 @@ void QueuedEventsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2085,7 +2085,7 @@ F32 QueuedEventsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedEventsTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedEventsTesterBase.ref.hpp
@@ -111,7 +111,7 @@ class QueuedEventsTesterBase :
       U32 u32;
       F32 f32;
       bool b;
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       E e;
       A a;
       S s;
@@ -122,7 +122,7 @@ class QueuedEventsTesterBase :
       U32 u32;
       F32 f32;
       bool b;
-      TypedReturnPortStrings::StringSize80 str2;
+      Ports::TypedReturnPortStrings::StringSize80 str2;
       E e;
       A a;
       S s;
@@ -224,49 +224,49 @@ class QueuedEventsTesterBase :
     //! Connect port to typedAsync[portNum]
     void connect_to_typedAsync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedAsyncAssert[portNum]
     void connect_to_typedAsyncAssert(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedAsyncBlockPriority[portNum]
     void connect_to_typedAsyncBlockPriority(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedAsyncDropPriority[portNum]
     void connect_to_typedAsyncDropPriority(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedGuarded[portNum]
     void connect_to_typedGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnGuarded[portNum]
     void connect_to_typedReturnGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
     //! Connect port to typedReturnSync[portNum]
     void connect_to_typedReturnSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
     //! Connect port to typedSync[portNum]
     void connect_to_typedSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
   public:
@@ -338,14 +338,14 @@ class QueuedEventsTesterBase :
     //! Get from port at index
     //!
     //! \return from_typedOut[portNum]
-    InputTypedPort* get_from_typedOut(
+    Ports::InputTypedPort* get_from_typedOut(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get from port at index
     //!
     //! \return from_typedReturnOut[portNum]
-    InputTypedReturnPort* get_from_typedReturnOut(
+    Ports::InputTypedReturnPort* get_from_typedReturnOut(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -376,7 +376,7 @@ class QueuedEventsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -388,7 +388,7 @@ class QueuedEventsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -406,7 +406,7 @@ class QueuedEventsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -418,7 +418,7 @@ class QueuedEventsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -461,7 +461,7 @@ class QueuedEventsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -473,7 +473,7 @@ class QueuedEventsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -485,7 +485,7 @@ class QueuedEventsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -497,7 +497,7 @@ class QueuedEventsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -509,7 +509,7 @@ class QueuedEventsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -521,7 +521,7 @@ class QueuedEventsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -533,7 +533,7 @@ class QueuedEventsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -545,7 +545,7 @@ class QueuedEventsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -873,7 +873,7 @@ class QueuedEventsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -884,7 +884,7 @@ class QueuedEventsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -950,7 +950,7 @@ class QueuedEventsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -963,7 +963,7 @@ class QueuedEventsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1040,28 +1040,28 @@ class QueuedEventsTesterBase :
     Ports::OutputNoArgsPort m_to_noArgsSync[3];
 
     //! To port connected to typedAsync
-    OutputTypedPort m_to_typedAsync[1];
+    Ports::OutputTypedPort m_to_typedAsync[1];
 
     //! To port connected to typedAsyncAssert
-    OutputTypedPort m_to_typedAsyncAssert[1];
+    Ports::OutputTypedPort m_to_typedAsyncAssert[1];
 
     //! To port connected to typedAsyncBlockPriority
-    OutputTypedPort m_to_typedAsyncBlockPriority[1];
+    Ports::OutputTypedPort m_to_typedAsyncBlockPriority[1];
 
     //! To port connected to typedAsyncDropPriority
-    OutputTypedPort m_to_typedAsyncDropPriority[1];
+    Ports::OutputTypedPort m_to_typedAsyncDropPriority[1];
 
     //! To port connected to typedGuarded
-    OutputTypedPort m_to_typedGuarded[1];
+    Ports::OutputTypedPort m_to_typedGuarded[1];
 
     //! To port connected to typedReturnGuarded
-    OutputTypedReturnPort m_to_typedReturnGuarded[1];
+    Ports::OutputTypedReturnPort m_to_typedReturnGuarded[1];
 
     //! To port connected to typedReturnSync
-    OutputTypedReturnPort m_to_typedReturnSync[3];
+    Ports::OutputTypedReturnPort m_to_typedReturnSync[3];
 
     //! To port connected to typedSync
-    OutputTypedPort m_to_typedSync[3];
+    Ports::OutputTypedPort m_to_typedSync[3];
 
   private:
 
@@ -1098,10 +1098,10 @@ class QueuedEventsTesterBase :
     Fw::InputTlmPort m_from_tlmOut[1];
 
     //! From port connected to typedOut
-    InputTypedPort m_from_typedOut[1];
+    Ports::InputTypedPort m_from_typedOut[1];
 
     //! From port connected to typedReturnOut
-    InputTypedReturnPort m_from_typedReturnOut[1];
+    Ports::InputTypedReturnPort m_from_typedReturnOut[1];
 
   private:
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedEventsTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedEventsTesterBase.ref.hpp
@@ -194,31 +194,31 @@ class QueuedEventsTesterBase :
     //! Connect port to noArgsAsync[portNum]
     void connect_to_noArgsAsync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsPort* port //!< The input port
+        Ports::InputNoArgsPort* port //!< The input port
     );
 
     //! Connect port to noArgsGuarded[portNum]
     void connect_to_noArgsGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsPort* port //!< The input port
+        Ports::InputNoArgsPort* port //!< The input port
     );
 
     //! Connect port to noArgsReturnGuarded[portNum]
     void connect_to_noArgsReturnGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsReturnPort* port //!< The input port
+        Ports::InputNoArgsReturnPort* port //!< The input port
     );
 
     //! Connect port to noArgsReturnSync[portNum]
     void connect_to_noArgsReturnSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsReturnPort* port //!< The input port
+        Ports::InputNoArgsReturnPort* port //!< The input port
     );
 
     //! Connect port to noArgsSync[portNum]
     void connect_to_noArgsSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsPort* port //!< The input port
+        Ports::InputNoArgsPort* port //!< The input port
     );
 
     //! Connect port to typedAsync[portNum]
@@ -1025,19 +1025,19 @@ class QueuedEventsTesterBase :
     Fw::OutputCmdPort m_to_cmdIn[1];
 
     //! To port connected to noArgsAsync
-    OutputNoArgsPort m_to_noArgsAsync[1];
+    Ports::OutputNoArgsPort m_to_noArgsAsync[1];
 
     //! To port connected to noArgsGuarded
-    OutputNoArgsPort m_to_noArgsGuarded[1];
+    Ports::OutputNoArgsPort m_to_noArgsGuarded[1];
 
     //! To port connected to noArgsReturnGuarded
-    OutputNoArgsReturnPort m_to_noArgsReturnGuarded[1];
+    Ports::OutputNoArgsReturnPort m_to_noArgsReturnGuarded[1];
 
     //! To port connected to noArgsReturnSync
-    OutputNoArgsReturnPort m_to_noArgsReturnSync[3];
+    Ports::OutputNoArgsReturnPort m_to_noArgsReturnSync[3];
 
     //! To port connected to noArgsSync
-    OutputNoArgsPort m_to_noArgsSync[3];
+    Ports::OutputNoArgsPort m_to_noArgsSync[3];
 
     //! To port connected to typedAsync
     OutputTypedPort m_to_typedAsync[1];

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedParamsComponentAc.ref.cpp
@@ -24,11 +24,11 @@ namespace {
 
   // Get the max size by doing a union of the input and internal port serialization sizes
   union BuffUnion {
-    BYTE noArgsAsyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsGuardedPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnGuardedPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnSyncPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsSyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsAsyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsGuardedPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
     BYTE typedAsyncPortSize[InputTypedPort::SERIALIZED_SIZE];
     BYTE typedAsyncAssertPortSize[InputTypedPort::SERIALIZED_SIZE];
     BYTE typedAsyncBlockPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
@@ -693,7 +693,7 @@ Fw::InputCmdPort* QueuedParamsComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-InputNoArgsPort* QueuedParamsComponentBase ::
+Ports::InputNoArgsPort* QueuedParamsComponentBase ::
   get_noArgsAsync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -704,7 +704,7 @@ InputNoArgsPort* QueuedParamsComponentBase ::
   return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-InputNoArgsPort* QueuedParamsComponentBase ::
+Ports::InputNoArgsPort* QueuedParamsComponentBase ::
   get_noArgsGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -715,7 +715,7 @@ InputNoArgsPort* QueuedParamsComponentBase ::
   return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* QueuedParamsComponentBase ::
+Ports::InputNoArgsReturnPort* QueuedParamsComponentBase ::
   get_noArgsReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -726,7 +726,7 @@ InputNoArgsReturnPort* QueuedParamsComponentBase ::
   return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* QueuedParamsComponentBase ::
+Ports::InputNoArgsReturnPort* QueuedParamsComponentBase ::
   get_noArgsReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -737,7 +737,7 @@ InputNoArgsReturnPort* QueuedParamsComponentBase ::
   return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-InputNoArgsPort* QueuedParamsComponentBase ::
+Ports::InputNoArgsPort* QueuedParamsComponentBase ::
   get_noArgsSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedParamsComponentAc.ref.cpp
@@ -29,14 +29,14 @@ namespace {
     BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
     BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
     BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE typedAsyncPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncAssertPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncBlockPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncDropPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedGuardedPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedReturnGuardedPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedReturnSyncPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedSyncPortSize[InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncAssertPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncBlockPriorityPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncDropPriorityPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedGuardedPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedReturnGuardedPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedReturnSyncPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedSyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
     BYTE cmdPortSize[Fw::InputCmdPort::SERIALIZED_SIZE];
   };
 
@@ -748,7 +748,7 @@ Ports::InputNoArgsPort* QueuedParamsComponentBase ::
   return &this->m_noArgsSync_InputPort[portNum];
 }
 
-InputTypedPort* QueuedParamsComponentBase ::
+Ports::InputTypedPort* QueuedParamsComponentBase ::
   get_typedAsync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -759,7 +759,7 @@ InputTypedPort* QueuedParamsComponentBase ::
   return &this->m_typedAsync_InputPort[portNum];
 }
 
-InputTypedPort* QueuedParamsComponentBase ::
+Ports::InputTypedPort* QueuedParamsComponentBase ::
   get_typedAsyncAssert_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -770,7 +770,7 @@ InputTypedPort* QueuedParamsComponentBase ::
   return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-InputTypedPort* QueuedParamsComponentBase ::
+Ports::InputTypedPort* QueuedParamsComponentBase ::
   get_typedAsyncBlockPriority_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -781,7 +781,7 @@ InputTypedPort* QueuedParamsComponentBase ::
   return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-InputTypedPort* QueuedParamsComponentBase ::
+Ports::InputTypedPort* QueuedParamsComponentBase ::
   get_typedAsyncDropPriority_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -792,7 +792,7 @@ InputTypedPort* QueuedParamsComponentBase ::
   return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-InputTypedPort* QueuedParamsComponentBase ::
+Ports::InputTypedPort* QueuedParamsComponentBase ::
   get_typedGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -803,7 +803,7 @@ InputTypedPort* QueuedParamsComponentBase ::
   return &this->m_typedGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* QueuedParamsComponentBase ::
+Ports::InputTypedReturnPort* QueuedParamsComponentBase ::
   get_typedReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -814,7 +814,7 @@ InputTypedReturnPort* QueuedParamsComponentBase ::
   return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* QueuedParamsComponentBase ::
+Ports::InputTypedReturnPort* QueuedParamsComponentBase ::
   get_typedReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -825,7 +825,7 @@ InputTypedReturnPort* QueuedParamsComponentBase ::
   return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-InputTypedPort* QueuedParamsComponentBase ::
+Ports::InputTypedPort* QueuedParamsComponentBase ::
   get_typedSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -963,7 +963,7 @@ void QueuedParamsComponentBase ::
 void QueuedParamsComponentBase ::
   set_typedOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -977,7 +977,7 @@ void QueuedParamsComponentBase ::
 void QueuedParamsComponentBase ::
   set_typedReturnOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -1785,7 +1785,7 @@ void QueuedParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1892,7 +1892,7 @@ void QueuedParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1999,7 +1999,7 @@ void QueuedParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2106,7 +2106,7 @@ void QueuedParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2218,7 +2218,7 @@ void QueuedParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2255,7 +2255,7 @@ F32 QueuedParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2296,7 +2296,7 @@ F32 QueuedParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2331,7 +2331,7 @@ void QueuedParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2376,7 +2376,7 @@ void QueuedParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2391,7 +2391,7 @@ void QueuedParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2406,7 +2406,7 @@ void QueuedParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2421,7 +2421,7 @@ void QueuedParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2440,7 +2440,7 @@ void QueuedParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2467,7 +2467,7 @@ F32 QueuedParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2709,7 +2709,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -2781,7 +2781,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -2853,7 +2853,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -2925,7 +2925,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedParamsComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -3186,7 +3186,7 @@ void QueuedParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3213,7 +3213,7 @@ void QueuedParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3240,7 +3240,7 @@ void QueuedParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3267,7 +3267,7 @@ void QueuedParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3294,7 +3294,7 @@ void QueuedParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3321,7 +3321,7 @@ F32 QueuedParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -3348,7 +3348,7 @@ F32 QueuedParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -3375,7 +3375,7 @@ void QueuedParamsComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedParamsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedParamsComponentAc.ref.hpp
@@ -190,56 +190,56 @@ class QueuedParamsComponentBase :
     //! Get typed input port at index
     //!
     //! \return typedAsync[portNum]
-    InputTypedPort* get_typedAsync_InputPort(
+    Ports::InputTypedPort* get_typedAsync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncAssert[portNum]
-    InputTypedPort* get_typedAsyncAssert_InputPort(
+    Ports::InputTypedPort* get_typedAsyncAssert_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncBlockPriority[portNum]
-    InputTypedPort* get_typedAsyncBlockPriority_InputPort(
+    Ports::InputTypedPort* get_typedAsyncBlockPriority_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncDropPriority[portNum]
-    InputTypedPort* get_typedAsyncDropPriority_InputPort(
+    Ports::InputTypedPort* get_typedAsyncDropPriority_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedGuarded[portNum]
-    InputTypedPort* get_typedGuarded_InputPort(
+    Ports::InputTypedPort* get_typedGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnGuarded[portNum]
-    InputTypedReturnPort* get_typedReturnGuarded_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnSync[portNum]
-    InputTypedReturnPort* get_typedReturnSync_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedSync[portNum]
-    InputTypedPort* get_typedSync_InputPort(
+    Ports::InputTypedPort* get_typedSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -310,13 +310,13 @@ class QueuedParamsComponentBase :
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnOut[portNum]
     void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
 #if FW_PORT_SERIALIZATION
@@ -698,7 +698,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -710,7 +710,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -722,7 +722,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -734,7 +734,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -746,7 +746,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -758,7 +758,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -770,7 +770,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -782,7 +782,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -827,7 +827,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -839,7 +839,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -851,7 +851,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -863,7 +863,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -875,7 +875,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -887,7 +887,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -899,7 +899,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -911,7 +911,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -938,7 +938,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -950,7 +950,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -962,7 +962,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -974,7 +974,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -992,7 +992,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1004,7 +1004,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1199,7 +1199,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1212,7 +1212,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1225,7 +1225,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1238,7 +1238,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1251,7 +1251,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1264,7 +1264,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1277,7 +1277,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1290,7 +1290,7 @@ class QueuedParamsComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1411,28 +1411,28 @@ class QueuedParamsComponentBase :
     Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedAsync
-    InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];
 
     //! Input port typedAsyncAssert
-    InputTypedPort m_typedAsyncAssert_InputPort[NUM_TYPEDASYNCASSERT_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncAssert_InputPort[NUM_TYPEDASYNCASSERT_INPUT_PORTS];
 
     //! Input port typedAsyncBlockPriority
-    InputTypedPort m_typedAsyncBlockPriority_InputPort[NUM_TYPEDASYNCBLOCKPRIORITY_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncBlockPriority_InputPort[NUM_TYPEDASYNCBLOCKPRIORITY_INPUT_PORTS];
 
     //! Input port typedAsyncDropPriority
-    InputTypedPort m_typedAsyncDropPriority_InputPort[NUM_TYPEDASYNCDROPPRIORITY_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncDropPriority_InputPort[NUM_TYPEDASYNCDROPPRIORITY_INPUT_PORTS];
 
     //! Input port typedGuarded
-    InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
+    Ports::InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnGuarded
-    InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnSync
-    InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
 
     //! Input port typedSync
-    InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
 
   PRIVATE:
 
@@ -1475,10 +1475,10 @@ class QueuedParamsComponentBase :
     // ----------------------------------------------------------------------
 
     //! Output port typedOut
-    OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
+    Ports::OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
 
     //! Output port typedReturnOut
-    OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
+    Ports::OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
 
   PRIVATE:
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedParamsComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedParamsComponentAc.ref.hpp
@@ -155,35 +155,35 @@ class QueuedParamsComponentBase :
     //! Get typed input port at index
     //!
     //! \return noArgsAsync[portNum]
-    InputNoArgsPort* get_noArgsAsync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsAsync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsGuarded[portNum]
-    InputNoArgsPort* get_noArgsGuarded_InputPort(
+    Ports::InputNoArgsPort* get_noArgsGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnGuarded[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnSync[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsSync[portNum]
-    InputNoArgsPort* get_noArgsSync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -1396,19 +1396,19 @@ class QueuedParamsComponentBase :
     // ----------------------------------------------------------------------
 
     //! Input port noArgsAsync
-    InputNoArgsPort m_noArgsAsync_InputPort[NUM_NOARGSASYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsAsync_InputPort[NUM_NOARGSASYNC_INPUT_PORTS];
 
     //! Input port noArgsGuarded
-    InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnGuarded
-    InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnSync
-    InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
 
     //! Input port noArgsSync
-    InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedAsync
     InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedParamsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedParamsTesterBase.ref.cpp
@@ -517,7 +517,7 @@ void QueuedParamsTesterBase ::
 void QueuedParamsTesterBase ::
   connect_to_noArgsAsync(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsPort* port
+      Ports::InputNoArgsPort* port
   )
 {
   FW_ASSERT(
@@ -531,7 +531,7 @@ void QueuedParamsTesterBase ::
 void QueuedParamsTesterBase ::
   connect_to_noArgsGuarded(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsPort* port
+      Ports::InputNoArgsPort* port
   )
 {
   FW_ASSERT(
@@ -545,7 +545,7 @@ void QueuedParamsTesterBase ::
 void QueuedParamsTesterBase ::
   connect_to_noArgsReturnGuarded(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsReturnPort* port
+      Ports::InputNoArgsReturnPort* port
   )
 {
   FW_ASSERT(
@@ -559,7 +559,7 @@ void QueuedParamsTesterBase ::
 void QueuedParamsTesterBase ::
   connect_to_noArgsReturnSync(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsReturnPort* port
+      Ports::InputNoArgsReturnPort* port
   )
 {
   FW_ASSERT(
@@ -573,7 +573,7 @@ void QueuedParamsTesterBase ::
 void QueuedParamsTesterBase ::
   connect_to_noArgsSync(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsPort* port
+      Ports::InputNoArgsPort* port
   )
 {
   FW_ASSERT(

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedParamsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedParamsTesterBase.ref.cpp
@@ -587,7 +587,7 @@ void QueuedParamsTesterBase ::
 void QueuedParamsTesterBase ::
   connect_to_typedAsync(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -601,7 +601,7 @@ void QueuedParamsTesterBase ::
 void QueuedParamsTesterBase ::
   connect_to_typedAsyncAssert(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -615,7 +615,7 @@ void QueuedParamsTesterBase ::
 void QueuedParamsTesterBase ::
   connect_to_typedAsyncBlockPriority(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -629,7 +629,7 @@ void QueuedParamsTesterBase ::
 void QueuedParamsTesterBase ::
   connect_to_typedAsyncDropPriority(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -643,7 +643,7 @@ void QueuedParamsTesterBase ::
 void QueuedParamsTesterBase ::
   connect_to_typedGuarded(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -657,7 +657,7 @@ void QueuedParamsTesterBase ::
 void QueuedParamsTesterBase ::
   connect_to_typedReturnGuarded(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -671,7 +671,7 @@ void QueuedParamsTesterBase ::
 void QueuedParamsTesterBase ::
   connect_to_typedReturnSync(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -685,7 +685,7 @@ void QueuedParamsTesterBase ::
 void QueuedParamsTesterBase ::
   connect_to_typedSync(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -792,7 +792,7 @@ Fw::InputTlmPort* QueuedParamsTesterBase ::
   return &this->m_from_tlmOut[portNum];
 }
 
-InputTypedPort* QueuedParamsTesterBase ::
+Ports::InputTypedPort* QueuedParamsTesterBase ::
   get_from_typedOut(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -803,7 +803,7 @@ InputTypedPort* QueuedParamsTesterBase ::
   return &this->m_from_typedOut[portNum];
 }
 
-InputTypedReturnPort* QueuedParamsTesterBase ::
+Ports::InputTypedReturnPort* QueuedParamsTesterBase ::
   get_from_typedReturnOut(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -863,7 +863,7 @@ void QueuedParamsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -892,7 +892,7 @@ F32 QueuedParamsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -980,7 +980,7 @@ void QueuedParamsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1008,7 +1008,7 @@ void QueuedParamsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1036,7 +1036,7 @@ void QueuedParamsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1064,7 +1064,7 @@ void QueuedParamsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1092,7 +1092,7 @@ void QueuedParamsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1120,7 +1120,7 @@ F32 QueuedParamsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1148,7 +1148,7 @@ F32 QueuedParamsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1176,7 +1176,7 @@ void QueuedParamsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1936,7 +1936,7 @@ void QueuedParamsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1960,7 +1960,7 @@ void QueuedParamsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2217,7 +2217,7 @@ void QueuedParamsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2244,7 +2244,7 @@ F32 QueuedParamsTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedParamsTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedParamsTesterBase.ref.hpp
@@ -111,7 +111,7 @@ class QueuedParamsTesterBase :
       U32 u32;
       F32 f32;
       bool b;
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       E e;
       A a;
       S s;
@@ -122,7 +122,7 @@ class QueuedParamsTesterBase :
       U32 u32;
       F32 f32;
       bool b;
-      TypedReturnPortStrings::StringSize80 str2;
+      Ports::TypedReturnPortStrings::StringSize80 str2;
       E e;
       A a;
       S s;
@@ -191,49 +191,49 @@ class QueuedParamsTesterBase :
     //! Connect port to typedAsync[portNum]
     void connect_to_typedAsync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedAsyncAssert[portNum]
     void connect_to_typedAsyncAssert(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedAsyncBlockPriority[portNum]
     void connect_to_typedAsyncBlockPriority(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedAsyncDropPriority[portNum]
     void connect_to_typedAsyncDropPriority(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedGuarded[portNum]
     void connect_to_typedGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnGuarded[portNum]
     void connect_to_typedReturnGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
     //! Connect port to typedReturnSync[portNum]
     void connect_to_typedReturnSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
     //! Connect port to typedSync[portNum]
     void connect_to_typedSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
   public:
@@ -305,14 +305,14 @@ class QueuedParamsTesterBase :
     //! Get from port at index
     //!
     //! \return from_typedOut[portNum]
-    InputTypedPort* get_from_typedOut(
+    Ports::InputTypedPort* get_from_typedOut(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get from port at index
     //!
     //! \return from_typedReturnOut[portNum]
-    InputTypedReturnPort* get_from_typedReturnOut(
+    Ports::InputTypedReturnPort* get_from_typedReturnOut(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -343,7 +343,7 @@ class QueuedParamsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -355,7 +355,7 @@ class QueuedParamsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -373,7 +373,7 @@ class QueuedParamsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -385,7 +385,7 @@ class QueuedParamsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -428,7 +428,7 @@ class QueuedParamsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -440,7 +440,7 @@ class QueuedParamsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -452,7 +452,7 @@ class QueuedParamsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -464,7 +464,7 @@ class QueuedParamsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -476,7 +476,7 @@ class QueuedParamsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -488,7 +488,7 @@ class QueuedParamsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -500,7 +500,7 @@ class QueuedParamsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -512,7 +512,7 @@ class QueuedParamsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -914,7 +914,7 @@ class QueuedParamsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -925,7 +925,7 @@ class QueuedParamsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -983,7 +983,7 @@ class QueuedParamsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -996,7 +996,7 @@ class QueuedParamsTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1045,28 +1045,28 @@ class QueuedParamsTesterBase :
     Ports::OutputNoArgsPort m_to_noArgsSync[3];
 
     //! To port connected to typedAsync
-    OutputTypedPort m_to_typedAsync[1];
+    Ports::OutputTypedPort m_to_typedAsync[1];
 
     //! To port connected to typedAsyncAssert
-    OutputTypedPort m_to_typedAsyncAssert[1];
+    Ports::OutputTypedPort m_to_typedAsyncAssert[1];
 
     //! To port connected to typedAsyncBlockPriority
-    OutputTypedPort m_to_typedAsyncBlockPriority[1];
+    Ports::OutputTypedPort m_to_typedAsyncBlockPriority[1];
 
     //! To port connected to typedAsyncDropPriority
-    OutputTypedPort m_to_typedAsyncDropPriority[1];
+    Ports::OutputTypedPort m_to_typedAsyncDropPriority[1];
 
     //! To port connected to typedGuarded
-    OutputTypedPort m_to_typedGuarded[1];
+    Ports::OutputTypedPort m_to_typedGuarded[1];
 
     //! To port connected to typedReturnGuarded
-    OutputTypedReturnPort m_to_typedReturnGuarded[1];
+    Ports::OutputTypedReturnPort m_to_typedReturnGuarded[1];
 
     //! To port connected to typedReturnSync
-    OutputTypedReturnPort m_to_typedReturnSync[3];
+    Ports::OutputTypedReturnPort m_to_typedReturnSync[3];
 
     //! To port connected to typedSync
-    OutputTypedPort m_to_typedSync[3];
+    Ports::OutputTypedPort m_to_typedSync[3];
 
   private:
 
@@ -1103,10 +1103,10 @@ class QueuedParamsTesterBase :
     Fw::InputTlmPort m_from_tlmOut[1];
 
     //! From port connected to typedOut
-    InputTypedPort m_from_typedOut[1];
+    Ports::InputTypedPort m_from_typedOut[1];
 
     //! From port connected to typedReturnOut
-    InputTypedReturnPort m_from_typedReturnOut[1];
+    Ports::InputTypedReturnPort m_from_typedReturnOut[1];
 
   private:
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedParamsTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedParamsTesterBase.ref.hpp
@@ -161,31 +161,31 @@ class QueuedParamsTesterBase :
     //! Connect port to noArgsAsync[portNum]
     void connect_to_noArgsAsync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsPort* port //!< The input port
+        Ports::InputNoArgsPort* port //!< The input port
     );
 
     //! Connect port to noArgsGuarded[portNum]
     void connect_to_noArgsGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsPort* port //!< The input port
+        Ports::InputNoArgsPort* port //!< The input port
     );
 
     //! Connect port to noArgsReturnGuarded[portNum]
     void connect_to_noArgsReturnGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsReturnPort* port //!< The input port
+        Ports::InputNoArgsReturnPort* port //!< The input port
     );
 
     //! Connect port to noArgsReturnSync[portNum]
     void connect_to_noArgsReturnSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsReturnPort* port //!< The input port
+        Ports::InputNoArgsReturnPort* port //!< The input port
     );
 
     //! Connect port to noArgsSync[portNum]
     void connect_to_noArgsSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsPort* port //!< The input port
+        Ports::InputNoArgsPort* port //!< The input port
     );
 
     //! Connect port to typedAsync[portNum]
@@ -1030,19 +1030,19 @@ class QueuedParamsTesterBase :
     Fw::OutputCmdPort m_to_cmdIn[1];
 
     //! To port connected to noArgsAsync
-    OutputNoArgsPort m_to_noArgsAsync[1];
+    Ports::OutputNoArgsPort m_to_noArgsAsync[1];
 
     //! To port connected to noArgsGuarded
-    OutputNoArgsPort m_to_noArgsGuarded[1];
+    Ports::OutputNoArgsPort m_to_noArgsGuarded[1];
 
     //! To port connected to noArgsReturnGuarded
-    OutputNoArgsReturnPort m_to_noArgsReturnGuarded[1];
+    Ports::OutputNoArgsReturnPort m_to_noArgsReturnGuarded[1];
 
     //! To port connected to noArgsReturnSync
-    OutputNoArgsReturnPort m_to_noArgsReturnSync[3];
+    Ports::OutputNoArgsReturnPort m_to_noArgsReturnSync[3];
 
     //! To port connected to noArgsSync
-    OutputNoArgsPort m_to_noArgsSync[3];
+    Ports::OutputNoArgsPort m_to_noArgsSync[3];
 
     //! To port connected to typedAsync
     OutputTypedPort m_to_typedAsync[1];

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialComponentAc.ref.cpp
@@ -44,14 +44,14 @@ namespace {
     BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
     BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
     BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE typedAsyncPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncAssertPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncBlockPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncDropPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedGuardedPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedReturnGuardedPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedReturnSyncPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedSyncPortSize[InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncAssertPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncBlockPriorityPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncDropPriorityPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedGuardedPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedReturnGuardedPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedReturnSyncPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedSyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
     BYTE cmdPortSize[Fw::InputCmdPort::SERIALIZED_SIZE];
     // Size of internalArray argument list
     BYTE internalArrayIntIfSize[
@@ -972,7 +972,7 @@ Ports::InputNoArgsPort* QueuedSerialComponentBase ::
   return &this->m_noArgsSync_InputPort[portNum];
 }
 
-InputTypedPort* QueuedSerialComponentBase ::
+Ports::InputTypedPort* QueuedSerialComponentBase ::
   get_typedAsync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -983,7 +983,7 @@ InputTypedPort* QueuedSerialComponentBase ::
   return &this->m_typedAsync_InputPort[portNum];
 }
 
-InputTypedPort* QueuedSerialComponentBase ::
+Ports::InputTypedPort* QueuedSerialComponentBase ::
   get_typedAsyncAssert_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -994,7 +994,7 @@ InputTypedPort* QueuedSerialComponentBase ::
   return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-InputTypedPort* QueuedSerialComponentBase ::
+Ports::InputTypedPort* QueuedSerialComponentBase ::
   get_typedAsyncBlockPriority_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -1005,7 +1005,7 @@ InputTypedPort* QueuedSerialComponentBase ::
   return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-InputTypedPort* QueuedSerialComponentBase ::
+Ports::InputTypedPort* QueuedSerialComponentBase ::
   get_typedAsyncDropPriority_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -1016,7 +1016,7 @@ InputTypedPort* QueuedSerialComponentBase ::
   return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-InputTypedPort* QueuedSerialComponentBase ::
+Ports::InputTypedPort* QueuedSerialComponentBase ::
   get_typedGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -1027,7 +1027,7 @@ InputTypedPort* QueuedSerialComponentBase ::
   return &this->m_typedGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* QueuedSerialComponentBase ::
+Ports::InputTypedReturnPort* QueuedSerialComponentBase ::
   get_typedReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -1038,7 +1038,7 @@ InputTypedReturnPort* QueuedSerialComponentBase ::
   return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* QueuedSerialComponentBase ::
+Ports::InputTypedReturnPort* QueuedSerialComponentBase ::
   get_typedReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -1049,7 +1049,7 @@ InputTypedReturnPort* QueuedSerialComponentBase ::
   return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-InputTypedPort* QueuedSerialComponentBase ::
+Ports::InputTypedPort* QueuedSerialComponentBase ::
   get_typedSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -1257,7 +1257,7 @@ void QueuedSerialComponentBase ::
 void QueuedSerialComponentBase ::
   set_typedOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -1271,7 +1271,7 @@ void QueuedSerialComponentBase ::
 void QueuedSerialComponentBase ::
   set_typedReturnOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -2245,7 +2245,7 @@ void QueuedSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2352,7 +2352,7 @@ void QueuedSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2459,7 +2459,7 @@ void QueuedSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2566,7 +2566,7 @@ void QueuedSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2678,7 +2678,7 @@ void QueuedSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2715,7 +2715,7 @@ F32 QueuedSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2756,7 +2756,7 @@ F32 QueuedSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2791,7 +2791,7 @@ void QueuedSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3091,7 +3091,7 @@ void QueuedSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3106,7 +3106,7 @@ void QueuedSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3121,7 +3121,7 @@ void QueuedSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3136,7 +3136,7 @@ void QueuedSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3199,7 +3199,7 @@ void QueuedSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3226,7 +3226,7 @@ F32 QueuedSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -5821,7 +5821,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -5893,7 +5893,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -5965,7 +5965,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -6037,7 +6037,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedSerialComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -6957,7 +6957,7 @@ void QueuedSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -6984,7 +6984,7 @@ void QueuedSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -7011,7 +7011,7 @@ void QueuedSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -7038,7 +7038,7 @@ void QueuedSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -7065,7 +7065,7 @@ void QueuedSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -7092,7 +7092,7 @@ F32 QueuedSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -7119,7 +7119,7 @@ F32 QueuedSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -7146,7 +7146,7 @@ void QueuedSerialComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialComponentAc.ref.cpp
@@ -39,11 +39,11 @@ namespace {
 
   // Get the max size by doing a union of the input and internal port serialization sizes
   union BuffUnion {
-    BYTE noArgsAsyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsGuardedPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnGuardedPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnSyncPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsSyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsAsyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsGuardedPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
     BYTE typedAsyncPortSize[InputTypedPort::SERIALIZED_SIZE];
     BYTE typedAsyncAssertPortSize[InputTypedPort::SERIALIZED_SIZE];
     BYTE typedAsyncBlockPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
@@ -917,7 +917,7 @@ Fw::InputCmdPort* QueuedSerialComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-InputNoArgsPort* QueuedSerialComponentBase ::
+Ports::InputNoArgsPort* QueuedSerialComponentBase ::
   get_noArgsAsync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -928,7 +928,7 @@ InputNoArgsPort* QueuedSerialComponentBase ::
   return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-InputNoArgsPort* QueuedSerialComponentBase ::
+Ports::InputNoArgsPort* QueuedSerialComponentBase ::
   get_noArgsGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -939,7 +939,7 @@ InputNoArgsPort* QueuedSerialComponentBase ::
   return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* QueuedSerialComponentBase ::
+Ports::InputNoArgsReturnPort* QueuedSerialComponentBase ::
   get_noArgsReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -950,7 +950,7 @@ InputNoArgsReturnPort* QueuedSerialComponentBase ::
   return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* QueuedSerialComponentBase ::
+Ports::InputNoArgsReturnPort* QueuedSerialComponentBase ::
   get_noArgsReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -961,7 +961,7 @@ InputNoArgsReturnPort* QueuedSerialComponentBase ::
   return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-InputNoArgsPort* QueuedSerialComponentBase ::
+Ports::InputNoArgsPort* QueuedSerialComponentBase ::
   get_noArgsSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialComponentAc.ref.hpp
@@ -229,35 +229,35 @@ class QueuedSerialComponentBase :
     //! Get typed input port at index
     //!
     //! \return noArgsAsync[portNum]
-    InputNoArgsPort* get_noArgsAsync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsAsync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsGuarded[portNum]
-    InputNoArgsPort* get_noArgsGuarded_InputPort(
+    Ports::InputNoArgsPort* get_noArgsGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnGuarded[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnSync[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsSync[portNum]
-    InputNoArgsPort* get_noArgsSync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -2376,19 +2376,19 @@ class QueuedSerialComponentBase :
     // ----------------------------------------------------------------------
 
     //! Input port noArgsAsync
-    InputNoArgsPort m_noArgsAsync_InputPort[NUM_NOARGSASYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsAsync_InputPort[NUM_NOARGSASYNC_INPUT_PORTS];
 
     //! Input port noArgsGuarded
-    InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnGuarded
-    InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnSync
-    InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
 
     //! Input port noArgsSync
-    InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedAsync
     InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialComponentAc.ref.hpp
@@ -264,56 +264,56 @@ class QueuedSerialComponentBase :
     //! Get typed input port at index
     //!
     //! \return typedAsync[portNum]
-    InputTypedPort* get_typedAsync_InputPort(
+    Ports::InputTypedPort* get_typedAsync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncAssert[portNum]
-    InputTypedPort* get_typedAsyncAssert_InputPort(
+    Ports::InputTypedPort* get_typedAsyncAssert_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncBlockPriority[portNum]
-    InputTypedPort* get_typedAsyncBlockPriority_InputPort(
+    Ports::InputTypedPort* get_typedAsyncBlockPriority_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncDropPriority[portNum]
-    InputTypedPort* get_typedAsyncDropPriority_InputPort(
+    Ports::InputTypedPort* get_typedAsyncDropPriority_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedGuarded[portNum]
-    InputTypedPort* get_typedGuarded_InputPort(
+    Ports::InputTypedPort* get_typedGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnGuarded[portNum]
-    InputTypedReturnPort* get_typedReturnGuarded_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnSync[portNum]
-    InputTypedReturnPort* get_typedReturnSync_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedSync[portNum]
-    InputTypedPort* get_typedSync_InputPort(
+    Ports::InputTypedPort* get_typedSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -432,13 +432,13 @@ class QueuedSerialComponentBase :
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnOut[portNum]
     void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
 #if FW_PORT_SERIALIZATION
@@ -896,7 +896,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -908,7 +908,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -920,7 +920,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -932,7 +932,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -944,7 +944,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -956,7 +956,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -968,7 +968,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -980,7 +980,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1025,7 +1025,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1037,7 +1037,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1049,7 +1049,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1061,7 +1061,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1073,7 +1073,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1085,7 +1085,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1097,7 +1097,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1109,7 +1109,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1222,7 +1222,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1234,7 +1234,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1246,7 +1246,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1258,7 +1258,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1310,7 +1310,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1322,7 +1322,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -2127,7 +2127,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -2140,7 +2140,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -2153,7 +2153,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -2166,7 +2166,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -2179,7 +2179,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -2192,7 +2192,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -2205,7 +2205,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -2218,7 +2218,7 @@ class QueuedSerialComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -2391,28 +2391,28 @@ class QueuedSerialComponentBase :
     Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedAsync
-    InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];
 
     //! Input port typedAsyncAssert
-    InputTypedPort m_typedAsyncAssert_InputPort[NUM_TYPEDASYNCASSERT_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncAssert_InputPort[NUM_TYPEDASYNCASSERT_INPUT_PORTS];
 
     //! Input port typedAsyncBlockPriority
-    InputTypedPort m_typedAsyncBlockPriority_InputPort[NUM_TYPEDASYNCBLOCKPRIORITY_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncBlockPriority_InputPort[NUM_TYPEDASYNCBLOCKPRIORITY_INPUT_PORTS];
 
     //! Input port typedAsyncDropPriority
-    InputTypedPort m_typedAsyncDropPriority_InputPort[NUM_TYPEDASYNCDROPPRIORITY_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncDropPriority_InputPort[NUM_TYPEDASYNCDROPPRIORITY_INPUT_PORTS];
 
     //! Input port typedGuarded
-    InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
+    Ports::InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnGuarded
-    InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnSync
-    InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
 
     //! Input port typedSync
-    InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
 
   PRIVATE:
 
@@ -2479,10 +2479,10 @@ class QueuedSerialComponentBase :
     // ----------------------------------------------------------------------
 
     //! Output port typedOut
-    OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
+    Ports::OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
 
     //! Output port typedReturnOut
-    OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
+    Ports::OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
 
   PRIVATE:
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.cpp
@@ -819,7 +819,7 @@ void QueuedSerialTesterBase ::
 void QueuedSerialTesterBase ::
   connect_to_typedAsync(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -833,7 +833,7 @@ void QueuedSerialTesterBase ::
 void QueuedSerialTesterBase ::
   connect_to_typedAsyncAssert(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -847,7 +847,7 @@ void QueuedSerialTesterBase ::
 void QueuedSerialTesterBase ::
   connect_to_typedAsyncBlockPriority(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -861,7 +861,7 @@ void QueuedSerialTesterBase ::
 void QueuedSerialTesterBase ::
   connect_to_typedAsyncDropPriority(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -875,7 +875,7 @@ void QueuedSerialTesterBase ::
 void QueuedSerialTesterBase ::
   connect_to_typedGuarded(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -889,7 +889,7 @@ void QueuedSerialTesterBase ::
 void QueuedSerialTesterBase ::
   connect_to_typedReturnGuarded(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -903,7 +903,7 @@ void QueuedSerialTesterBase ::
 void QueuedSerialTesterBase ::
   connect_to_typedReturnSync(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -917,7 +917,7 @@ void QueuedSerialTesterBase ::
 void QueuedSerialTesterBase ::
   connect_to_typedSync(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -1108,7 +1108,7 @@ Fw::InputTlmPort* QueuedSerialTesterBase ::
   return &this->m_from_tlmOut[portNum];
 }
 
-InputTypedPort* QueuedSerialTesterBase ::
+Ports::InputTypedPort* QueuedSerialTesterBase ::
   get_from_typedOut(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -1119,7 +1119,7 @@ InputTypedPort* QueuedSerialTesterBase ::
   return &this->m_from_typedOut[portNum];
 }
 
-InputTypedReturnPort* QueuedSerialTesterBase ::
+Ports::InputTypedReturnPort* QueuedSerialTesterBase ::
   get_from_typedReturnOut(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -1236,7 +1236,7 @@ void QueuedSerialTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1265,7 +1265,7 @@ F32 QueuedSerialTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1370,7 +1370,7 @@ void QueuedSerialTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1398,7 +1398,7 @@ void QueuedSerialTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1426,7 +1426,7 @@ void QueuedSerialTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1454,7 +1454,7 @@ void QueuedSerialTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1482,7 +1482,7 @@ void QueuedSerialTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1510,7 +1510,7 @@ F32 QueuedSerialTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1538,7 +1538,7 @@ F32 QueuedSerialTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1566,7 +1566,7 @@ void QueuedSerialTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3802,7 +3802,7 @@ void QueuedSerialTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3826,7 +3826,7 @@ void QueuedSerialTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -4220,7 +4220,7 @@ void QueuedSerialTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -4247,7 +4247,7 @@ F32 QueuedSerialTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.cpp
@@ -749,7 +749,7 @@ void QueuedSerialTesterBase ::
 void QueuedSerialTesterBase ::
   connect_to_noArgsAsync(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsPort* port
+      Ports::InputNoArgsPort* port
   )
 {
   FW_ASSERT(
@@ -763,7 +763,7 @@ void QueuedSerialTesterBase ::
 void QueuedSerialTesterBase ::
   connect_to_noArgsGuarded(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsPort* port
+      Ports::InputNoArgsPort* port
   )
 {
   FW_ASSERT(
@@ -777,7 +777,7 @@ void QueuedSerialTesterBase ::
 void QueuedSerialTesterBase ::
   connect_to_noArgsReturnGuarded(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsReturnPort* port
+      Ports::InputNoArgsReturnPort* port
   )
 {
   FW_ASSERT(
@@ -791,7 +791,7 @@ void QueuedSerialTesterBase ::
 void QueuedSerialTesterBase ::
   connect_to_noArgsReturnSync(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsReturnPort* port
+      Ports::InputNoArgsReturnPort* port
   )
 {
   FW_ASSERT(
@@ -805,7 +805,7 @@ void QueuedSerialTesterBase ::
 void QueuedSerialTesterBase ::
   connect_to_noArgsSync(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsPort* port
+      Ports::InputNoArgsPort* port
   )
 {
   FW_ASSERT(

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.hpp
@@ -111,7 +111,7 @@ class QueuedSerialTesterBase :
       U32 u32;
       F32 f32;
       bool b;
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       E e;
       A a;
       S s;
@@ -122,7 +122,7 @@ class QueuedSerialTesterBase :
       U32 u32;
       F32 f32;
       bool b;
-      TypedReturnPortStrings::StringSize80 str2;
+      Ports::TypedReturnPortStrings::StringSize80 str2;
       E e;
       A a;
       S s;
@@ -297,49 +297,49 @@ class QueuedSerialTesterBase :
     //! Connect port to typedAsync[portNum]
     void connect_to_typedAsync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedAsyncAssert[portNum]
     void connect_to_typedAsyncAssert(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedAsyncBlockPriority[portNum]
     void connect_to_typedAsyncBlockPriority(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedAsyncDropPriority[portNum]
     void connect_to_typedAsyncDropPriority(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedGuarded[portNum]
     void connect_to_typedGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnGuarded[portNum]
     void connect_to_typedReturnGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
     //! Connect port to typedReturnSync[portNum]
     void connect_to_typedReturnSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
     //! Connect port to typedSync[portNum]
     void connect_to_typedSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to serialAsync[portNum]
@@ -447,14 +447,14 @@ class QueuedSerialTesterBase :
     //! Get from port at index
     //!
     //! \return from_typedOut[portNum]
-    InputTypedPort* get_from_typedOut(
+    Ports::InputTypedPort* get_from_typedOut(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get from port at index
     //!
     //! \return from_typedReturnOut[portNum]
-    InputTypedReturnPort* get_from_typedReturnOut(
+    Ports::InputTypedReturnPort* get_from_typedReturnOut(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -492,7 +492,7 @@ class QueuedSerialTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -504,7 +504,7 @@ class QueuedSerialTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -528,7 +528,7 @@ class QueuedSerialTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -540,7 +540,7 @@ class QueuedSerialTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -589,7 +589,7 @@ class QueuedSerialTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -601,7 +601,7 @@ class QueuedSerialTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -613,7 +613,7 @@ class QueuedSerialTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -625,7 +625,7 @@ class QueuedSerialTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -637,7 +637,7 @@ class QueuedSerialTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -649,7 +649,7 @@ class QueuedSerialTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -661,7 +661,7 @@ class QueuedSerialTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -673,7 +673,7 @@ class QueuedSerialTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1447,7 +1447,7 @@ class QueuedSerialTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1458,7 +1458,7 @@ class QueuedSerialTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1568,7 +1568,7 @@ class QueuedSerialTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1581,7 +1581,7 @@ class QueuedSerialTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1704,28 +1704,28 @@ class QueuedSerialTesterBase :
     Ports::OutputNoArgsPort m_to_noArgsSync[3];
 
     //! To port connected to typedAsync
-    OutputTypedPort m_to_typedAsync[1];
+    Ports::OutputTypedPort m_to_typedAsync[1];
 
     //! To port connected to typedAsyncAssert
-    OutputTypedPort m_to_typedAsyncAssert[1];
+    Ports::OutputTypedPort m_to_typedAsyncAssert[1];
 
     //! To port connected to typedAsyncBlockPriority
-    OutputTypedPort m_to_typedAsyncBlockPriority[1];
+    Ports::OutputTypedPort m_to_typedAsyncBlockPriority[1];
 
     //! To port connected to typedAsyncDropPriority
-    OutputTypedPort m_to_typedAsyncDropPriority[1];
+    Ports::OutputTypedPort m_to_typedAsyncDropPriority[1];
 
     //! To port connected to typedGuarded
-    OutputTypedPort m_to_typedGuarded[1];
+    Ports::OutputTypedPort m_to_typedGuarded[1];
 
     //! To port connected to typedReturnGuarded
-    OutputTypedReturnPort m_to_typedReturnGuarded[1];
+    Ports::OutputTypedReturnPort m_to_typedReturnGuarded[1];
 
     //! To port connected to typedReturnSync
-    OutputTypedReturnPort m_to_typedReturnSync[3];
+    Ports::OutputTypedReturnPort m_to_typedReturnSync[3];
 
     //! To port connected to typedSync
-    OutputTypedPort m_to_typedSync[3];
+    Ports::OutputTypedPort m_to_typedSync[3];
 
     //! To port connected to serialAsync
     Fw::OutputSerializePort m_to_serialAsync[1];
@@ -1780,10 +1780,10 @@ class QueuedSerialTesterBase :
     Fw::InputTlmPort m_from_tlmOut[1];
 
     //! From port connected to typedOut
-    InputTypedPort m_from_typedOut[1];
+    Ports::InputTypedPort m_from_typedOut[1];
 
     //! From port connected to typedReturnOut
-    InputTypedReturnPort m_from_typedReturnOut[1];
+    Ports::InputTypedReturnPort m_from_typedReturnOut[1];
 
     //! From port connected to serialOut
     Fw::InputSerializePort m_from_serialOut[5];

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.hpp
@@ -267,31 +267,31 @@ class QueuedSerialTesterBase :
     //! Connect port to noArgsAsync[portNum]
     void connect_to_noArgsAsync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsPort* port //!< The input port
+        Ports::InputNoArgsPort* port //!< The input port
     );
 
     //! Connect port to noArgsGuarded[portNum]
     void connect_to_noArgsGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsPort* port //!< The input port
+        Ports::InputNoArgsPort* port //!< The input port
     );
 
     //! Connect port to noArgsReturnGuarded[portNum]
     void connect_to_noArgsReturnGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsReturnPort* port //!< The input port
+        Ports::InputNoArgsReturnPort* port //!< The input port
     );
 
     //! Connect port to noArgsReturnSync[portNum]
     void connect_to_noArgsReturnSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsReturnPort* port //!< The input port
+        Ports::InputNoArgsReturnPort* port //!< The input port
     );
 
     //! Connect port to noArgsSync[portNum]
     void connect_to_noArgsSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsPort* port //!< The input port
+        Ports::InputNoArgsPort* port //!< The input port
     );
 
     //! Connect port to typedAsync[portNum]
@@ -1689,19 +1689,19 @@ class QueuedSerialTesterBase :
     Fw::OutputCmdPort m_to_cmdIn[1];
 
     //! To port connected to noArgsAsync
-    OutputNoArgsPort m_to_noArgsAsync[1];
+    Ports::OutputNoArgsPort m_to_noArgsAsync[1];
 
     //! To port connected to noArgsGuarded
-    OutputNoArgsPort m_to_noArgsGuarded[1];
+    Ports::OutputNoArgsPort m_to_noArgsGuarded[1];
 
     //! To port connected to noArgsReturnGuarded
-    OutputNoArgsReturnPort m_to_noArgsReturnGuarded[1];
+    Ports::OutputNoArgsReturnPort m_to_noArgsReturnGuarded[1];
 
     //! To port connected to noArgsReturnSync
-    OutputNoArgsReturnPort m_to_noArgsReturnSync[3];
+    Ports::OutputNoArgsReturnPort m_to_noArgsReturnSync[3];
 
     //! To port connected to noArgsSync
-    OutputNoArgsPort m_to_noArgsSync[3];
+    Ports::OutputNoArgsPort m_to_noArgsSync[3];
 
     //! To port connected to typedAsync
     OutputTypedPort m_to_typedAsync[1];

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTelemetryComponentAc.ref.cpp
@@ -29,14 +29,14 @@ namespace {
     BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
     BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
     BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE typedAsyncPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncAssertPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncBlockPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncDropPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedGuardedPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedReturnGuardedPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedReturnSyncPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedSyncPortSize[InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncAssertPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncBlockPriorityPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncDropPriorityPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedGuardedPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedReturnGuardedPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedReturnSyncPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedSyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
     BYTE cmdPortSize[Fw::InputCmdPort::SERIALIZED_SIZE];
   };
 
@@ -748,7 +748,7 @@ Ports::InputNoArgsPort* QueuedTelemetryComponentBase ::
   return &this->m_noArgsSync_InputPort[portNum];
 }
 
-InputTypedPort* QueuedTelemetryComponentBase ::
+Ports::InputTypedPort* QueuedTelemetryComponentBase ::
   get_typedAsync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -759,7 +759,7 @@ InputTypedPort* QueuedTelemetryComponentBase ::
   return &this->m_typedAsync_InputPort[portNum];
 }
 
-InputTypedPort* QueuedTelemetryComponentBase ::
+Ports::InputTypedPort* QueuedTelemetryComponentBase ::
   get_typedAsyncAssert_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -770,7 +770,7 @@ InputTypedPort* QueuedTelemetryComponentBase ::
   return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-InputTypedPort* QueuedTelemetryComponentBase ::
+Ports::InputTypedPort* QueuedTelemetryComponentBase ::
   get_typedAsyncBlockPriority_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -781,7 +781,7 @@ InputTypedPort* QueuedTelemetryComponentBase ::
   return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-InputTypedPort* QueuedTelemetryComponentBase ::
+Ports::InputTypedPort* QueuedTelemetryComponentBase ::
   get_typedAsyncDropPriority_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -792,7 +792,7 @@ InputTypedPort* QueuedTelemetryComponentBase ::
   return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-InputTypedPort* QueuedTelemetryComponentBase ::
+Ports::InputTypedPort* QueuedTelemetryComponentBase ::
   get_typedGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -803,7 +803,7 @@ InputTypedPort* QueuedTelemetryComponentBase ::
   return &this->m_typedGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* QueuedTelemetryComponentBase ::
+Ports::InputTypedReturnPort* QueuedTelemetryComponentBase ::
   get_typedReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -814,7 +814,7 @@ InputTypedReturnPort* QueuedTelemetryComponentBase ::
   return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* QueuedTelemetryComponentBase ::
+Ports::InputTypedReturnPort* QueuedTelemetryComponentBase ::
   get_typedReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -825,7 +825,7 @@ InputTypedReturnPort* QueuedTelemetryComponentBase ::
   return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-InputTypedPort* QueuedTelemetryComponentBase ::
+Ports::InputTypedPort* QueuedTelemetryComponentBase ::
   get_typedSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -963,7 +963,7 @@ void QueuedTelemetryComponentBase ::
 void QueuedTelemetryComponentBase ::
   set_typedOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -977,7 +977,7 @@ void QueuedTelemetryComponentBase ::
 void QueuedTelemetryComponentBase ::
   set_typedReturnOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -1552,7 +1552,7 @@ void QueuedTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1659,7 +1659,7 @@ void QueuedTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1766,7 +1766,7 @@ void QueuedTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1873,7 +1873,7 @@ void QueuedTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1985,7 +1985,7 @@ void QueuedTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2022,7 +2022,7 @@ F32 QueuedTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2063,7 +2063,7 @@ F32 QueuedTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2098,7 +2098,7 @@ void QueuedTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2143,7 +2143,7 @@ void QueuedTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2158,7 +2158,7 @@ void QueuedTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2173,7 +2173,7 @@ void QueuedTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2188,7 +2188,7 @@ void QueuedTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2207,7 +2207,7 @@ void QueuedTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2234,7 +2234,7 @@ F32 QueuedTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2772,7 +2772,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -2844,7 +2844,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -2916,7 +2916,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -2988,7 +2988,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTelemetryComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -3125,7 +3125,7 @@ void QueuedTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3152,7 +3152,7 @@ void QueuedTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3179,7 +3179,7 @@ void QueuedTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3206,7 +3206,7 @@ void QueuedTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3233,7 +3233,7 @@ void QueuedTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3260,7 +3260,7 @@ F32 QueuedTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -3287,7 +3287,7 @@ F32 QueuedTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -3314,7 +3314,7 @@ void QueuedTelemetryComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTelemetryComponentAc.ref.cpp
@@ -24,11 +24,11 @@ namespace {
 
   // Get the max size by doing a union of the input and internal port serialization sizes
   union BuffUnion {
-    BYTE noArgsAsyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsGuardedPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnGuardedPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnSyncPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsSyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsAsyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsGuardedPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
     BYTE typedAsyncPortSize[InputTypedPort::SERIALIZED_SIZE];
     BYTE typedAsyncAssertPortSize[InputTypedPort::SERIALIZED_SIZE];
     BYTE typedAsyncBlockPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
@@ -693,7 +693,7 @@ Fw::InputCmdPort* QueuedTelemetryComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-InputNoArgsPort* QueuedTelemetryComponentBase ::
+Ports::InputNoArgsPort* QueuedTelemetryComponentBase ::
   get_noArgsAsync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -704,7 +704,7 @@ InputNoArgsPort* QueuedTelemetryComponentBase ::
   return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-InputNoArgsPort* QueuedTelemetryComponentBase ::
+Ports::InputNoArgsPort* QueuedTelemetryComponentBase ::
   get_noArgsGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -715,7 +715,7 @@ InputNoArgsPort* QueuedTelemetryComponentBase ::
   return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* QueuedTelemetryComponentBase ::
+Ports::InputNoArgsReturnPort* QueuedTelemetryComponentBase ::
   get_noArgsReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -726,7 +726,7 @@ InputNoArgsReturnPort* QueuedTelemetryComponentBase ::
   return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* QueuedTelemetryComponentBase ::
+Ports::InputNoArgsReturnPort* QueuedTelemetryComponentBase ::
   get_noArgsReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -737,7 +737,7 @@ InputNoArgsReturnPort* QueuedTelemetryComponentBase ::
   return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-InputNoArgsPort* QueuedTelemetryComponentBase ::
+Ports::InputNoArgsPort* QueuedTelemetryComponentBase ::
   get_noArgsSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTelemetryComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTelemetryComponentAc.ref.hpp
@@ -142,35 +142,35 @@ class QueuedTelemetryComponentBase :
     //! Get typed input port at index
     //!
     //! \return noArgsAsync[portNum]
-    InputNoArgsPort* get_noArgsAsync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsAsync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsGuarded[portNum]
-    InputNoArgsPort* get_noArgsGuarded_InputPort(
+    Ports::InputNoArgsPort* get_noArgsGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnGuarded[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnSync[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsSync[portNum]
-    InputNoArgsPort* get_noArgsSync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -1275,19 +1275,19 @@ class QueuedTelemetryComponentBase :
     // ----------------------------------------------------------------------
 
     //! Input port noArgsAsync
-    InputNoArgsPort m_noArgsAsync_InputPort[NUM_NOARGSASYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsAsync_InputPort[NUM_NOARGSASYNC_INPUT_PORTS];
 
     //! Input port noArgsGuarded
-    InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnGuarded
-    InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnSync
-    InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
 
     //! Input port noArgsSync
-    InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedAsync
     InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTelemetryComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTelemetryComponentAc.ref.hpp
@@ -177,56 +177,56 @@ class QueuedTelemetryComponentBase :
     //! Get typed input port at index
     //!
     //! \return typedAsync[portNum]
-    InputTypedPort* get_typedAsync_InputPort(
+    Ports::InputTypedPort* get_typedAsync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncAssert[portNum]
-    InputTypedPort* get_typedAsyncAssert_InputPort(
+    Ports::InputTypedPort* get_typedAsyncAssert_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncBlockPriority[portNum]
-    InputTypedPort* get_typedAsyncBlockPriority_InputPort(
+    Ports::InputTypedPort* get_typedAsyncBlockPriority_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncDropPriority[portNum]
-    InputTypedPort* get_typedAsyncDropPriority_InputPort(
+    Ports::InputTypedPort* get_typedAsyncDropPriority_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedGuarded[portNum]
-    InputTypedPort* get_typedGuarded_InputPort(
+    Ports::InputTypedPort* get_typedGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnGuarded[portNum]
-    InputTypedReturnPort* get_typedReturnGuarded_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnSync[portNum]
-    InputTypedReturnPort* get_typedReturnSync_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedSync[portNum]
-    InputTypedPort* get_typedSync_InputPort(
+    Ports::InputTypedPort* get_typedSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -297,13 +297,13 @@ class QueuedTelemetryComponentBase :
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnOut[portNum]
     void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
 #if FW_PORT_SERIALIZATION
@@ -663,7 +663,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -675,7 +675,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -687,7 +687,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -699,7 +699,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -711,7 +711,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -723,7 +723,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -735,7 +735,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -747,7 +747,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -792,7 +792,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -804,7 +804,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -816,7 +816,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -828,7 +828,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -840,7 +840,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -852,7 +852,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -864,7 +864,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -876,7 +876,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -903,7 +903,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -915,7 +915,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -927,7 +927,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -939,7 +939,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -957,7 +957,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -969,7 +969,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1162,7 +1162,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1175,7 +1175,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1188,7 +1188,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1201,7 +1201,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1214,7 +1214,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1227,7 +1227,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1240,7 +1240,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1253,7 +1253,7 @@ class QueuedTelemetryComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1290,28 +1290,28 @@ class QueuedTelemetryComponentBase :
     Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedAsync
-    InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];
 
     //! Input port typedAsyncAssert
-    InputTypedPort m_typedAsyncAssert_InputPort[NUM_TYPEDASYNCASSERT_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncAssert_InputPort[NUM_TYPEDASYNCASSERT_INPUT_PORTS];
 
     //! Input port typedAsyncBlockPriority
-    InputTypedPort m_typedAsyncBlockPriority_InputPort[NUM_TYPEDASYNCBLOCKPRIORITY_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncBlockPriority_InputPort[NUM_TYPEDASYNCBLOCKPRIORITY_INPUT_PORTS];
 
     //! Input port typedAsyncDropPriority
-    InputTypedPort m_typedAsyncDropPriority_InputPort[NUM_TYPEDASYNCDROPPRIORITY_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncDropPriority_InputPort[NUM_TYPEDASYNCDROPPRIORITY_INPUT_PORTS];
 
     //! Input port typedGuarded
-    InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
+    Ports::InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnGuarded
-    InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnSync
-    InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
 
     //! Input port typedSync
-    InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
 
   PRIVATE:
 
@@ -1354,10 +1354,10 @@ class QueuedTelemetryComponentBase :
     // ----------------------------------------------------------------------
 
     //! Output port typedOut
-    OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
+    Ports::OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
 
     //! Output port typedReturnOut
-    OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
+    Ports::OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
 
   PRIVATE:
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTelemetryTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTelemetryTesterBase.ref.cpp
@@ -488,7 +488,7 @@ void QueuedTelemetryTesterBase ::
 void QueuedTelemetryTesterBase ::
   connect_to_typedAsync(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -502,7 +502,7 @@ void QueuedTelemetryTesterBase ::
 void QueuedTelemetryTesterBase ::
   connect_to_typedAsyncAssert(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -516,7 +516,7 @@ void QueuedTelemetryTesterBase ::
 void QueuedTelemetryTesterBase ::
   connect_to_typedAsyncBlockPriority(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -530,7 +530,7 @@ void QueuedTelemetryTesterBase ::
 void QueuedTelemetryTesterBase ::
   connect_to_typedAsyncDropPriority(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -544,7 +544,7 @@ void QueuedTelemetryTesterBase ::
 void QueuedTelemetryTesterBase ::
   connect_to_typedGuarded(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -558,7 +558,7 @@ void QueuedTelemetryTesterBase ::
 void QueuedTelemetryTesterBase ::
   connect_to_typedReturnGuarded(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -572,7 +572,7 @@ void QueuedTelemetryTesterBase ::
 void QueuedTelemetryTesterBase ::
   connect_to_typedReturnSync(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -586,7 +586,7 @@ void QueuedTelemetryTesterBase ::
 void QueuedTelemetryTesterBase ::
   connect_to_typedSync(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -693,7 +693,7 @@ Fw::InputTlmPort* QueuedTelemetryTesterBase ::
   return &this->m_from_tlmOut[portNum];
 }
 
-InputTypedPort* QueuedTelemetryTesterBase ::
+Ports::InputTypedPort* QueuedTelemetryTesterBase ::
   get_from_typedOut(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -704,7 +704,7 @@ InputTypedPort* QueuedTelemetryTesterBase ::
   return &this->m_from_typedOut[portNum];
 }
 
-InputTypedReturnPort* QueuedTelemetryTesterBase ::
+Ports::InputTypedReturnPort* QueuedTelemetryTesterBase ::
   get_from_typedReturnOut(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -778,7 +778,7 @@ void QueuedTelemetryTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -807,7 +807,7 @@ F32 QueuedTelemetryTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -895,7 +895,7 @@ void QueuedTelemetryTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -923,7 +923,7 @@ void QueuedTelemetryTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -951,7 +951,7 @@ void QueuedTelemetryTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -979,7 +979,7 @@ void QueuedTelemetryTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1007,7 +1007,7 @@ void QueuedTelemetryTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1035,7 +1035,7 @@ F32 QueuedTelemetryTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1063,7 +1063,7 @@ F32 QueuedTelemetryTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1091,7 +1091,7 @@ void QueuedTelemetryTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1745,7 +1745,7 @@ void QueuedTelemetryTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1769,7 +1769,7 @@ void QueuedTelemetryTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1840,7 +1840,7 @@ void QueuedTelemetryTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1867,7 +1867,7 @@ F32 QueuedTelemetryTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTelemetryTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTelemetryTesterBase.ref.cpp
@@ -418,7 +418,7 @@ void QueuedTelemetryTesterBase ::
 void QueuedTelemetryTesterBase ::
   connect_to_noArgsAsync(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsPort* port
+      Ports::InputNoArgsPort* port
   )
 {
   FW_ASSERT(
@@ -432,7 +432,7 @@ void QueuedTelemetryTesterBase ::
 void QueuedTelemetryTesterBase ::
   connect_to_noArgsGuarded(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsPort* port
+      Ports::InputNoArgsPort* port
   )
 {
   FW_ASSERT(
@@ -446,7 +446,7 @@ void QueuedTelemetryTesterBase ::
 void QueuedTelemetryTesterBase ::
   connect_to_noArgsReturnGuarded(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsReturnPort* port
+      Ports::InputNoArgsReturnPort* port
   )
 {
   FW_ASSERT(
@@ -460,7 +460,7 @@ void QueuedTelemetryTesterBase ::
 void QueuedTelemetryTesterBase ::
   connect_to_noArgsReturnSync(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsReturnPort* port
+      Ports::InputNoArgsReturnPort* port
   )
 {
   FW_ASSERT(
@@ -474,7 +474,7 @@ void QueuedTelemetryTesterBase ::
 void QueuedTelemetryTesterBase ::
   connect_to_noArgsSync(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsPort* port
+      Ports::InputNoArgsPort* port
   )
 {
   FW_ASSERT(

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTelemetryTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTelemetryTesterBase.ref.hpp
@@ -111,7 +111,7 @@ class QueuedTelemetryTesterBase :
       U32 u32;
       F32 f32;
       bool b;
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       E e;
       A a;
       S s;
@@ -122,7 +122,7 @@ class QueuedTelemetryTesterBase :
       U32 u32;
       F32 f32;
       bool b;
-      TypedReturnPortStrings::StringSize80 str2;
+      Ports::TypedReturnPortStrings::StringSize80 str2;
       E e;
       A a;
       S s;
@@ -250,49 +250,49 @@ class QueuedTelemetryTesterBase :
     //! Connect port to typedAsync[portNum]
     void connect_to_typedAsync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedAsyncAssert[portNum]
     void connect_to_typedAsyncAssert(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedAsyncBlockPriority[portNum]
     void connect_to_typedAsyncBlockPriority(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedAsyncDropPriority[portNum]
     void connect_to_typedAsyncDropPriority(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedGuarded[portNum]
     void connect_to_typedGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnGuarded[portNum]
     void connect_to_typedReturnGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
     //! Connect port to typedReturnSync[portNum]
     void connect_to_typedReturnSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
     //! Connect port to typedSync[portNum]
     void connect_to_typedSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
   public:
@@ -364,14 +364,14 @@ class QueuedTelemetryTesterBase :
     //! Get from port at index
     //!
     //! \return from_typedOut[portNum]
-    InputTypedPort* get_from_typedOut(
+    Ports::InputTypedPort* get_from_typedOut(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get from port at index
     //!
     //! \return from_typedReturnOut[portNum]
-    InputTypedReturnPort* get_from_typedReturnOut(
+    Ports::InputTypedReturnPort* get_from_typedReturnOut(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -402,7 +402,7 @@ class QueuedTelemetryTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -414,7 +414,7 @@ class QueuedTelemetryTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -432,7 +432,7 @@ class QueuedTelemetryTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -444,7 +444,7 @@ class QueuedTelemetryTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -487,7 +487,7 @@ class QueuedTelemetryTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -499,7 +499,7 @@ class QueuedTelemetryTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -511,7 +511,7 @@ class QueuedTelemetryTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -523,7 +523,7 @@ class QueuedTelemetryTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -535,7 +535,7 @@ class QueuedTelemetryTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -547,7 +547,7 @@ class QueuedTelemetryTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -559,7 +559,7 @@ class QueuedTelemetryTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -571,7 +571,7 @@ class QueuedTelemetryTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -918,7 +918,7 @@ class QueuedTelemetryTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -929,7 +929,7 @@ class QueuedTelemetryTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -967,7 +967,7 @@ class QueuedTelemetryTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -980,7 +980,7 @@ class QueuedTelemetryTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1062,28 +1062,28 @@ class QueuedTelemetryTesterBase :
     Ports::OutputNoArgsPort m_to_noArgsSync[3];
 
     //! To port connected to typedAsync
-    OutputTypedPort m_to_typedAsync[1];
+    Ports::OutputTypedPort m_to_typedAsync[1];
 
     //! To port connected to typedAsyncAssert
-    OutputTypedPort m_to_typedAsyncAssert[1];
+    Ports::OutputTypedPort m_to_typedAsyncAssert[1];
 
     //! To port connected to typedAsyncBlockPriority
-    OutputTypedPort m_to_typedAsyncBlockPriority[1];
+    Ports::OutputTypedPort m_to_typedAsyncBlockPriority[1];
 
     //! To port connected to typedAsyncDropPriority
-    OutputTypedPort m_to_typedAsyncDropPriority[1];
+    Ports::OutputTypedPort m_to_typedAsyncDropPriority[1];
 
     //! To port connected to typedGuarded
-    OutputTypedPort m_to_typedGuarded[1];
+    Ports::OutputTypedPort m_to_typedGuarded[1];
 
     //! To port connected to typedReturnGuarded
-    OutputTypedReturnPort m_to_typedReturnGuarded[1];
+    Ports::OutputTypedReturnPort m_to_typedReturnGuarded[1];
 
     //! To port connected to typedReturnSync
-    OutputTypedReturnPort m_to_typedReturnSync[3];
+    Ports::OutputTypedReturnPort m_to_typedReturnSync[3];
 
     //! To port connected to typedSync
-    OutputTypedPort m_to_typedSync[3];
+    Ports::OutputTypedPort m_to_typedSync[3];
 
   private:
 
@@ -1120,10 +1120,10 @@ class QueuedTelemetryTesterBase :
     Fw::InputTlmPort m_from_tlmOut[1];
 
     //! From port connected to typedOut
-    InputTypedPort m_from_typedOut[1];
+    Ports::InputTypedPort m_from_typedOut[1];
 
     //! From port connected to typedReturnOut
-    InputTypedReturnPort m_from_typedReturnOut[1];
+    Ports::InputTypedReturnPort m_from_typedReturnOut[1];
 
   private:
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTelemetryTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTelemetryTesterBase.ref.hpp
@@ -220,31 +220,31 @@ class QueuedTelemetryTesterBase :
     //! Connect port to noArgsAsync[portNum]
     void connect_to_noArgsAsync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsPort* port //!< The input port
+        Ports::InputNoArgsPort* port //!< The input port
     );
 
     //! Connect port to noArgsGuarded[portNum]
     void connect_to_noArgsGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsPort* port //!< The input port
+        Ports::InputNoArgsPort* port //!< The input port
     );
 
     //! Connect port to noArgsReturnGuarded[portNum]
     void connect_to_noArgsReturnGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsReturnPort* port //!< The input port
+        Ports::InputNoArgsReturnPort* port //!< The input port
     );
 
     //! Connect port to noArgsReturnSync[portNum]
     void connect_to_noArgsReturnSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsReturnPort* port //!< The input port
+        Ports::InputNoArgsReturnPort* port //!< The input port
     );
 
     //! Connect port to noArgsSync[portNum]
     void connect_to_noArgsSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsPort* port //!< The input port
+        Ports::InputNoArgsPort* port //!< The input port
     );
 
     //! Connect port to typedAsync[portNum]
@@ -1047,19 +1047,19 @@ class QueuedTelemetryTesterBase :
     Fw::OutputCmdPort m_to_cmdIn[1];
 
     //! To port connected to noArgsAsync
-    OutputNoArgsPort m_to_noArgsAsync[1];
+    Ports::OutputNoArgsPort m_to_noArgsAsync[1];
 
     //! To port connected to noArgsGuarded
-    OutputNoArgsPort m_to_noArgsGuarded[1];
+    Ports::OutputNoArgsPort m_to_noArgsGuarded[1];
 
     //! To port connected to noArgsReturnGuarded
-    OutputNoArgsReturnPort m_to_noArgsReturnGuarded[1];
+    Ports::OutputNoArgsReturnPort m_to_noArgsReturnGuarded[1];
 
     //! To port connected to noArgsReturnSync
-    OutputNoArgsReturnPort m_to_noArgsReturnSync[3];
+    Ports::OutputNoArgsReturnPort m_to_noArgsReturnSync[3];
 
     //! To port connected to noArgsSync
-    OutputNoArgsPort m_to_noArgsSync[3];
+    Ports::OutputNoArgsPort m_to_noArgsSync[3];
 
     //! To port connected to typedAsync
     OutputTypedPort m_to_typedAsync[1];

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestComponentAc.ref.cpp
@@ -35,11 +35,11 @@ namespace {
 
   // Get the max size by doing a union of the input and internal port serialization sizes
   union BuffUnion {
-    BYTE noArgsAsyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsGuardedPortSize[InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnGuardedPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsReturnSyncPortSize[InputNoArgsReturnPort::SERIALIZED_SIZE];
-    BYTE noArgsSyncPortSize[InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsAsyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsGuardedPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
+    BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
     BYTE typedAsyncPortSize[InputTypedPort::SERIALIZED_SIZE];
     BYTE typedAsyncAssertPortSize[InputTypedPort::SERIALIZED_SIZE];
     BYTE typedAsyncBlockPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
@@ -729,7 +729,7 @@ Fw::InputCmdPort* QueuedTestComponentBase ::
 // Getters for typed input ports
 // ----------------------------------------------------------------------
 
-InputNoArgsPort* QueuedTestComponentBase ::
+Ports::InputNoArgsPort* QueuedTestComponentBase ::
   get_noArgsAsync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -740,7 +740,7 @@ InputNoArgsPort* QueuedTestComponentBase ::
   return &this->m_noArgsAsync_InputPort[portNum];
 }
 
-InputNoArgsPort* QueuedTestComponentBase ::
+Ports::InputNoArgsPort* QueuedTestComponentBase ::
   get_noArgsGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -751,7 +751,7 @@ InputNoArgsPort* QueuedTestComponentBase ::
   return &this->m_noArgsGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* QueuedTestComponentBase ::
+Ports::InputNoArgsReturnPort* QueuedTestComponentBase ::
   get_noArgsReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -762,7 +762,7 @@ InputNoArgsReturnPort* QueuedTestComponentBase ::
   return &this->m_noArgsReturnGuarded_InputPort[portNum];
 }
 
-InputNoArgsReturnPort* QueuedTestComponentBase ::
+Ports::InputNoArgsReturnPort* QueuedTestComponentBase ::
   get_noArgsReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -773,7 +773,7 @@ InputNoArgsReturnPort* QueuedTestComponentBase ::
   return &this->m_noArgsReturnSync_InputPort[portNum];
 }
 
-InputNoArgsPort* QueuedTestComponentBase ::
+Ports::InputNoArgsPort* QueuedTestComponentBase ::
   get_noArgsSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestComponentAc.ref.cpp
@@ -40,14 +40,14 @@ namespace {
     BYTE noArgsReturnGuardedPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
     BYTE noArgsReturnSyncPortSize[Ports::InputNoArgsReturnPort::SERIALIZED_SIZE];
     BYTE noArgsSyncPortSize[Ports::InputNoArgsPort::SERIALIZED_SIZE];
-    BYTE typedAsyncPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncAssertPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncBlockPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedAsyncDropPriorityPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedGuardedPortSize[InputTypedPort::SERIALIZED_SIZE];
-    BYTE typedReturnGuardedPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedReturnSyncPortSize[InputTypedReturnPort::SERIALIZED_SIZE];
-    BYTE typedSyncPortSize[InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncAssertPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncBlockPriorityPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedAsyncDropPriorityPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedGuardedPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
+    BYTE typedReturnGuardedPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedReturnSyncPortSize[Ports::InputTypedReturnPort::SERIALIZED_SIZE];
+    BYTE typedSyncPortSize[Ports::InputTypedPort::SERIALIZED_SIZE];
     BYTE cmdPortSize[Fw::InputCmdPort::SERIALIZED_SIZE];
     // Size of internalArray argument list
     BYTE internalArrayIntIfSize[
@@ -784,7 +784,7 @@ Ports::InputNoArgsPort* QueuedTestComponentBase ::
   return &this->m_noArgsSync_InputPort[portNum];
 }
 
-InputTypedPort* QueuedTestComponentBase ::
+Ports::InputTypedPort* QueuedTestComponentBase ::
   get_typedAsync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -795,7 +795,7 @@ InputTypedPort* QueuedTestComponentBase ::
   return &this->m_typedAsync_InputPort[portNum];
 }
 
-InputTypedPort* QueuedTestComponentBase ::
+Ports::InputTypedPort* QueuedTestComponentBase ::
   get_typedAsyncAssert_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -806,7 +806,7 @@ InputTypedPort* QueuedTestComponentBase ::
   return &this->m_typedAsyncAssert_InputPort[portNum];
 }
 
-InputTypedPort* QueuedTestComponentBase ::
+Ports::InputTypedPort* QueuedTestComponentBase ::
   get_typedAsyncBlockPriority_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -817,7 +817,7 @@ InputTypedPort* QueuedTestComponentBase ::
   return &this->m_typedAsyncBlockPriority_InputPort[portNum];
 }
 
-InputTypedPort* QueuedTestComponentBase ::
+Ports::InputTypedPort* QueuedTestComponentBase ::
   get_typedAsyncDropPriority_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -828,7 +828,7 @@ InputTypedPort* QueuedTestComponentBase ::
   return &this->m_typedAsyncDropPriority_InputPort[portNum];
 }
 
-InputTypedPort* QueuedTestComponentBase ::
+Ports::InputTypedPort* QueuedTestComponentBase ::
   get_typedGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -839,7 +839,7 @@ InputTypedPort* QueuedTestComponentBase ::
   return &this->m_typedGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* QueuedTestComponentBase ::
+Ports::InputTypedReturnPort* QueuedTestComponentBase ::
   get_typedReturnGuarded_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -850,7 +850,7 @@ InputTypedReturnPort* QueuedTestComponentBase ::
   return &this->m_typedReturnGuarded_InputPort[portNum];
 }
 
-InputTypedReturnPort* QueuedTestComponentBase ::
+Ports::InputTypedReturnPort* QueuedTestComponentBase ::
   get_typedReturnSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -861,7 +861,7 @@ InputTypedReturnPort* QueuedTestComponentBase ::
   return &this->m_typedReturnSync_InputPort[portNum];
 }
 
-InputTypedPort* QueuedTestComponentBase ::
+Ports::InputTypedPort* QueuedTestComponentBase ::
   get_typedSync_InputPort(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -999,7 +999,7 @@ void QueuedTestComponentBase ::
 void QueuedTestComponentBase ::
   set_typedOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -1013,7 +1013,7 @@ void QueuedTestComponentBase ::
 void QueuedTestComponentBase ::
   set_typedReturnOut_OutputPort(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -1900,7 +1900,7 @@ void QueuedTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2007,7 +2007,7 @@ void QueuedTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2114,7 +2114,7 @@ void QueuedTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2221,7 +2221,7 @@ void QueuedTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2333,7 +2333,7 @@ void QueuedTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2370,7 +2370,7 @@ F32 QueuedTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2411,7 +2411,7 @@ F32 QueuedTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -2446,7 +2446,7 @@ void QueuedTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2491,7 +2491,7 @@ void QueuedTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2506,7 +2506,7 @@ void QueuedTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2521,7 +2521,7 @@ void QueuedTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2536,7 +2536,7 @@ void QueuedTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2555,7 +2555,7 @@ void QueuedTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -2582,7 +2582,7 @@ F32 QueuedTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -5157,7 +5157,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -5229,7 +5229,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -5301,7 +5301,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -5373,7 +5373,7 @@ Fw::QueuedComponentBase::MsgDispatchStatus QueuedTestComponentBase ::
       );
 
       // Deserialize argument str1
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       deserStatus = msg.deserialize(str1);
       FW_ASSERT(
         deserStatus == Fw::FW_SERIALIZE_OK,
@@ -6233,7 +6233,7 @@ void QueuedTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -6260,7 +6260,7 @@ void QueuedTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -6287,7 +6287,7 @@ void QueuedTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -6314,7 +6314,7 @@ void QueuedTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -6341,7 +6341,7 @@ void QueuedTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -6368,7 +6368,7 @@ F32 QueuedTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -6395,7 +6395,7 @@ F32 QueuedTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -6422,7 +6422,7 @@ void QueuedTestComponentBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestComponentAc.ref.hpp
@@ -243,56 +243,56 @@ class QueuedTestComponentBase :
     //! Get typed input port at index
     //!
     //! \return typedAsync[portNum]
-    InputTypedPort* get_typedAsync_InputPort(
+    Ports::InputTypedPort* get_typedAsync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncAssert[portNum]
-    InputTypedPort* get_typedAsyncAssert_InputPort(
+    Ports::InputTypedPort* get_typedAsyncAssert_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncBlockPriority[portNum]
-    InputTypedPort* get_typedAsyncBlockPriority_InputPort(
+    Ports::InputTypedPort* get_typedAsyncBlockPriority_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedAsyncDropPriority[portNum]
-    InputTypedPort* get_typedAsyncDropPriority_InputPort(
+    Ports::InputTypedPort* get_typedAsyncDropPriority_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedGuarded[portNum]
-    InputTypedPort* get_typedGuarded_InputPort(
+    Ports::InputTypedPort* get_typedGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnGuarded[portNum]
-    InputTypedReturnPort* get_typedReturnGuarded_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedReturnSync[portNum]
-    InputTypedReturnPort* get_typedReturnSync_InputPort(
+    Ports::InputTypedReturnPort* get_typedReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return typedSync[portNum]
-    InputTypedPort* get_typedSync_InputPort(
+    Ports::InputTypedPort* get_typedSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -363,13 +363,13 @@ class QueuedTestComponentBase :
     //! Connect port to typedOut[portNum]
     void set_typedOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnOut[portNum]
     void set_typedReturnOut_OutputPort(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
 #if FW_PORT_SERIALIZATION
@@ -751,7 +751,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -763,7 +763,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -775,7 +775,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -787,7 +787,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -799,7 +799,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -811,7 +811,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -823,7 +823,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -835,7 +835,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -880,7 +880,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -892,7 +892,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -904,7 +904,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -916,7 +916,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -928,7 +928,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -940,7 +940,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -952,7 +952,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -964,7 +964,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -991,7 +991,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1003,7 +1003,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1015,7 +1015,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1027,7 +1027,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1045,7 +1045,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1057,7 +1057,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1850,7 +1850,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1863,7 +1863,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1876,7 +1876,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1889,7 +1889,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1902,7 +1902,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1915,7 +1915,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1928,7 +1928,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1941,7 +1941,7 @@ class QueuedTestComponentBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -2062,28 +2062,28 @@ class QueuedTestComponentBase :
     Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedAsync
-    InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];
 
     //! Input port typedAsyncAssert
-    InputTypedPort m_typedAsyncAssert_InputPort[NUM_TYPEDASYNCASSERT_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncAssert_InputPort[NUM_TYPEDASYNCASSERT_INPUT_PORTS];
 
     //! Input port typedAsyncBlockPriority
-    InputTypedPort m_typedAsyncBlockPriority_InputPort[NUM_TYPEDASYNCBLOCKPRIORITY_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncBlockPriority_InputPort[NUM_TYPEDASYNCBLOCKPRIORITY_INPUT_PORTS];
 
     //! Input port typedAsyncDropPriority
-    InputTypedPort m_typedAsyncDropPriority_InputPort[NUM_TYPEDASYNCDROPPRIORITY_INPUT_PORTS];
+    Ports::InputTypedPort m_typedAsyncDropPriority_InputPort[NUM_TYPEDASYNCDROPPRIORITY_INPUT_PORTS];
 
     //! Input port typedGuarded
-    InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
+    Ports::InputTypedPort m_typedGuarded_InputPort[NUM_TYPEDGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnGuarded
-    InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnGuarded_InputPort[NUM_TYPEDRETURNGUARDED_INPUT_PORTS];
 
     //! Input port typedReturnSync
-    InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
+    Ports::InputTypedReturnPort m_typedReturnSync_InputPort[NUM_TYPEDRETURNSYNC_INPUT_PORTS];
 
     //! Input port typedSync
-    InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
+    Ports::InputTypedPort m_typedSync_InputPort[NUM_TYPEDSYNC_INPUT_PORTS];
 
   PRIVATE:
 
@@ -2126,10 +2126,10 @@ class QueuedTestComponentBase :
     // ----------------------------------------------------------------------
 
     //! Output port typedOut
-    OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
+    Ports::OutputTypedPort m_typedOut_OutputPort[NUM_TYPEDOUT_OUTPUT_PORTS];
 
     //! Output port typedReturnOut
-    OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
+    Ports::OutputTypedReturnPort m_typedReturnOut_OutputPort[NUM_TYPEDRETURNOUT_OUTPUT_PORTS];
 
   PRIVATE:
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestComponentAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestComponentAc.ref.hpp
@@ -208,35 +208,35 @@ class QueuedTestComponentBase :
     //! Get typed input port at index
     //!
     //! \return noArgsAsync[portNum]
-    InputNoArgsPort* get_noArgsAsync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsAsync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsGuarded[portNum]
-    InputNoArgsPort* get_noArgsGuarded_InputPort(
+    Ports::InputNoArgsPort* get_noArgsGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnGuarded[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnGuarded_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsReturnSync[portNum]
-    InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
+    Ports::InputNoArgsReturnPort* get_noArgsReturnSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get typed input port at index
     //!
     //! \return noArgsSync[portNum]
-    InputNoArgsPort* get_noArgsSync_InputPort(
+    Ports::InputNoArgsPort* get_noArgsSync_InputPort(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -2047,19 +2047,19 @@ class QueuedTestComponentBase :
     // ----------------------------------------------------------------------
 
     //! Input port noArgsAsync
-    InputNoArgsPort m_noArgsAsync_InputPort[NUM_NOARGSASYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsAsync_InputPort[NUM_NOARGSASYNC_INPUT_PORTS];
 
     //! Input port noArgsGuarded
-    InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsGuarded_InputPort[NUM_NOARGSGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnGuarded
-    InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnGuarded_InputPort[NUM_NOARGSRETURNGUARDED_INPUT_PORTS];
 
     //! Input port noArgsReturnSync
-    InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
+    Ports::InputNoArgsReturnPort m_noArgsReturnSync_InputPort[NUM_NOARGSRETURNSYNC_INPUT_PORTS];
 
     //! Input port noArgsSync
-    InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
+    Ports::InputNoArgsPort m_noArgsSync_InputPort[NUM_NOARGSSYNC_INPUT_PORTS];
 
     //! Input port typedAsync
     InputTypedPort m_typedAsync_InputPort[NUM_TYPEDASYNC_INPUT_PORTS];

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.cpp
@@ -667,7 +667,7 @@ void QueuedTestTesterBase ::
 void QueuedTestTesterBase ::
   connect_to_typedAsync(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -681,7 +681,7 @@ void QueuedTestTesterBase ::
 void QueuedTestTesterBase ::
   connect_to_typedAsyncAssert(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -695,7 +695,7 @@ void QueuedTestTesterBase ::
 void QueuedTestTesterBase ::
   connect_to_typedAsyncBlockPriority(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -709,7 +709,7 @@ void QueuedTestTesterBase ::
 void QueuedTestTesterBase ::
   connect_to_typedAsyncDropPriority(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -723,7 +723,7 @@ void QueuedTestTesterBase ::
 void QueuedTestTesterBase ::
   connect_to_typedGuarded(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -737,7 +737,7 @@ void QueuedTestTesterBase ::
 void QueuedTestTesterBase ::
   connect_to_typedReturnGuarded(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -751,7 +751,7 @@ void QueuedTestTesterBase ::
 void QueuedTestTesterBase ::
   connect_to_typedReturnSync(
       NATIVE_INT_TYPE portNum,
-      InputTypedReturnPort* port
+      Ports::InputTypedReturnPort* port
   )
 {
   FW_ASSERT(
@@ -765,7 +765,7 @@ void QueuedTestTesterBase ::
 void QueuedTestTesterBase ::
   connect_to_typedSync(
       NATIVE_INT_TYPE portNum,
-      InputTypedPort* port
+      Ports::InputTypedPort* port
   )
 {
   FW_ASSERT(
@@ -872,7 +872,7 @@ Fw::InputTlmPort* QueuedTestTesterBase ::
   return &this->m_from_tlmOut[portNum];
 }
 
-InputTypedPort* QueuedTestTesterBase ::
+Ports::InputTypedPort* QueuedTestTesterBase ::
   get_from_typedOut(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -883,7 +883,7 @@ InputTypedPort* QueuedTestTesterBase ::
   return &this->m_from_typedOut[portNum];
 }
 
-InputTypedReturnPort* QueuedTestTesterBase ::
+Ports::InputTypedReturnPort* QueuedTestTesterBase ::
   get_from_typedReturnOut(NATIVE_INT_TYPE portNum)
 {
   FW_ASSERT(
@@ -989,7 +989,7 @@ void QueuedTestTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1018,7 +1018,7 @@ F32 QueuedTestTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1106,7 +1106,7 @@ void QueuedTestTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1134,7 +1134,7 @@ void QueuedTestTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1162,7 +1162,7 @@ void QueuedTestTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1190,7 +1190,7 @@ void QueuedTestTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1218,7 +1218,7 @@ void QueuedTestTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -1246,7 +1246,7 @@ F32 QueuedTestTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1274,7 +1274,7 @@ F32 QueuedTestTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -1302,7 +1302,7 @@ void QueuedTestTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3334,7 +3334,7 @@ void QueuedTestTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3358,7 +3358,7 @@ void QueuedTestTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s
@@ -3752,7 +3752,7 @@ void QueuedTestTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -3779,7 +3779,7 @@ F32 QueuedTestTesterBase ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.cpp
@@ -597,7 +597,7 @@ void QueuedTestTesterBase ::
 void QueuedTestTesterBase ::
   connect_to_noArgsAsync(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsPort* port
+      Ports::InputNoArgsPort* port
   )
 {
   FW_ASSERT(
@@ -611,7 +611,7 @@ void QueuedTestTesterBase ::
 void QueuedTestTesterBase ::
   connect_to_noArgsGuarded(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsPort* port
+      Ports::InputNoArgsPort* port
   )
 {
   FW_ASSERT(
@@ -625,7 +625,7 @@ void QueuedTestTesterBase ::
 void QueuedTestTesterBase ::
   connect_to_noArgsReturnGuarded(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsReturnPort* port
+      Ports::InputNoArgsReturnPort* port
   )
 {
   FW_ASSERT(
@@ -639,7 +639,7 @@ void QueuedTestTesterBase ::
 void QueuedTestTesterBase ::
   connect_to_noArgsReturnSync(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsReturnPort* port
+      Ports::InputNoArgsReturnPort* port
   )
 {
   FW_ASSERT(
@@ -653,7 +653,7 @@ void QueuedTestTesterBase ::
 void QueuedTestTesterBase ::
   connect_to_noArgsSync(
       NATIVE_INT_TYPE portNum,
-      InputNoArgsPort* port
+      Ports::InputNoArgsPort* port
   )
 {
   FW_ASSERT(

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.hpp
@@ -111,7 +111,7 @@ class QueuedTestTesterBase :
       U32 u32;
       F32 f32;
       bool b;
-      TypedPortStrings::StringSize80 str1;
+      Ports::TypedPortStrings::StringSize80 str1;
       E e;
       A a;
       S s;
@@ -122,7 +122,7 @@ class QueuedTestTesterBase :
       U32 u32;
       F32 f32;
       bool b;
-      TypedReturnPortStrings::StringSize80 str2;
+      Ports::TypedReturnPortStrings::StringSize80 str2;
       E e;
       A a;
       S s;
@@ -297,49 +297,49 @@ class QueuedTestTesterBase :
     //! Connect port to typedAsync[portNum]
     void connect_to_typedAsync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedAsyncAssert[portNum]
     void connect_to_typedAsyncAssert(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedAsyncBlockPriority[portNum]
     void connect_to_typedAsyncBlockPriority(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedAsyncDropPriority[portNum]
     void connect_to_typedAsyncDropPriority(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedGuarded[portNum]
     void connect_to_typedGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
     //! Connect port to typedReturnGuarded[portNum]
     void connect_to_typedReturnGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
     //! Connect port to typedReturnSync[portNum]
     void connect_to_typedReturnSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedReturnPort* port //!< The input port
+        Ports::InputTypedReturnPort* port //!< The input port
     );
 
     //! Connect port to typedSync[portNum]
     void connect_to_typedSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputTypedPort* port //!< The input port
+        Ports::InputTypedPort* port //!< The input port
     );
 
   public:
@@ -411,14 +411,14 @@ class QueuedTestTesterBase :
     //! Get from port at index
     //!
     //! \return from_typedOut[portNum]
-    InputTypedPort* get_from_typedOut(
+    Ports::InputTypedPort* get_from_typedOut(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
     //! Get from port at index
     //!
     //! \return from_typedReturnOut[portNum]
-    InputTypedReturnPort* get_from_typedReturnOut(
+    Ports::InputTypedReturnPort* get_from_typedReturnOut(
         NATIVE_INT_TYPE portNum //!< The port number
     );
 
@@ -449,7 +449,7 @@ class QueuedTestTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -461,7 +461,7 @@ class QueuedTestTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -479,7 +479,7 @@ class QueuedTestTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -491,7 +491,7 @@ class QueuedTestTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -534,7 +534,7 @@ class QueuedTestTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -546,7 +546,7 @@ class QueuedTestTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -558,7 +558,7 @@ class QueuedTestTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -570,7 +570,7 @@ class QueuedTestTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -582,7 +582,7 @@ class QueuedTestTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -594,7 +594,7 @@ class QueuedTestTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -606,7 +606,7 @@ class QueuedTestTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -618,7 +618,7 @@ class QueuedTestTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1279,7 +1279,7 @@ class QueuedTestTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1290,7 +1290,7 @@ class QueuedTestTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1400,7 +1400,7 @@ class QueuedTestTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1413,7 +1413,7 @@ class QueuedTestTesterBase :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -1529,28 +1529,28 @@ class QueuedTestTesterBase :
     Ports::OutputNoArgsPort m_to_noArgsSync[3];
 
     //! To port connected to typedAsync
-    OutputTypedPort m_to_typedAsync[1];
+    Ports::OutputTypedPort m_to_typedAsync[1];
 
     //! To port connected to typedAsyncAssert
-    OutputTypedPort m_to_typedAsyncAssert[1];
+    Ports::OutputTypedPort m_to_typedAsyncAssert[1];
 
     //! To port connected to typedAsyncBlockPriority
-    OutputTypedPort m_to_typedAsyncBlockPriority[1];
+    Ports::OutputTypedPort m_to_typedAsyncBlockPriority[1];
 
     //! To port connected to typedAsyncDropPriority
-    OutputTypedPort m_to_typedAsyncDropPriority[1];
+    Ports::OutputTypedPort m_to_typedAsyncDropPriority[1];
 
     //! To port connected to typedGuarded
-    OutputTypedPort m_to_typedGuarded[1];
+    Ports::OutputTypedPort m_to_typedGuarded[1];
 
     //! To port connected to typedReturnGuarded
-    OutputTypedReturnPort m_to_typedReturnGuarded[1];
+    Ports::OutputTypedReturnPort m_to_typedReturnGuarded[1];
 
     //! To port connected to typedReturnSync
-    OutputTypedReturnPort m_to_typedReturnSync[3];
+    Ports::OutputTypedReturnPort m_to_typedReturnSync[3];
 
     //! To port connected to typedSync
-    OutputTypedPort m_to_typedSync[3];
+    Ports::OutputTypedPort m_to_typedSync[3];
 
   private:
 
@@ -1587,10 +1587,10 @@ class QueuedTestTesterBase :
     Fw::InputTlmPort m_from_tlmOut[1];
 
     //! From port connected to typedOut
-    InputTypedPort m_from_typedOut[1];
+    Ports::InputTypedPort m_from_typedOut[1];
 
     //! From port connected to typedReturnOut
-    InputTypedReturnPort m_from_typedReturnOut[1];
+    Ports::InputTypedReturnPort m_from_typedReturnOut[1];
 
   private:
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.hpp
@@ -267,31 +267,31 @@ class QueuedTestTesterBase :
     //! Connect port to noArgsAsync[portNum]
     void connect_to_noArgsAsync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsPort* port //!< The input port
+        Ports::InputNoArgsPort* port //!< The input port
     );
 
     //! Connect port to noArgsGuarded[portNum]
     void connect_to_noArgsGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsPort* port //!< The input port
+        Ports::InputNoArgsPort* port //!< The input port
     );
 
     //! Connect port to noArgsReturnGuarded[portNum]
     void connect_to_noArgsReturnGuarded(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsReturnPort* port //!< The input port
+        Ports::InputNoArgsReturnPort* port //!< The input port
     );
 
     //! Connect port to noArgsReturnSync[portNum]
     void connect_to_noArgsReturnSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsReturnPort* port //!< The input port
+        Ports::InputNoArgsReturnPort* port //!< The input port
     );
 
     //! Connect port to noArgsSync[portNum]
     void connect_to_noArgsSync(
         NATIVE_INT_TYPE portNum, //!< The port number
-        InputNoArgsPort* port //!< The input port
+        Ports::InputNoArgsPort* port //!< The input port
     );
 
     //! Connect port to typedAsync[portNum]
@@ -1514,19 +1514,19 @@ class QueuedTestTesterBase :
     Fw::OutputCmdPort m_to_cmdIn[1];
 
     //! To port connected to noArgsAsync
-    OutputNoArgsPort m_to_noArgsAsync[1];
+    Ports::OutputNoArgsPort m_to_noArgsAsync[1];
 
     //! To port connected to noArgsGuarded
-    OutputNoArgsPort m_to_noArgsGuarded[1];
+    Ports::OutputNoArgsPort m_to_noArgsGuarded[1];
 
     //! To port connected to noArgsReturnGuarded
-    OutputNoArgsReturnPort m_to_noArgsReturnGuarded[1];
+    Ports::OutputNoArgsReturnPort m_to_noArgsReturnGuarded[1];
 
     //! To port connected to noArgsReturnSync
-    OutputNoArgsReturnPort m_to_noArgsReturnSync[3];
+    Ports::OutputNoArgsReturnPort m_to_noArgsReturnSync[3];
 
     //! To port connected to noArgsSync
-    OutputNoArgsPort m_to_noArgsSync[3];
+    Ports::OutputNoArgsPort m_to_noArgsSync[3];
 
     //! To port connected to typedAsync
     OutputTypedPort m_to_typedAsync[1];

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/TypedPortAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/TypedPortAc.ref.cpp
@@ -8,317 +8,321 @@
 #include "Fw/Types/StringUtils.hpp"
 #include "test-base/TypedPortAc.hpp"
 
-namespace TypedPortStrings {
+namespace Ports {
 
-  // ----------------------------------------------------------------------
-  // StringSize80 class
-  // ----------------------------------------------------------------------
+  namespace TypedPortStrings {
 
-  StringSize80 ::
-    StringSize80() :
-      StringBase()
-  {
-    this->m_buf[0] = 0;
-  }
+    // ----------------------------------------------------------------------
+    // StringSize80 class
+    // ----------------------------------------------------------------------
 
-  StringSize80 ::
-    StringSize80(const char* src) :
-      StringBase()
-  {
-    Fw::StringUtils::string_copy(this->m_buf, src, sizeof(this->m_buf));
-  }
+    StringSize80 ::
+      StringSize80() :
+        StringBase()
+    {
+      this->m_buf[0] = 0;
+    }
 
-  StringSize80 ::
-    StringSize80(const Fw::StringBase& src) :
-      StringBase()
-  {
-    Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
-  }
+    StringSize80 ::
+      StringSize80(const char* src) :
+        StringBase()
+    {
+      Fw::StringUtils::string_copy(this->m_buf, src, sizeof(this->m_buf));
+    }
 
-  StringSize80 ::
-    StringSize80(const StringSize80& src) :
-      StringBase()
-  {
-    Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
-  }
+    StringSize80 ::
+      StringSize80(const Fw::StringBase& src) :
+        StringBase()
+    {
+      Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
+    }
 
-  StringSize80 ::
-    ~StringSize80()
-  {
+    StringSize80 ::
+      StringSize80(const StringSize80& src) :
+        StringBase()
+    {
+      Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
+    }
 
-  }
+    StringSize80 ::
+      ~StringSize80()
+    {
 
-  StringSize80& StringSize80 ::
-    operator=(const StringSize80& other)
-  {
-    if (this == &other) {
+    }
+
+    StringSize80& StringSize80 ::
+      operator=(const StringSize80& other)
+    {
+      if (this == &other) {
+        return *this;
+      }
+
+      Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
       return *this;
     }
 
-    Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
-    return *this;
-  }
+    StringSize80& StringSize80 ::
+      operator=(const Fw::StringBase& other)
+    {
+      if (this == &other) {
+        return *this;
+      }
 
-  StringSize80& StringSize80 ::
-    operator=(const Fw::StringBase& other)
-  {
-    if (this == &other) {
+      Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
       return *this;
     }
 
-    Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
-    return *this;
+    StringSize80& StringSize80 ::
+      operator=(const char* other)
+    {
+      Fw::StringUtils::string_copy(this->m_buf, other, sizeof(this->m_buf));
+      return *this;
+    }
+
+    const char* StringSize80 ::
+      toChar() const
+    {
+      return this->m_buf;
+    }
+
+    NATIVE_UINT_TYPE StringSize80 ::
+      getCapacity() const
+    {
+      return sizeof(this->m_buf);
+    }
+
   }
 
-  StringSize80& StringSize80 ::
-    operator=(const char* other)
-  {
-    Fw::StringUtils::string_copy(this->m_buf, other, sizeof(this->m_buf));
-    return *this;
+  namespace {
+
+    // ----------------------------------------------------------------------
+    // Port buffer class
+    // ----------------------------------------------------------------------
+
+    class TypedPortBuffer : public Fw::SerializeBufferBase {
+
+      public:
+
+        NATIVE_UINT_TYPE getBuffCapacity() const {
+          return InputTypedPort::SERIALIZED_SIZE;
+        }
+
+        U8* getBuffAddr() {
+          return m_buff;
+        }
+
+        const U8* getBuffAddr() const {
+          return m_buff;
+        }
+
+      private:
+
+        U8 m_buff[InputTypedPort::SERIALIZED_SIZE];
+
+    };
+
   }
-
-  const char* StringSize80 ::
-    toChar() const
-  {
-    return this->m_buf;
-  }
-
-  NATIVE_UINT_TYPE StringSize80 ::
-    getCapacity() const
-  {
-    return sizeof(this->m_buf);
-  }
-
-}
-
-namespace {
 
   // ----------------------------------------------------------------------
-  // Port buffer class
+  // Input Port Member functions
   // ----------------------------------------------------------------------
 
-  class TypedPortBuffer : public Fw::SerializeBufferBase {
+  InputTypedPort ::
+    InputTypedPort() :
+      Fw::InputPortBase(),
+      m_func(nullptr)
+  {
 
-    public:
+  }
 
-      NATIVE_UINT_TYPE getBuffCapacity() const {
-        return InputTypedPort::SERIALIZED_SIZE;
-      }
+  void InputTypedPort ::
+    init()
+  {
+    Fw::InputPortBase::init();
+  }
 
-      U8* getBuffAddr() {
-        return m_buff;
-      }
+  void InputTypedPort ::
+    addCallComp(
+        Fw::PassiveComponentBase* callComp,
+        CompFuncPtr funcPtr
+    )
+  {
+    FW_ASSERT(callComp != nullptr);
+    FW_ASSERT(funcPtr != nullptr);
 
-      const U8* getBuffAddr() const {
-        return m_buff;
-      }
+    this->m_comp = callComp;
+    this->m_func = funcPtr;
+    this->m_connObj = callComp;
+  }
 
-    private:
-
-      U8 m_buff[InputTypedPort::SERIALIZED_SIZE];
-
-  };
-
-}
-
-// ----------------------------------------------------------------------
-// Input Port Member functions
-// ----------------------------------------------------------------------
-
-InputTypedPort ::
-  InputTypedPort() :
-    Fw::InputPortBase(),
-    m_func(nullptr)
-{
-
-}
-
-void InputTypedPort ::
-  init()
-{
-  Fw::InputPortBase::init();
-}
-
-void InputTypedPort ::
-  addCallComp(
-      Fw::PassiveComponentBase* callComp,
-      CompFuncPtr funcPtr
-  )
-{
-  FW_ASSERT(callComp != nullptr);
-  FW_ASSERT(funcPtr != nullptr);
-
-  this->m_comp = callComp;
-  this->m_func = funcPtr;
-  this->m_connObj = callComp;
-}
-
-void InputTypedPort ::
-  invoke(
-      U32 u32,
-      F32 f32,
-      bool b,
-      const TypedPortStrings::StringSize80& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
+  void InputTypedPort ::
+    invoke(
+        U32 u32,
+        F32 f32,
+        bool b,
+        const TypedPortStrings::StringSize80& str1,
+        const E& e,
+        const A& a,
+        const S& s
+    )
+  {
 #if FW_PORT_TRACING == 1
-  this->trace();
+    this->trace();
 #endif
 
-  FW_ASSERT(this->m_comp != nullptr);
-  FW_ASSERT(this->m_func != nullptr);
+    FW_ASSERT(this->m_comp != nullptr);
+    FW_ASSERT(this->m_func != nullptr);
 
-  return this->m_func(this->m_comp, this->m_portNum, u32, f32, b, str1, e, a, s);
-}
+    return this->m_func(this->m_comp, this->m_portNum, u32, f32, b, str1, e, a, s);
+  }
 
 #if FW_PORT_SERIALIZATION == 1
 
-Fw::SerializeStatus InputTypedPort ::
-  invokeSerial(Fw::SerializeBufferBase& _buffer)
-{
-  Fw::SerializeStatus _status;
+  Fw::SerializeStatus InputTypedPort ::
+    invokeSerial(Fw::SerializeBufferBase& _buffer)
+  {
+    Fw::SerializeStatus _status;
 
 #if FW_PORT_TRACING == 1
-  this->trace();
+    this->trace();
 #endif
 
-  FW_ASSERT(this->m_comp != nullptr);
-  FW_ASSERT(this->m_func != nullptr);
+    FW_ASSERT(this->m_comp != nullptr);
+    FW_ASSERT(this->m_func != nullptr);
 
-  U32 u32;
-  _status = _buffer.deserialize(u32);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    return _status;
+    U32 u32;
+    _status = _buffer.deserialize(u32);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+      return _status;
+    }
+
+    F32 f32;
+    _status = _buffer.deserialize(f32);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+      return _status;
+    }
+
+    bool b;
+    _status = _buffer.deserialize(b);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+      return _status;
+    }
+
+    TypedPortStrings::StringSize80 str1;
+    _status = _buffer.deserialize(str1);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+      return _status;
+    }
+
+    E e;
+    _status = _buffer.deserialize(e);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+      return _status;
+    }
+
+    A a;
+    _status = _buffer.deserialize(a);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+      return _status;
+    }
+
+    S s;
+    _status = _buffer.deserialize(s);
+    if (_status != Fw::FW_SERIALIZE_OK) {
+      return _status;
+    }
+
+    this->m_func(this->m_comp, this->m_portNum, u32, f32, b, str1, e, a, s);
+
+    return Fw::FW_SERIALIZE_OK;
   }
-
-  F32 f32;
-  _status = _buffer.deserialize(f32);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    return _status;
-  }
-
-  bool b;
-  _status = _buffer.deserialize(b);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    return _status;
-  }
-
-  TypedPortStrings::StringSize80 str1;
-  _status = _buffer.deserialize(str1);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    return _status;
-  }
-
-  E e;
-  _status = _buffer.deserialize(e);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    return _status;
-  }
-
-  A a;
-  _status = _buffer.deserialize(a);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    return _status;
-  }
-
-  S s;
-  _status = _buffer.deserialize(s);
-  if (_status != Fw::FW_SERIALIZE_OK) {
-    return _status;
-  }
-
-  this->m_func(this->m_comp, this->m_portNum, u32, f32, b, str1, e, a, s);
-
-  return Fw::FW_SERIALIZE_OK;
-}
 
 #endif
 
-// ----------------------------------------------------------------------
-// Output Port Member functions
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Output Port Member functions
+  // ----------------------------------------------------------------------
 
-OutputTypedPort ::
-  OutputTypedPort() :
-    Fw::OutputPortBase(),
-    m_port(nullptr)
-{
+  OutputTypedPort ::
+    OutputTypedPort() :
+      Fw::OutputPortBase(),
+      m_port(nullptr)
+  {
 
-}
+  }
 
-void OutputTypedPort ::
-  init()
-{
-  Fw::OutputPortBase::init();
-}
+  void OutputTypedPort ::
+    init()
+  {
+    Fw::OutputPortBase::init();
+  }
 
-void OutputTypedPort ::
-  addCallPort(InputTypedPort* callPort)
-{
-  FW_ASSERT(callPort != nullptr);
+  void OutputTypedPort ::
+    addCallPort(InputTypedPort* callPort)
+  {
+    FW_ASSERT(callPort != nullptr);
 
-  this->m_port = callPort;
-  this->m_connObj = callPort;
+    this->m_port = callPort;
+    this->m_connObj = callPort;
 
 #if FW_PORT_SERIALIZATION == 1
-  this->m_serPort = nullptr;
+    this->m_serPort = nullptr;
 #endif
-}
+  }
 
-void OutputTypedPort ::
-  invoke(
-      U32 u32,
-      F32 f32,
-      bool b,
-      const TypedPortStrings::StringSize80& str1,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
+  void OutputTypedPort ::
+    invoke(
+        U32 u32,
+        F32 f32,
+        bool b,
+        const TypedPortStrings::StringSize80& str1,
+        const E& e,
+        const A& a,
+        const S& s
+    )
+  {
 #if FW_PORT_TRACING == 1
-  this->trace();
+    this->trace();
 #endif
 
 #if FW_PORT_SERIALIZATION
-  FW_ASSERT((this->m_port != nullptr) || (this->m_serPort != nullptr));
+    FW_ASSERT((this->m_port != nullptr) || (this->m_serPort != nullptr));
 
-  if (this->m_port != nullptr) {
-    this->m_port->invoke(u32, f32, b, str1, e, a, s);
-  }
-  else {
-    Fw::SerializeStatus _status;
-    TypedPortBuffer _buffer;
+    if (this->m_port != nullptr) {
+      this->m_port->invoke(u32, f32, b, str1, e, a, s);
+    }
+    else {
+      Fw::SerializeStatus _status;
+      TypedPortBuffer _buffer;
 
-    _status = _buffer.serialize(u32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+      _status = _buffer.serialize(u32);
+      FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-    _status = _buffer.serialize(f32);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+      _status = _buffer.serialize(f32);
+      FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-    _status = _buffer.serialize(b);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+      _status = _buffer.serialize(b);
+      FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-    _status = _buffer.serialize(str1);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+      _status = _buffer.serialize(str1);
+      FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-    _status = _buffer.serialize(e);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+      _status = _buffer.serialize(e);
+      FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-    _status = _buffer.serialize(a);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+      _status = _buffer.serialize(a);
+      FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-    _status = _buffer.serialize(s);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+      _status = _buffer.serialize(s);
+      FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
 
-    _status = this->m_serPort->invokeSerial(_buffer);
-    FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
-  }
+      _status = this->m_serPort->invokeSerial(_buffer);
+      FW_ASSERT(_status == Fw::FW_SERIALIZE_OK, static_cast<FwAssertArgType>(_status));
+    }
 #else
-  FW_ASSERT(this->m_port != nullptr);
-  this->m_port->invoke(u32, f32, b, str1, e, a, s);
+    FW_ASSERT(this->m_port != nullptr);
+    this->m_port->invoke(u32, f32, b, str1, e, a, s);
 #endif
+  }
+
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/TypedPortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/TypedPortAc.ref.hpp
@@ -4,8 +4,8 @@
 // \brief  hpp file for Typed port
 // ======================================================================
 
-#ifndef TypedPortAc_HPP
-#define TypedPortAc_HPP
+#ifndef Ports_TypedPortAc_HPP
+#define Ports_TypedPortAc_HPP
 
 #include <cstdio>
 #include <cstring>
@@ -20,201 +20,205 @@
 #include "Fw/Types/StringType.hpp"
 #include "SSerializableAc.hpp"
 
-namespace TypedPortStrings {
+namespace Ports {
+
+  namespace TypedPortStrings {
+
+    // ----------------------------------------------------------------------
+    // StringSize80 class
+    // ----------------------------------------------------------------------
+
+    class StringSize80 :
+      public Fw::StringBase
+    {
+
+      public:
+
+        enum {
+          //! The size of the string length plus the size of the string buffer
+          SERIALIZED_SIZE = sizeof(FwBuffSizeType) + 80
+        };
+
+        //! Default constructor
+        StringSize80();
+
+        //! Char array constructor
+        StringSize80(const char* src);
+
+        //! String base constructor
+        StringSize80(const Fw::StringBase& src);
+
+        //! Copy constructor
+        StringSize80(const StringSize80& src);
+
+        //! Destructor
+        ~StringSize80();
+
+        //! Copy assignment operator
+        StringSize80& operator=(const StringSize80& other);
+
+        //! String base assignment operator
+        StringSize80& operator=(const Fw::StringBase& other);
+
+        //! char* assignment operator
+        StringSize80& operator=(const char* other);
+
+        //! Retrieves char buffer of string
+        const char* toChar() const;
+
+        NATIVE_UINT_TYPE getCapacity() const;
+
+      private:
+
+        char m_buf[80]; //!< Buffer for string storage
+
+    };
+
+  }
 
   // ----------------------------------------------------------------------
-  // StringSize80 class
+  // String types for backwards compatibility
   // ----------------------------------------------------------------------
 
-  class StringSize80 :
-    public Fw::StringBase
+  typedef TypedPortStrings::StringSize80 str1String;
+
+  //! Input Typed port
+  //! A typed port
+  class InputTypedPort :
+    public Fw::InputPortBase
   {
 
     public:
 
+      // ----------------------------------------------------------------------
+      // Constants
+      // ----------------------------------------------------------------------
+
       enum {
-        //! The size of the string length plus the size of the string buffer
-        SERIALIZED_SIZE = sizeof(FwBuffSizeType) + 80
+        //! The size of the serial representations of the port arguments
+        SERIALIZED_SIZE =
+          sizeof(U32) +
+          sizeof(F32) +
+          sizeof(U8) +
+          TypedPortStrings::StringSize80::SERIALIZED_SIZE +
+          E::SERIALIZED_SIZE +
+          A::SERIALIZED_SIZE +
+          S::SERIALIZED_SIZE
       };
 
-      //! Default constructor
-      StringSize80();
+    public:
 
-      //! Char array constructor
-      StringSize80(const char* src);
+      // ----------------------------------------------------------------------
+      // Types
+      // ----------------------------------------------------------------------
 
-      //! String base constructor
-      StringSize80(const Fw::StringBase& src);
+      //! The port callback function type
+      typedef void (*CompFuncPtr)(
+        Fw::PassiveComponentBase* callComp,
+        NATIVE_INT_TYPE portNum,
+        U32 u32,
+        F32 f32,
+        bool b,
+        const TypedPortStrings::StringSize80& str1,
+        const E& e,
+        const A& a,
+        const S& s
+      );
 
-      //! Copy constructor
-      StringSize80(const StringSize80& src);
+    public:
 
-      //! Destructor
-      ~StringSize80();
+      // ----------------------------------------------------------------------
+      // Input Port Member functions
+      // ----------------------------------------------------------------------
 
-      //! Copy assignment operator
-      StringSize80& operator=(const StringSize80& other);
+      //! Constructor
+      InputTypedPort();
 
-      //! String base assignment operator
-      StringSize80& operator=(const Fw::StringBase& other);
+      //! Initialization function
+      void init();
 
-      //! char* assignment operator
-      StringSize80& operator=(const char* other);
+      //! Register a component
+      void addCallComp(
+          Fw::PassiveComponentBase* callComp, //!< The containing component
+          CompFuncPtr funcPtr //!< The port callback function
+      );
 
-      //! Retrieves char buffer of string
-      const char* toChar() const;
-
-      NATIVE_UINT_TYPE getCapacity() const;
+      //! Invoke a port interface
+      void invoke(
+          U32 u32, //!< A U32
+          F32 f32, //!< An F32
+          bool b, //!< A boolean
+          const TypedPortStrings::StringSize80& str1, //!< A string
+          const E& e, //!< An enum
+          const A& a, //!< An array
+          const S& s //!< A struct
+      );
 
     private:
 
-      char m_buf[80]; //!< Buffer for string storage
+#if FW_PORT_SERIALIZATION == 1
+
+      //! Invoke the port with serialized arguments
+      Fw::SerializeStatus invokeSerial(Fw::SerializeBufferBase& _buffer);
+
+#endif
+
+    private:
+
+      // ----------------------------------------------------------------------
+      // Member variables
+      // ----------------------------------------------------------------------
+
+      //! The pointer to the port callback function
+      CompFuncPtr m_func;
+
+  };
+
+  //! Output Typed port
+  //! A typed port
+  class OutputTypedPort :
+    public Fw::OutputPortBase
+  {
+
+    public:
+
+      // ----------------------------------------------------------------------
+      // Output Port Member functions
+      // ----------------------------------------------------------------------
+
+      //! Constructor
+      OutputTypedPort();
+
+      //! Initialization function
+      void init();
+
+      //! Register an input port
+      void addCallPort(
+          InputTypedPort* callPort //!< The input port
+      );
+
+      //! Invoke a port interface
+      void invoke(
+          U32 u32, //!< A U32
+          F32 f32, //!< An F32
+          bool b, //!< A boolean
+          const TypedPortStrings::StringSize80& str1, //!< A string
+          const E& e, //!< An enum
+          const A& a, //!< An array
+          const S& s //!< A struct
+      );
+
+    private:
+
+      // ----------------------------------------------------------------------
+      // Member variables
+      // ----------------------------------------------------------------------
+
+      //! The pointer to the input port
+      InputTypedPort* m_port;
 
   };
 
 }
-
-// ----------------------------------------------------------------------
-// String types for backwards compatibility
-// ----------------------------------------------------------------------
-
-typedef TypedPortStrings::StringSize80 str1String;
-
-//! Input Typed port
-//! A typed port
-class InputTypedPort :
-  public Fw::InputPortBase
-{
-
-  public:
-
-    // ----------------------------------------------------------------------
-    // Constants
-    // ----------------------------------------------------------------------
-
-    enum {
-      //! The size of the serial representations of the port arguments
-      SERIALIZED_SIZE =
-        sizeof(U32) +
-        sizeof(F32) +
-        sizeof(U8) +
-        TypedPortStrings::StringSize80::SERIALIZED_SIZE +
-        E::SERIALIZED_SIZE +
-        A::SERIALIZED_SIZE +
-        S::SERIALIZED_SIZE
-    };
-
-  public:
-
-    // ----------------------------------------------------------------------
-    // Types
-    // ----------------------------------------------------------------------
-
-    //! The port callback function type
-    typedef void (*CompFuncPtr)(
-      Fw::PassiveComponentBase* callComp,
-      NATIVE_INT_TYPE portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const TypedPortStrings::StringSize80& str1,
-      const E& e,
-      const A& a,
-      const S& s
-    );
-
-  public:
-
-    // ----------------------------------------------------------------------
-    // Input Port Member functions
-    // ----------------------------------------------------------------------
-
-    //! Constructor
-    InputTypedPort();
-
-    //! Initialization function
-    void init();
-
-    //! Register a component
-    void addCallComp(
-        Fw::PassiveComponentBase* callComp, //!< The containing component
-        CompFuncPtr funcPtr //!< The port callback function
-    );
-
-    //! Invoke a port interface
-    void invoke(
-        U32 u32, //!< A U32
-        F32 f32, //!< An F32
-        bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
-        const E& e, //!< An enum
-        const A& a, //!< An array
-        const S& s //!< A struct
-    );
-
-  private:
-
-#if FW_PORT_SERIALIZATION == 1
-
-    //! Invoke the port with serialized arguments
-    Fw::SerializeStatus invokeSerial(Fw::SerializeBufferBase& _buffer);
-
-#endif
-
-  private:
-
-    // ----------------------------------------------------------------------
-    // Member variables
-    // ----------------------------------------------------------------------
-
-    //! The pointer to the port callback function
-    CompFuncPtr m_func;
-
-};
-
-//! Output Typed port
-//! A typed port
-class OutputTypedPort :
-  public Fw::OutputPortBase
-{
-
-  public:
-
-    // ----------------------------------------------------------------------
-    // Output Port Member functions
-    // ----------------------------------------------------------------------
-
-    //! Constructor
-    OutputTypedPort();
-
-    //! Initialization function
-    void init();
-
-    //! Register an input port
-    void addCallPort(
-        InputTypedPort* callPort //!< The input port
-    );
-
-    //! Invoke a port interface
-    void invoke(
-        U32 u32, //!< A U32
-        F32 f32, //!< An F32
-        bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
-        const E& e, //!< An enum
-        const A& a, //!< An array
-        const S& s //!< A struct
-    );
-
-  private:
-
-    // ----------------------------------------------------------------------
-    // Member variables
-    // ----------------------------------------------------------------------
-
-    //! The pointer to the input port
-    InputTypedPort* m_port;
-
-};
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/TypedReturnPortAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/TypedReturnPortAc.ref.cpp
@@ -8,202 +8,206 @@
 #include "Fw/Types/StringUtils.hpp"
 #include "test-base/TypedReturnPortAc.hpp"
 
-namespace TypedReturnPortStrings {
+namespace Ports {
 
-  // ----------------------------------------------------------------------
-  // StringSize80 class
-  // ----------------------------------------------------------------------
+  namespace TypedReturnPortStrings {
 
-  StringSize80 ::
-    StringSize80() :
-      StringBase()
-  {
-    this->m_buf[0] = 0;
-  }
+    // ----------------------------------------------------------------------
+    // StringSize80 class
+    // ----------------------------------------------------------------------
 
-  StringSize80 ::
-    StringSize80(const char* src) :
-      StringBase()
-  {
-    Fw::StringUtils::string_copy(this->m_buf, src, sizeof(this->m_buf));
-  }
+    StringSize80 ::
+      StringSize80() :
+        StringBase()
+    {
+      this->m_buf[0] = 0;
+    }
 
-  StringSize80 ::
-    StringSize80(const Fw::StringBase& src) :
-      StringBase()
-  {
-    Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
-  }
+    StringSize80 ::
+      StringSize80(const char* src) :
+        StringBase()
+    {
+      Fw::StringUtils::string_copy(this->m_buf, src, sizeof(this->m_buf));
+    }
 
-  StringSize80 ::
-    StringSize80(const StringSize80& src) :
-      StringBase()
-  {
-    Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
-  }
+    StringSize80 ::
+      StringSize80(const Fw::StringBase& src) :
+        StringBase()
+    {
+      Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
+    }
 
-  StringSize80 ::
-    ~StringSize80()
-  {
+    StringSize80 ::
+      StringSize80(const StringSize80& src) :
+        StringBase()
+    {
+      Fw::StringUtils::string_copy(this->m_buf, src.toChar(), sizeof(this->m_buf));
+    }
 
-  }
+    StringSize80 ::
+      ~StringSize80()
+    {
 
-  StringSize80& StringSize80 ::
-    operator=(const StringSize80& other)
-  {
-    if (this == &other) {
+    }
+
+    StringSize80& StringSize80 ::
+      operator=(const StringSize80& other)
+    {
+      if (this == &other) {
+        return *this;
+      }
+
+      Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
       return *this;
     }
 
-    Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
-    return *this;
-  }
+    StringSize80& StringSize80 ::
+      operator=(const Fw::StringBase& other)
+    {
+      if (this == &other) {
+        return *this;
+      }
 
-  StringSize80& StringSize80 ::
-    operator=(const Fw::StringBase& other)
-  {
-    if (this == &other) {
+      Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
       return *this;
     }
 
-    Fw::StringUtils::string_copy(this->m_buf, other.toChar(), sizeof(this->m_buf));
-    return *this;
+    StringSize80& StringSize80 ::
+      operator=(const char* other)
+    {
+      Fw::StringUtils::string_copy(this->m_buf, other, sizeof(this->m_buf));
+      return *this;
+    }
+
+    const char* StringSize80 ::
+      toChar() const
+    {
+      return this->m_buf;
+    }
+
+    NATIVE_UINT_TYPE StringSize80 ::
+      getCapacity() const
+    {
+      return sizeof(this->m_buf);
+    }
+
   }
 
-  StringSize80& StringSize80 ::
-    operator=(const char* other)
+  // ----------------------------------------------------------------------
+  // Input Port Member functions
+  // ----------------------------------------------------------------------
+
+  InputTypedReturnPort ::
+    InputTypedReturnPort() :
+      Fw::InputPortBase(),
+      m_func(nullptr)
   {
-    Fw::StringUtils::string_copy(this->m_buf, other, sizeof(this->m_buf));
-    return *this;
+
   }
 
-  const char* StringSize80 ::
-    toChar() const
+  void InputTypedReturnPort ::
+    init()
   {
-    return this->m_buf;
+    Fw::InputPortBase::init();
   }
 
-  NATIVE_UINT_TYPE StringSize80 ::
-    getCapacity() const
+  void InputTypedReturnPort ::
+    addCallComp(
+        Fw::PassiveComponentBase* callComp,
+        CompFuncPtr funcPtr
+    )
   {
-    return sizeof(this->m_buf);
+    FW_ASSERT(callComp != nullptr);
+    FW_ASSERT(funcPtr != nullptr);
+
+    this->m_comp = callComp;
+    this->m_func = funcPtr;
+    this->m_connObj = callComp;
   }
 
-}
-
-// ----------------------------------------------------------------------
-// Input Port Member functions
-// ----------------------------------------------------------------------
-
-InputTypedReturnPort ::
-  InputTypedReturnPort() :
-    Fw::InputPortBase(),
-    m_func(nullptr)
-{
-
-}
-
-void InputTypedReturnPort ::
-  init()
-{
-  Fw::InputPortBase::init();
-}
-
-void InputTypedReturnPort ::
-  addCallComp(
-      Fw::PassiveComponentBase* callComp,
-      CompFuncPtr funcPtr
-  )
-{
-  FW_ASSERT(callComp != nullptr);
-  FW_ASSERT(funcPtr != nullptr);
-
-  this->m_comp = callComp;
-  this->m_func = funcPtr;
-  this->m_connObj = callComp;
-}
-
-F32 InputTypedReturnPort ::
-  invoke(
-      U32 u32,
-      F32 f32,
-      bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
+  F32 InputTypedReturnPort ::
+    invoke(
+        U32 u32,
+        F32 f32,
+        bool b,
+        const TypedReturnPortStrings::StringSize80& str2,
+        const E& e,
+        const A& a,
+        const S& s
+    )
+  {
 #if FW_PORT_TRACING == 1
-  this->trace();
+    this->trace();
 #endif
 
-  FW_ASSERT(this->m_comp != nullptr);
-  FW_ASSERT(this->m_func != nullptr);
+    FW_ASSERT(this->m_comp != nullptr);
+    FW_ASSERT(this->m_func != nullptr);
 
-  return this->m_func(this->m_comp, this->m_portNum, u32, f32, b, str2, e, a, s);
-}
+    return this->m_func(this->m_comp, this->m_portNum, u32, f32, b, str2, e, a, s);
+  }
 
 #if FW_PORT_SERIALIZATION == 1
 
-Fw::SerializeStatus InputTypedReturnPort ::
-  invokeSerial(Fw::SerializeBufferBase& _buffer)
-{
-  // For ports with a return type, invokeSerial is not used
-  (void) _buffer;
+  Fw::SerializeStatus InputTypedReturnPort ::
+    invokeSerial(Fw::SerializeBufferBase& _buffer)
+  {
+    // For ports with a return type, invokeSerial is not used
+    (void) _buffer;
 
-  FW_ASSERT(0);
-  return Fw::FW_SERIALIZE_OK;
-}
+    FW_ASSERT(0);
+    return Fw::FW_SERIALIZE_OK;
+  }
 
 #endif
 
-// ----------------------------------------------------------------------
-// Output Port Member functions
-// ----------------------------------------------------------------------
+  // ----------------------------------------------------------------------
+  // Output Port Member functions
+  // ----------------------------------------------------------------------
 
-OutputTypedReturnPort ::
-  OutputTypedReturnPort() :
-    Fw::OutputPortBase(),
-    m_port(nullptr)
-{
+  OutputTypedReturnPort ::
+    OutputTypedReturnPort() :
+      Fw::OutputPortBase(),
+      m_port(nullptr)
+  {
 
-}
+  }
 
-void OutputTypedReturnPort ::
-  init()
-{
-  Fw::OutputPortBase::init();
-}
+  void OutputTypedReturnPort ::
+    init()
+  {
+    Fw::OutputPortBase::init();
+  }
 
-void OutputTypedReturnPort ::
-  addCallPort(InputTypedReturnPort* callPort)
-{
-  FW_ASSERT(callPort != nullptr);
+  void OutputTypedReturnPort ::
+    addCallPort(InputTypedReturnPort* callPort)
+  {
+    FW_ASSERT(callPort != nullptr);
 
-  this->m_port = callPort;
-  this->m_connObj = callPort;
+    this->m_port = callPort;
+    this->m_connObj = callPort;
 
 #if FW_PORT_SERIALIZATION == 1
-  this->m_serPort = nullptr;
+    this->m_serPort = nullptr;
 #endif
-}
+  }
 
-F32 OutputTypedReturnPort ::
-  invoke(
-      U32 u32,
-      F32 f32,
-      bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
-      const E& e,
-      const A& a,
-      const S& s
-  )
-{
+  F32 OutputTypedReturnPort ::
+    invoke(
+        U32 u32,
+        F32 f32,
+        bool b,
+        const TypedReturnPortStrings::StringSize80& str2,
+        const E& e,
+        const A& a,
+        const S& s
+    )
+  {
 #if FW_PORT_TRACING == 1
-  this->trace();
+    this->trace();
 #endif
 
-  FW_ASSERT(this->m_port != nullptr);
-  return this->m_port->invoke(u32, f32, b, str2, e, a, s);
+    FW_ASSERT(this->m_port != nullptr);
+    return this->m_port->invoke(u32, f32, b, str2, e, a, s);
+  }
+
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/TypedReturnPortAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/TypedReturnPortAc.ref.hpp
@@ -4,8 +4,8 @@
 // \brief  hpp file for TypedReturn port
 // ======================================================================
 
-#ifndef TypedReturnPortAc_HPP
-#define TypedReturnPortAc_HPP
+#ifndef Ports_TypedReturnPortAc_HPP
+#define Ports_TypedReturnPortAc_HPP
 
 #include <cstdio>
 #include <cstring>
@@ -19,201 +19,205 @@
 #include "Fw/Types/StringType.hpp"
 #include "SSerializableAc.hpp"
 
-namespace TypedReturnPortStrings {
+namespace Ports {
+
+  namespace TypedReturnPortStrings {
+
+    // ----------------------------------------------------------------------
+    // StringSize80 class
+    // ----------------------------------------------------------------------
+
+    class StringSize80 :
+      public Fw::StringBase
+    {
+
+      public:
+
+        enum {
+          //! The size of the string length plus the size of the string buffer
+          SERIALIZED_SIZE = sizeof(FwBuffSizeType) + 80
+        };
+
+        //! Default constructor
+        StringSize80();
+
+        //! Char array constructor
+        StringSize80(const char* src);
+
+        //! String base constructor
+        StringSize80(const Fw::StringBase& src);
+
+        //! Copy constructor
+        StringSize80(const StringSize80& src);
+
+        //! Destructor
+        ~StringSize80();
+
+        //! Copy assignment operator
+        StringSize80& operator=(const StringSize80& other);
+
+        //! String base assignment operator
+        StringSize80& operator=(const Fw::StringBase& other);
+
+        //! char* assignment operator
+        StringSize80& operator=(const char* other);
+
+        //! Retrieves char buffer of string
+        const char* toChar() const;
+
+        NATIVE_UINT_TYPE getCapacity() const;
+
+      private:
+
+        char m_buf[80]; //!< Buffer for string storage
+
+    };
+
+  }
 
   // ----------------------------------------------------------------------
-  // StringSize80 class
+  // String types for backwards compatibility
   // ----------------------------------------------------------------------
 
-  class StringSize80 :
-    public Fw::StringBase
+  typedef TypedReturnPortStrings::StringSize80 str2String;
+
+  //! Input TypedReturn port
+  //! A typed port with a return type
+  class InputTypedReturnPort :
+    public Fw::InputPortBase
   {
 
     public:
 
+      // ----------------------------------------------------------------------
+      // Constants
+      // ----------------------------------------------------------------------
+
       enum {
-        //! The size of the string length plus the size of the string buffer
-        SERIALIZED_SIZE = sizeof(FwBuffSizeType) + 80
+        //! The size of the serial representations of the port arguments
+        SERIALIZED_SIZE =
+          sizeof(U32) +
+          sizeof(F32) +
+          sizeof(U8) +
+          TypedReturnPortStrings::StringSize80::SERIALIZED_SIZE +
+          E::SERIALIZED_SIZE +
+          A::SERIALIZED_SIZE +
+          S::SERIALIZED_SIZE
       };
 
-      //! Default constructor
-      StringSize80();
+    public:
 
-      //! Char array constructor
-      StringSize80(const char* src);
+      // ----------------------------------------------------------------------
+      // Types
+      // ----------------------------------------------------------------------
 
-      //! String base constructor
-      StringSize80(const Fw::StringBase& src);
+      //! The port callback function type
+      typedef F32 (*CompFuncPtr)(
+        Fw::PassiveComponentBase* callComp,
+        NATIVE_INT_TYPE portNum,
+        U32 u32,
+        F32 f32,
+        bool b,
+        const TypedReturnPortStrings::StringSize80& str2,
+        const E& e,
+        const A& a,
+        const S& s
+      );
 
-      //! Copy constructor
-      StringSize80(const StringSize80& src);
+    public:
 
-      //! Destructor
-      ~StringSize80();
+      // ----------------------------------------------------------------------
+      // Input Port Member functions
+      // ----------------------------------------------------------------------
 
-      //! Copy assignment operator
-      StringSize80& operator=(const StringSize80& other);
+      //! Constructor
+      InputTypedReturnPort();
 
-      //! String base assignment operator
-      StringSize80& operator=(const Fw::StringBase& other);
+      //! Initialization function
+      void init();
 
-      //! char* assignment operator
-      StringSize80& operator=(const char* other);
+      //! Register a component
+      void addCallComp(
+          Fw::PassiveComponentBase* callComp, //!< The containing component
+          CompFuncPtr funcPtr //!< The port callback function
+      );
 
-      //! Retrieves char buffer of string
-      const char* toChar() const;
-
-      NATIVE_UINT_TYPE getCapacity() const;
+      //! Invoke a port interface
+      F32 invoke(
+          U32 u32, //!< A U32
+          F32 f32, //!< An F32
+          bool b, //!< A boolean
+          const TypedReturnPortStrings::StringSize80& str2, //!< A string
+          const E& e, //!< An enum
+          const A& a, //!< An array
+          const S& s //!< A struct
+      );
 
     private:
 
-      char m_buf[80]; //!< Buffer for string storage
+#if FW_PORT_SERIALIZATION == 1
+
+      //! Invoke the port with serialized arguments
+      Fw::SerializeStatus invokeSerial(Fw::SerializeBufferBase& _buffer);
+
+#endif
+
+    private:
+
+      // ----------------------------------------------------------------------
+      // Member variables
+      // ----------------------------------------------------------------------
+
+      //! The pointer to the port callback function
+      CompFuncPtr m_func;
+
+  };
+
+  //! Output TypedReturn port
+  //! A typed port with a return type
+  class OutputTypedReturnPort :
+    public Fw::OutputPortBase
+  {
+
+    public:
+
+      // ----------------------------------------------------------------------
+      // Output Port Member functions
+      // ----------------------------------------------------------------------
+
+      //! Constructor
+      OutputTypedReturnPort();
+
+      //! Initialization function
+      void init();
+
+      //! Register an input port
+      void addCallPort(
+          InputTypedReturnPort* callPort //!< The input port
+      );
+
+      //! Invoke a port interface
+      F32 invoke(
+          U32 u32, //!< A U32
+          F32 f32, //!< An F32
+          bool b, //!< A boolean
+          const TypedReturnPortStrings::StringSize80& str2, //!< A string
+          const E& e, //!< An enum
+          const A& a, //!< An array
+          const S& s //!< A struct
+      );
+
+    private:
+
+      // ----------------------------------------------------------------------
+      // Member variables
+      // ----------------------------------------------------------------------
+
+      //! The pointer to the input port
+      InputTypedReturnPort* m_port;
 
   };
 
 }
-
-// ----------------------------------------------------------------------
-// String types for backwards compatibility
-// ----------------------------------------------------------------------
-
-typedef TypedReturnPortStrings::StringSize80 str2String;
-
-//! Input TypedReturn port
-//! A typed port with a return type
-class InputTypedReturnPort :
-  public Fw::InputPortBase
-{
-
-  public:
-
-    // ----------------------------------------------------------------------
-    // Constants
-    // ----------------------------------------------------------------------
-
-    enum {
-      //! The size of the serial representations of the port arguments
-      SERIALIZED_SIZE =
-        sizeof(U32) +
-        sizeof(F32) +
-        sizeof(U8) +
-        TypedReturnPortStrings::StringSize80::SERIALIZED_SIZE +
-        E::SERIALIZED_SIZE +
-        A::SERIALIZED_SIZE +
-        S::SERIALIZED_SIZE
-    };
-
-  public:
-
-    // ----------------------------------------------------------------------
-    // Types
-    // ----------------------------------------------------------------------
-
-    //! The port callback function type
-    typedef F32 (*CompFuncPtr)(
-      Fw::PassiveComponentBase* callComp,
-      NATIVE_INT_TYPE portNum,
-      U32 u32,
-      F32 f32,
-      bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
-      const E& e,
-      const A& a,
-      const S& s
-    );
-
-  public:
-
-    // ----------------------------------------------------------------------
-    // Input Port Member functions
-    // ----------------------------------------------------------------------
-
-    //! Constructor
-    InputTypedReturnPort();
-
-    //! Initialization function
-    void init();
-
-    //! Register a component
-    void addCallComp(
-        Fw::PassiveComponentBase* callComp, //!< The containing component
-        CompFuncPtr funcPtr //!< The port callback function
-    );
-
-    //! Invoke a port interface
-    F32 invoke(
-        U32 u32, //!< A U32
-        F32 f32, //!< An F32
-        bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
-        const E& e, //!< An enum
-        const A& a, //!< An array
-        const S& s //!< A struct
-    );
-
-  private:
-
-#if FW_PORT_SERIALIZATION == 1
-
-    //! Invoke the port with serialized arguments
-    Fw::SerializeStatus invokeSerial(Fw::SerializeBufferBase& _buffer);
-
-#endif
-
-  private:
-
-    // ----------------------------------------------------------------------
-    // Member variables
-    // ----------------------------------------------------------------------
-
-    //! The pointer to the port callback function
-    CompFuncPtr m_func;
-
-};
-
-//! Output TypedReturn port
-//! A typed port with a return type
-class OutputTypedReturnPort :
-  public Fw::OutputPortBase
-{
-
-  public:
-
-    // ----------------------------------------------------------------------
-    // Output Port Member functions
-    // ----------------------------------------------------------------------
-
-    //! Constructor
-    OutputTypedReturnPort();
-
-    //! Initialization function
-    void init();
-
-    //! Register an input port
-    void addCallPort(
-        InputTypedReturnPort* callPort //!< The input port
-    );
-
-    //! Invoke a port interface
-    F32 invoke(
-        U32 u32, //!< A U32
-        F32 f32, //!< An F32
-        bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
-        const E& e, //!< An enum
-        const A& a, //!< An array
-        const S& s //!< A struct
-    );
-
-  private:
-
-    // ----------------------------------------------------------------------
-    // Member variables
-    // ----------------------------------------------------------------------
-
-    //! The pointer to the input port
-    InputTypedReturnPort* m_port;
-
-};
 
 #endif

--- a/compiler/tools/fpp-to-cpp/test/component/test-impl/ActiveCommandsTester.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-impl/ActiveCommandsTester.ref.cpp
@@ -45,7 +45,7 @@ void ActiveCommandsTester ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -60,7 +60,7 @@ F32 ActiveCommandsTester ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-impl/ActiveCommandsTester.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-impl/ActiveCommandsTester.ref.hpp
@@ -62,7 +62,7 @@ class ActiveCommandsTester :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -74,7 +74,7 @@ class ActiveCommandsTester :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct

--- a/compiler/tools/fpp-to-cpp/test/component/test-impl/ActiveEventsTester.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-impl/ActiveEventsTester.ref.cpp
@@ -45,7 +45,7 @@ void ActiveEventsTester ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -60,7 +60,7 @@ F32 ActiveEventsTester ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-impl/ActiveEventsTester.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-impl/ActiveEventsTester.ref.hpp
@@ -62,7 +62,7 @@ class ActiveEventsTester :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -74,7 +74,7 @@ class ActiveEventsTester :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct

--- a/compiler/tools/fpp-to-cpp/test/component/test-impl/ActiveParamsTester.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-impl/ActiveParamsTester.ref.cpp
@@ -45,7 +45,7 @@ void ActiveParamsTester ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -60,7 +60,7 @@ F32 ActiveParamsTester ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-impl/ActiveParamsTester.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-impl/ActiveParamsTester.ref.hpp
@@ -62,7 +62,7 @@ class ActiveParamsTester :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -74,7 +74,7 @@ class ActiveParamsTester :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct

--- a/compiler/tools/fpp-to-cpp/test/component/test-impl/ActiveSerialTester.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-impl/ActiveSerialTester.ref.cpp
@@ -45,7 +45,7 @@ void ActiveSerialTester ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -60,7 +60,7 @@ F32 ActiveSerialTester ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-impl/ActiveSerialTester.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-impl/ActiveSerialTester.ref.hpp
@@ -62,7 +62,7 @@ class ActiveSerialTester :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -74,7 +74,7 @@ class ActiveSerialTester :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct

--- a/compiler/tools/fpp-to-cpp/test/component/test-impl/ActiveTelemetryTester.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-impl/ActiveTelemetryTester.ref.cpp
@@ -45,7 +45,7 @@ void ActiveTelemetryTester ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -60,7 +60,7 @@ F32 ActiveTelemetryTester ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-impl/ActiveTelemetryTester.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-impl/ActiveTelemetryTester.ref.hpp
@@ -62,7 +62,7 @@ class ActiveTelemetryTester :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -74,7 +74,7 @@ class ActiveTelemetryTester :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct

--- a/compiler/tools/fpp-to-cpp/test/component/test-impl/ActiveTestTester.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-impl/ActiveTestTester.ref.cpp
@@ -47,7 +47,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedPortStrings::StringSize80& str1,
+        const Ports::TypedPortStrings::StringSize80& str1,
         const E& e,
         const A& a,
         const S& s
@@ -62,7 +62,7 @@ namespace M {
         U32 u32,
         F32 f32,
         bool b,
-        const TypedReturnPortStrings::StringSize80& str2,
+        const Ports::TypedReturnPortStrings::StringSize80& str2,
         const E& e,
         const A& a,
         const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-impl/ActiveTestTester.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-impl/ActiveTestTester.ref.hpp
@@ -64,7 +64,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedPortStrings::StringSize80& str1, //!< A string
+          const Ports::TypedPortStrings::StringSize80& str1, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct
@@ -76,7 +76,7 @@ namespace M {
           U32 u32, //!< A U32
           F32 f32, //!< An F32
           bool b, //!< A boolean
-          const TypedReturnPortStrings::StringSize80& str2, //!< A string
+          const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
           const E& e, //!< An enum
           const A& a, //!< An array
           const S& s //!< A struct

--- a/compiler/tools/fpp-to-cpp/test/component/test-impl/PassiveCommandsTester.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-impl/PassiveCommandsTester.ref.cpp
@@ -45,7 +45,7 @@ void PassiveCommandsTester ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -60,7 +60,7 @@ F32 PassiveCommandsTester ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-impl/PassiveCommandsTester.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-impl/PassiveCommandsTester.ref.hpp
@@ -59,7 +59,7 @@ class PassiveCommandsTester :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -71,7 +71,7 @@ class PassiveCommandsTester :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct

--- a/compiler/tools/fpp-to-cpp/test/component/test-impl/PassiveEventsTester.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-impl/PassiveEventsTester.ref.cpp
@@ -45,7 +45,7 @@ void PassiveEventsTester ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -60,7 +60,7 @@ F32 PassiveEventsTester ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-impl/PassiveEventsTester.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-impl/PassiveEventsTester.ref.hpp
@@ -59,7 +59,7 @@ class PassiveEventsTester :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -71,7 +71,7 @@ class PassiveEventsTester :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct

--- a/compiler/tools/fpp-to-cpp/test/component/test-impl/PassiveParamsTester.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-impl/PassiveParamsTester.ref.cpp
@@ -45,7 +45,7 @@ void PassiveParamsTester ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -60,7 +60,7 @@ F32 PassiveParamsTester ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-impl/PassiveParamsTester.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-impl/PassiveParamsTester.ref.hpp
@@ -59,7 +59,7 @@ class PassiveParamsTester :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -71,7 +71,7 @@ class PassiveParamsTester :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct

--- a/compiler/tools/fpp-to-cpp/test/component/test-impl/PassiveSerialTester.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-impl/PassiveSerialTester.ref.cpp
@@ -45,7 +45,7 @@ void PassiveSerialTester ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -60,7 +60,7 @@ F32 PassiveSerialTester ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-impl/PassiveSerialTester.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-impl/PassiveSerialTester.ref.hpp
@@ -59,7 +59,7 @@ class PassiveSerialTester :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -71,7 +71,7 @@ class PassiveSerialTester :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct

--- a/compiler/tools/fpp-to-cpp/test/component/test-impl/PassiveTelemetryTester.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-impl/PassiveTelemetryTester.ref.cpp
@@ -45,7 +45,7 @@ void PassiveTelemetryTester ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -60,7 +60,7 @@ F32 PassiveTelemetryTester ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-impl/PassiveTelemetryTester.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-impl/PassiveTelemetryTester.ref.hpp
@@ -59,7 +59,7 @@ class PassiveTelemetryTester :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -71,7 +71,7 @@ class PassiveTelemetryTester :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct

--- a/compiler/tools/fpp-to-cpp/test/component/test-impl/PassiveTestTester.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-impl/PassiveTestTester.ref.cpp
@@ -45,7 +45,7 @@ void PassiveTestTester ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -60,7 +60,7 @@ F32 PassiveTestTester ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-impl/PassiveTestTester.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-impl/PassiveTestTester.ref.hpp
@@ -59,7 +59,7 @@ class PassiveTestTester :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -71,7 +71,7 @@ class PassiveTestTester :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct

--- a/compiler/tools/fpp-to-cpp/test/component/test-impl/QueuedCommandsTester.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-impl/QueuedCommandsTester.ref.cpp
@@ -45,7 +45,7 @@ void QueuedCommandsTester ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -60,7 +60,7 @@ F32 QueuedCommandsTester ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-impl/QueuedCommandsTester.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-impl/QueuedCommandsTester.ref.hpp
@@ -62,7 +62,7 @@ class QueuedCommandsTester :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -74,7 +74,7 @@ class QueuedCommandsTester :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct

--- a/compiler/tools/fpp-to-cpp/test/component/test-impl/QueuedEventsTester.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-impl/QueuedEventsTester.ref.cpp
@@ -45,7 +45,7 @@ void QueuedEventsTester ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -60,7 +60,7 @@ F32 QueuedEventsTester ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-impl/QueuedEventsTester.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-impl/QueuedEventsTester.ref.hpp
@@ -62,7 +62,7 @@ class QueuedEventsTester :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -74,7 +74,7 @@ class QueuedEventsTester :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct

--- a/compiler/tools/fpp-to-cpp/test/component/test-impl/QueuedParamsTester.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-impl/QueuedParamsTester.ref.cpp
@@ -45,7 +45,7 @@ void QueuedParamsTester ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -60,7 +60,7 @@ F32 QueuedParamsTester ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-impl/QueuedParamsTester.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-impl/QueuedParamsTester.ref.hpp
@@ -62,7 +62,7 @@ class QueuedParamsTester :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -74,7 +74,7 @@ class QueuedParamsTester :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct

--- a/compiler/tools/fpp-to-cpp/test/component/test-impl/QueuedSerialTester.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-impl/QueuedSerialTester.ref.cpp
@@ -45,7 +45,7 @@ void QueuedSerialTester ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -60,7 +60,7 @@ F32 QueuedSerialTester ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-impl/QueuedSerialTester.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-impl/QueuedSerialTester.ref.hpp
@@ -62,7 +62,7 @@ class QueuedSerialTester :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -74,7 +74,7 @@ class QueuedSerialTester :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct

--- a/compiler/tools/fpp-to-cpp/test/component/test-impl/QueuedTelemetryTester.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-impl/QueuedTelemetryTester.ref.cpp
@@ -45,7 +45,7 @@ void QueuedTelemetryTester ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -60,7 +60,7 @@ F32 QueuedTelemetryTester ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-impl/QueuedTelemetryTester.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-impl/QueuedTelemetryTester.ref.hpp
@@ -62,7 +62,7 @@ class QueuedTelemetryTester :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -74,7 +74,7 @@ class QueuedTelemetryTester :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct

--- a/compiler/tools/fpp-to-cpp/test/component/test-impl/QueuedTestTester.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-impl/QueuedTestTester.ref.cpp
@@ -45,7 +45,7 @@ void QueuedTestTester ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedPortStrings::StringSize80& str1,
+      const Ports::TypedPortStrings::StringSize80& str1,
       const E& e,
       const A& a,
       const S& s
@@ -60,7 +60,7 @@ F32 QueuedTestTester ::
       U32 u32,
       F32 f32,
       bool b,
-      const TypedReturnPortStrings::StringSize80& str2,
+      const Ports::TypedReturnPortStrings::StringSize80& str2,
       const E& e,
       const A& a,
       const S& s

--- a/compiler/tools/fpp-to-cpp/test/component/test-impl/QueuedTestTester.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-impl/QueuedTestTester.ref.hpp
@@ -62,7 +62,7 @@ class QueuedTestTester :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedPortStrings::StringSize80& str1, //!< A string
+        const Ports::TypedPortStrings::StringSize80& str1, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct
@@ -74,7 +74,7 @@ class QueuedTestTester :
         U32 u32, //!< A U32
         F32 f32, //!< An F32
         bool b, //!< A boolean
-        const TypedReturnPortStrings::StringSize80& str2, //!< A string
+        const Ports::TypedReturnPortStrings::StringSize80& str2, //!< A string
         const E& e, //!< An enum
         const A& a, //!< An array
         const S& s //!< A struct

--- a/compiler/tools/fpp-to-cpp/test/component/types.fpp
+++ b/compiler/tools/fpp-to-cpp/test/component/types.fpp
@@ -7,30 +7,34 @@ array A = [3] U32
 @ A struct
 struct S { x: U32, y: string }
 
-@ A typed port with no arguments
-port NoArgs
+module Ports {
 
-@ A type port with no arguments and a return type
-port NoArgsReturn -> U32
+  @ A typed port with no arguments
+  port NoArgs
 
-@ A typed port
-port Typed(
-  u32: U32, @< A U32
-  f32: F32, @< An F32
-  b: bool, @< A boolean
-  str1: string, @< A string
-  e: E, @< An enum
-  a: A, @< An array
-  s: S @< A struct
-)
+  @ A type port with no arguments and a return type
+  port NoArgsReturn -> U32
 
-@ A typed port with a return type
-port TypedReturn(
-  u32: U32, @< A U32
-  f32: F32, @< An F32
-  b: bool, @< A boolean
-  str2: string, @< A string
-  e: E, @< An enum
-  a: A, @< An array
-  s: S @< A struct
-) -> F32
+  @ A typed port
+  port Typed(
+    u32: U32, @< A U32
+    f32: F32, @< An F32
+    b: bool, @< A boolean
+    str1: string, @< A string
+    e: E, @< An enum
+    a: A, @< An array
+    s: S @< A struct
+  )
+
+  @ A typed port with a return type
+  port TypedReturn(
+    u32: U32, @< A U32
+    f32: F32, @< An F32
+    b: bool, @< A boolean
+    str2: string, @< A string
+    e: E, @< An enum
+    a: A, @< An array
+    s: S @< A struct
+  ) -> F32
+
+}


### PR DESCRIPTION
* Revise the C++ code gen
* Update unit tests to add namespaces and cover this case.

Note: Most of the changes in this PR are updates to the C++ unit test output. The Scala code changes are minimal.

Closes #318.