### PR TITLE
Fix Enum shadow variable

### DIFF
--- a/compiler/clean
+++ b/compiler/clean
@@ -1,5 +1,9 @@
 #!/bin/sh -e
 
+# Ensure the script can be run from any directory
+wd=`dirname $0`
+cd $wd
+
 . scripts/utils.sh
 
 sbt clean

--- a/compiler/lib/src/main/scala/codegen/CppWriter/EnumCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/EnumCppWriter.scala
@@ -189,10 +189,10 @@ case class EnumCppWriter(
                 |
                 |//! Constructor (user-provided value)
                 |$name(
-                |    const T e //!< The raw enum value
+                |    const T e1 //!< The raw enum value
                 |)
                 |{
-                |  this->e = e;
+                |  this->e = e1;
                 |}
                 |
                 |//! Copy constructor
@@ -202,6 +202,7 @@ case class EnumCppWriter(
                 |{
                 |  this->e = obj.e;
                 |}"""
+
           )
         ).flatten
       ),
@@ -244,7 +245,7 @@ case class EnumCppWriter(
         ),
         CppDoc.Type(s"$name&"),
         List(
-          line("this->e = e;"),
+          line("this->e = e1;"),
           line("return *this;"),
         )
       ),
@@ -258,15 +259,15 @@ case class EnumCppWriter(
              |}
              |
              |//! Equality operator
-             |bool operator==(T e) const
+             |bool operator==(T e1) const
              |{
-             |  return this->e == e;
+             |  return this->e == e1;
              |}
              |
              |//! Inequality operator
-             |bool operator!=(T e) const
+             |bool operator!=(T e1) const
              |{
-             |  return !(*this == e);
+             |  return !(*this == e1);
              |}"""
         )
       ),

--- a/compiler/lib/src/main/scala/codegen/CppWriter/EnumCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/EnumCppWriter.scala
@@ -239,7 +239,7 @@ case class EnumCppWriter(
         List(
           CppDoc.Function.Param(
             CppDoc.Type("T"),
-            "e",
+            "e1",
             Some("The enum value"),
           ),
         ),

--- a/compiler/tools/fpp-to-cpp/test/array/E1EnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/E1EnumAc.ref.cpp
@@ -26,7 +26,7 @@ namespace M {
   E1& E1 ::
     operator=(T e)
   {
-    this->e = e;
+    this->e = e1;
     return *this;
   }
 

--- a/compiler/tools/fpp-to-cpp/test/array/E1EnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/E1EnumAc.ref.cpp
@@ -24,7 +24,7 @@ namespace M {
   }
 
   E1& E1 ::
-    operator=(T e)
+    operator=(T e1)
   {
     this->e = e1;
     return *this;

--- a/compiler/tools/fpp-to-cpp/test/array/E1EnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/E1EnumAc.ref.hpp
@@ -91,7 +91,7 @@ namespace M {
 
       //! Copy assignment operator (raw enum)
       E1& operator=(
-          T e //!< The enum value
+          T e1 //!< The enum value
       );
 
       //! Conversion operator

--- a/compiler/tools/fpp-to-cpp/test/array/E1EnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/E1EnumAc.ref.hpp
@@ -64,10 +64,10 @@ namespace M {
 
       //! Constructor (user-provided value)
       E1(
-          const T e //!< The raw enum value
+          const T e1 //!< The raw enum value
       )
       {
-        this->e = e;
+        this->e = e1;
       }
 
       //! Copy constructor
@@ -101,15 +101,15 @@ namespace M {
       }
 
       //! Equality operator
-      bool operator==(T e) const
+      bool operator==(T e1) const
       {
-        return this->e == e;
+        return this->e == e1;
       }
 
       //! Inequality operator
-      bool operator!=(T e) const
+      bool operator!=(T e1) const
       {
-        return !(*this == e);
+        return !(*this == e1);
       }
 
 #ifdef BUILD_UT

--- a/compiler/tools/fpp-to-cpp/test/array/E2EnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/E2EnumAc.ref.cpp
@@ -22,7 +22,7 @@ E2& E2 ::
 }
 
 E2& E2 ::
-  operator=(T e)
+  operator=(T e1)
 {
   this->e = e1;
   return *this;

--- a/compiler/tools/fpp-to-cpp/test/array/E2EnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/E2EnumAc.ref.cpp
@@ -24,7 +24,7 @@ E2& E2 ::
 E2& E2 ::
   operator=(T e)
 {
-  this->e = e;
+  this->e = e1;
   return *this;
 }
 

--- a/compiler/tools/fpp-to-cpp/test/array/E2EnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/E2EnumAc.ref.hpp
@@ -90,7 +90,7 @@ class E2 :
 
     //! Copy assignment operator (raw enum)
     E2& operator=(
-        T e //!< The enum value
+        T e1 //!< The enum value
     );
 
     //! Conversion operator

--- a/compiler/tools/fpp-to-cpp/test/array/E2EnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/array/E2EnumAc.ref.hpp
@@ -63,10 +63,10 @@ class E2 :
 
     //! Constructor (user-provided value)
     E2(
-        const T e //!< The raw enum value
+        const T e1 //!< The raw enum value
     )
     {
-      this->e = e;
+      this->e = e1;
     }
 
     //! Copy constructor
@@ -100,15 +100,15 @@ class E2 :
     }
 
     //! Equality operator
-    bool operator==(T e) const
+    bool operator==(T e1) const
     {
-      return this->e == e;
+      return this->e == e1;
     }
 
     //! Inequality operator
-    bool operator!=(T e) const
+    bool operator!=(T e1) const
     {
-      return !(*this == e);
+      return !(*this == e1);
     }
 
 #ifdef BUILD_UT

--- a/compiler/tools/fpp-to-cpp/test/component/base/EEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/EEnumAc.ref.cpp
@@ -24,7 +24,7 @@ E& E ::
 E& E ::
   operator=(T e)
 {
-  this->e = e;
+  this->e = e1;
   return *this;
 }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/EEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/EEnumAc.ref.cpp
@@ -22,7 +22,7 @@ E& E ::
 }
 
 E& E ::
-  operator=(T e)
+  operator=(T e1)
 {
   this->e = e1;
   return *this;

--- a/compiler/tools/fpp-to-cpp/test/component/base/EEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/EEnumAc.ref.hpp
@@ -89,7 +89,7 @@ class E :
 
     //! Copy assignment operator (raw enum)
     E& operator=(
-        T e //!< The enum value
+        T e1 //!< The enum value
     );
 
     //! Conversion operator

--- a/compiler/tools/fpp-to-cpp/test/component/base/EEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/EEnumAc.ref.hpp
@@ -62,10 +62,10 @@ class E :
 
     //! Constructor (user-provided value)
     E(
-        const T e //!< The raw enum value
+        const T e1 //!< The raw enum value
     )
     {
-      this->e = e;
+      this->e = e1;
     }
 
     //! Copy constructor
@@ -99,15 +99,15 @@ class E :
     }
 
     //! Equality operator
-    bool operator==(T e) const
+    bool operator==(T e1) const
     {
-      return this->e == e;
+      return this->e == e1;
     }
 
     //! Inequality operator
-    bool operator!=(T e) const
+    bool operator!=(T e1) const
     {
-      return !(*this == e);
+      return !(*this == e1);
     }
 
 #ifdef BUILD_UT

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/EEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/EEnumAc.ref.cpp
@@ -24,7 +24,7 @@ E& E ::
 E& E ::
   operator=(T e)
 {
-  this->e = e;
+  this->e = e1;
   return *this;
 }
 

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/EEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/EEnumAc.ref.cpp
@@ -22,7 +22,7 @@ E& E ::
 }
 
 E& E ::
-  operator=(T e)
+  operator=(T e1)
 {
   this->e = e1;
   return *this;

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/EEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/EEnumAc.ref.hpp
@@ -89,7 +89,7 @@ class E :
 
     //! Copy assignment operator (raw enum)
     E& operator=(
-        T e //!< The enum value
+        T e1 //!< The enum value
     );
 
     //! Conversion operator

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/EEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/EEnumAc.ref.hpp
@@ -62,10 +62,10 @@ class E :
 
     //! Constructor (user-provided value)
     E(
-        const T e //!< The raw enum value
+        const T e1 //!< The raw enum value
     )
     {
-      this->e = e;
+      this->e = e1;
     }
 
     //! Copy constructor
@@ -99,15 +99,15 @@ class E :
     }
 
     //! Equality operator
-    bool operator==(T e) const
+    bool operator==(T e1) const
     {
-      return this->e == e;
+      return this->e == e1;
     }
 
     //! Inequality operator
-    bool operator!=(T e) const
+    bool operator!=(T e1) const
     {
-      return !(*this == e);
+      return !(*this == e1);
     }
 
 #ifdef BUILD_UT

--- a/compiler/tools/fpp-to-cpp/test/enum/C_EEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/C_EEnumAc.ref.cpp
@@ -22,7 +22,7 @@ C_E& C_E ::
 }
 
 C_E& C_E ::
-  operator=(T e)
+  operator=(T e1)
 {
   this->e = e1;
   return *this;

--- a/compiler/tools/fpp-to-cpp/test/enum/C_EEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/C_EEnumAc.ref.cpp
@@ -24,7 +24,7 @@ C_E& C_E ::
 C_E& C_E ::
   operator=(T e)
 {
-  this->e = e;
+  this->e = e1;
   return *this;
 }
 

--- a/compiler/tools/fpp-to-cpp/test/enum/C_EEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/C_EEnumAc.ref.hpp
@@ -60,10 +60,10 @@ class C_E :
 
     //! Constructor (user-provided value)
     C_E(
-        const T e //!< The raw enum value
+        const T e1 //!< The raw enum value
     )
     {
-      this->e = e;
+      this->e = e1;
     }
 
     //! Copy constructor
@@ -97,15 +97,15 @@ class C_E :
     }
 
     //! Equality operator
-    bool operator==(T e) const
+    bool operator==(T e1) const
     {
-      return this->e == e;
+      return this->e == e1;
     }
 
     //! Inequality operator
-    bool operator!=(T e) const
+    bool operator!=(T e1) const
     {
-      return !(*this == e);
+      return !(*this == e1);
     }
 
 #ifdef BUILD_UT

--- a/compiler/tools/fpp-to-cpp/test/enum/C_EEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/C_EEnumAc.ref.hpp
@@ -87,7 +87,7 @@ class C_E :
 
     //! Copy assignment operator (raw enum)
     C_E& operator=(
-        T e //!< The enum value
+        T e1 //!< The enum value
     );
 
     //! Conversion operator

--- a/compiler/tools/fpp-to-cpp/test/enum/DefaultEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/DefaultEnumAc.ref.cpp
@@ -26,7 +26,7 @@ namespace M {
   Default& Default ::
     operator=(T e)
   {
-    this->e = e;
+    this->e = e1;
     return *this;
   }
 

--- a/compiler/tools/fpp-to-cpp/test/enum/DefaultEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/DefaultEnumAc.ref.cpp
@@ -24,7 +24,7 @@ namespace M {
   }
 
   Default& Default ::
-    operator=(T e)
+    operator=(T e1)
   {
     this->e = e1;
     return *this;

--- a/compiler/tools/fpp-to-cpp/test/enum/DefaultEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/DefaultEnumAc.ref.hpp
@@ -91,7 +91,7 @@ namespace M {
 
       //! Copy assignment operator (raw enum)
       Default& operator=(
-          T e //!< The enum value
+          T e1 //!< The enum value
       );
 
       //! Conversion operator

--- a/compiler/tools/fpp-to-cpp/test/enum/DefaultEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/DefaultEnumAc.ref.hpp
@@ -64,10 +64,10 @@ namespace M {
 
       //! Constructor (user-provided value)
       Default(
-          const T e //!< The raw enum value
+          const T e1 //!< The raw enum value
       )
       {
-        this->e = e;
+        this->e = e1;
       }
 
       //! Copy constructor
@@ -101,15 +101,15 @@ namespace M {
       }
 
       //! Equality operator
-      bool operator==(T e) const
+      bool operator==(T e1) const
       {
-        return this->e == e;
+        return this->e == e1;
       }
 
       //! Inequality operator
-      bool operator!=(T e) const
+      bool operator!=(T e1) const
       {
-        return !(*this == e);
+        return !(*this == e1);
       }
 
 #ifdef BUILD_UT

--- a/compiler/tools/fpp-to-cpp/test/enum/EEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/EEnumAc.ref.cpp
@@ -24,7 +24,7 @@ E& E ::
 E& E ::
   operator=(T e)
 {
-  this->e = e;
+  this->e = e1;
   return *this;
 }
 

--- a/compiler/tools/fpp-to-cpp/test/enum/EEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/EEnumAc.ref.cpp
@@ -22,7 +22,7 @@ E& E ::
 }
 
 E& E ::
-  operator=(T e)
+  operator=(T e1)
 {
   this->e = e1;
   return *this;

--- a/compiler/tools/fpp-to-cpp/test/enum/EEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/EEnumAc.ref.hpp
@@ -61,10 +61,10 @@ class E :
 
     //! Constructor (user-provided value)
     E(
-        const T e //!< The raw enum value
+        const T e1 //!< The raw enum value
     )
     {
-      this->e = e;
+      this->e = e1;
     }
 
     //! Copy constructor
@@ -98,15 +98,15 @@ class E :
     }
 
     //! Equality operator
-    bool operator==(T e) const
+    bool operator==(T e1) const
     {
-      return this->e == e;
+      return this->e == e1;
     }
 
     //! Inequality operator
-    bool operator!=(T e) const
+    bool operator!=(T e1) const
     {
-      return !(*this == e);
+      return !(*this == e1);
     }
 
 #ifdef BUILD_UT

--- a/compiler/tools/fpp-to-cpp/test/enum/EEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/EEnumAc.ref.hpp
@@ -88,7 +88,7 @@ class E :
 
     //! Copy assignment operator (raw enum)
     E& operator=(
-        T e //!< The enum value
+        T e1 //!< The enum value
     );
 
     //! Conversion operator

--- a/compiler/tools/fpp-to-cpp/test/enum/ExplicitEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/ExplicitEnumAc.ref.cpp
@@ -24,7 +24,7 @@ namespace M {
   }
 
   Explicit& Explicit ::
-    operator=(T e)
+    operator=(T e1)
   {
     this->e = e1;
     return *this;

--- a/compiler/tools/fpp-to-cpp/test/enum/ExplicitEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/ExplicitEnumAc.ref.cpp
@@ -26,7 +26,7 @@ namespace M {
   Explicit& Explicit ::
     operator=(T e)
   {
-    this->e = e;
+    this->e = e1;
     return *this;
   }
 

--- a/compiler/tools/fpp-to-cpp/test/enum/ExplicitEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/ExplicitEnumAc.ref.hpp
@@ -64,10 +64,10 @@ namespace M {
 
       //! Constructor (user-provided value)
       Explicit(
-          const T e //!< The raw enum value
+          const T e1 //!< The raw enum value
       )
       {
-        this->e = e;
+        this->e = e1;
       }
 
       //! Copy constructor
@@ -101,15 +101,15 @@ namespace M {
       }
 
       //! Equality operator
-      bool operator==(T e) const
+      bool operator==(T e1) const
       {
-        return this->e == e;
+        return this->e == e1;
       }
 
       //! Inequality operator
-      bool operator!=(T e) const
+      bool operator!=(T e1) const
       {
-        return !(*this == e);
+        return !(*this == e1);
       }
 
 #ifdef BUILD_UT

--- a/compiler/tools/fpp-to-cpp/test/enum/ExplicitEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/ExplicitEnumAc.ref.hpp
@@ -91,7 +91,7 @@ namespace M {
 
       //! Copy assignment operator (raw enum)
       Explicit& operator=(
-          T e //!< The enum value
+          T e1 //!< The enum value
       );
 
       //! Conversion operator

--- a/compiler/tools/fpp-to-cpp/test/enum/ImplicitEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/ImplicitEnumAc.ref.cpp
@@ -26,7 +26,7 @@ namespace M {
   Implicit& Implicit ::
     operator=(T e)
   {
-    this->e = e;
+    this->e = e1;
     return *this;
   }
 

--- a/compiler/tools/fpp-to-cpp/test/enum/ImplicitEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/ImplicitEnumAc.ref.cpp
@@ -24,7 +24,7 @@ namespace M {
   }
 
   Implicit& Implicit ::
-    operator=(T e)
+    operator=(T e1)
   {
     this->e = e1;
     return *this;

--- a/compiler/tools/fpp-to-cpp/test/enum/ImplicitEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/ImplicitEnumAc.ref.hpp
@@ -91,7 +91,7 @@ namespace M {
 
       //! Copy assignment operator (raw enum)
       Implicit& operator=(
-          T e //!< The enum value
+          T e1 //!< The enum value
       );
 
       //! Conversion operator

--- a/compiler/tools/fpp-to-cpp/test/enum/ImplicitEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/ImplicitEnumAc.ref.hpp
@@ -64,10 +64,10 @@ namespace M {
 
       //! Constructor (user-provided value)
       Implicit(
-          const T e //!< The raw enum value
+          const T e1 //!< The raw enum value
       )
       {
-        this->e = e;
+        this->e = e1;
       }
 
       //! Copy constructor
@@ -101,15 +101,15 @@ namespace M {
       }
 
       //! Equality operator
-      bool operator==(T e) const
+      bool operator==(T e1) const
       {
-        return this->e == e;
+        return this->e == e1;
       }
 
       //! Inequality operator
-      bool operator!=(T e) const
+      bool operator!=(T e1) const
       {
-        return !(*this == e);
+        return !(*this == e1);
       }
 
 #ifdef BUILD_UT

--- a/compiler/tools/fpp-to-cpp/test/enum/SerializeTypeEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/SerializeTypeEnumAc.ref.cpp
@@ -26,7 +26,7 @@ namespace M {
   SerializeType& SerializeType ::
     operator=(T e)
   {
-    this->e = e;
+    this->e = e1;
     return *this;
   }
 

--- a/compiler/tools/fpp-to-cpp/test/enum/SerializeTypeEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/SerializeTypeEnumAc.ref.cpp
@@ -24,7 +24,7 @@ namespace M {
   }
 
   SerializeType& SerializeType ::
-    operator=(T e)
+    operator=(T e1)
   {
     this->e = e1;
     return *this;

--- a/compiler/tools/fpp-to-cpp/test/enum/SerializeTypeEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/SerializeTypeEnumAc.ref.hpp
@@ -91,7 +91,7 @@ namespace M {
 
       //! Copy assignment operator (raw enum)
       SerializeType& operator=(
-          T e //!< The enum value
+          T e1 //!< The enum value
       );
 
       //! Conversion operator

--- a/compiler/tools/fpp-to-cpp/test/enum/SerializeTypeEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/enum/SerializeTypeEnumAc.ref.hpp
@@ -64,10 +64,10 @@ namespace M {
 
       //! Constructor (user-provided value)
       SerializeType(
-          const T e //!< The raw enum value
+          const T e1 //!< The raw enum value
       )
       {
-        this->e = e;
+        this->e = e1;
       }
 
       //! Copy constructor
@@ -101,15 +101,15 @@ namespace M {
       }
 
       //! Equality operator
-      bool operator==(T e) const
+      bool operator==(T e1) const
       {
-        return this->e == e;
+        return this->e == e1;
       }
 
       //! Inequality operator
-      bool operator!=(T e) const
+      bool operator!=(T e1) const
       {
-        return !(*this == e);
+        return !(*this == e1);
       }
 
 #ifdef BUILD_UT

--- a/compiler/tools/fpp-to-cpp/test/struct/EEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/EEnumAc.ref.cpp
@@ -26,7 +26,7 @@ namespace M {
   E& E ::
     operator=(T e)
   {
-    this->e = e;
+    this->e = e1;
     return *this;
   }
 

--- a/compiler/tools/fpp-to-cpp/test/struct/EEnumAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/EEnumAc.ref.cpp
@@ -24,7 +24,7 @@ namespace M {
   }
 
   E& E ::
-    operator=(T e)
+    operator=(T e1)
   {
     this->e = e1;
     return *this;

--- a/compiler/tools/fpp-to-cpp/test/struct/EEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/EEnumAc.ref.hpp
@@ -62,10 +62,10 @@ namespace M {
 
       //! Constructor (user-provided value)
       E(
-          const T e //!< The raw enum value
+          const T e1 //!< The raw enum value
       )
       {
-        this->e = e;
+        this->e = e1;
       }
 
       //! Copy constructor
@@ -99,15 +99,15 @@ namespace M {
       }
 
       //! Equality operator
-      bool operator==(T e) const
+      bool operator==(T e1) const
       {
-        return this->e == e;
+        return this->e == e1;
       }
 
       //! Inequality operator
-      bool operator!=(T e) const
+      bool operator!=(T e1) const
       {
-        return !(*this == e);
+        return !(*this == e1);
       }
 
 #ifdef BUILD_UT

--- a/compiler/tools/fpp-to-cpp/test/struct/EEnumAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/struct/EEnumAc.ref.hpp
@@ -89,7 +89,7 @@ namespace M {
 
       //! Copy assignment operator (raw enum)
       E& operator=(
-          T e //!< The enum value
+          T e1 //!< The enum value
       );
 
       //! Conversion operator


### PR DESCRIPTION
Renamed function argument `e` to `e1` to avoid shadow variable warnings, as mentioned in #326 

Also fixed `clean` script, to be able to run it from other directories, like `install` and `test`