### PR TITLE
Fix bug in resolution of qualified identifiers

### DIFF
--- a/compiler/lib/src/main/scala/analysis/CheckSemantics/CheckUses.scala
+++ b/compiler/lib/src/main/scala/analysis/CheckSemantics/CheckUses.scala
@@ -151,9 +151,21 @@ object CheckUses extends UseAnalyzer {
     ) = {
       for {
         a <- visitQualIdentNode (ng) (a, qualifier)
-        symbol <- {
+        scope <- {
           val symbol = a.useDefMap(qualifier.id)
-          val scope = a.symbolScopeMap(symbol)
+          a.symbolScopeMap.get(symbol) match {
+            case Some(symbol) => Right(symbol)
+            case None => Left(
+              SemanticError.InvalidSymbol(
+                symbol.getUnqualifiedName,
+                Locations.get(node.id),
+                "not a qualifier",
+                symbol.getLoc
+              )
+            )
+          }
+        }
+        symbol <- {
           val mapping = scope.get (ng) _
           getSymbolForName(mapping)(name, name.data)
         }

--- a/compiler/tools/fpp-check/test/invalid_symbols/tests.sh
+++ b/compiler/tools/fpp-check/test/invalid_symbols/tests.sh
@@ -8,5 +8,6 @@ module_as_port
 module_as_topology
 module_as_type
 module_hides_constant
+topology_as_qualifier
 type_as_constant
 "

--- a/compiler/tools/fpp-check/test/invalid_symbols/topology_as_qualifier.fpp
+++ b/compiler/tools/fpp-check/test/invalid_symbols/topology_as_qualifier.fpp
@@ -1,0 +1,6 @@
+topology M {
+
+  import M.T
+
+}
+

--- a/compiler/tools/fpp-check/test/invalid_symbols/topology_as_qualifier.ref.txt
+++ b/compiler/tools/fpp-check/test/invalid_symbols/topology_as_qualifier.ref.txt
@@ -1,0 +1,9 @@
+fpp-check
+[ local path prefix ]/compiler/tools/fpp-check/test/invalid_symbols/topology_as_qualifier.fpp:3.10
+  import M.T
+         ^
+error: invalid symbol M: not a qualifier
+symbol is defined here:
+[ local path prefix ]/compiler/tools/fpp-check/test/invalid_symbols/topology_as_qualifier.fpp:1.1
+topology M {
+^


### PR DESCRIPTION
Properly report the error when a non-qualifier symbol is used as a qualifier.

**Example:**
```
topology M {
  import M.T
}
```
Note that the topology symbol `M` is incorrectly used as a qualifier in the qualified identifier `M.T`.

**Old behavior:** Crash.

**New behavior:**
```
fpp-check
/Users/bocchino/test.fpp:2.10
  import M.T
         ^
error: invalid symbol M: not a qualifier
symbol is defined here:
/Users/bocchino/test.fpp:1.1
topology M {
^
```

Closes #350.