### PR TITLE
Add index and size of array when asserting index is smaller than the SIZE

### DIFF
--- a/compiler/lib/src/main/scala/codegen/CppWriter/ArrayCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ArrayCppWriter.scala
@@ -265,7 +265,7 @@ case class ArrayCppWriter (
         ),
         CppDoc.Type("ElementType&", Some(s"$name::ElementType&")),
         List(
-          line("FW_ASSERT(i < SIZE);"),
+          line("FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));"),
           line("return this->elements[i];"),
         ),
       ),
@@ -281,7 +281,7 @@ case class ArrayCppWriter (
         ),
         CppDoc.Type("const ElementType&", Some(s"const $name::ElementType&")),
         List(
-          line("FW_ASSERT(i < SIZE);"),
+          line("FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));"),
           line("return this->elements[i];"),
         ),
         CppDoc.Function.NonSV,

--- a/compiler/tools/fpp-to-cpp/test/array/AArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/AArrayAc.ref.cpp
@@ -74,14 +74,14 @@ A ::
 A::ElementType& A ::
   operator[](const U32 i)
 {
-  FW_ASSERT(i < SIZE);
+  FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
   return this->elements[i];
 }
 
 const A::ElementType& A ::
   operator[](const U32 i) const
 {
-  FW_ASSERT(i < SIZE);
+  FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
   return this->elements[i];
 }
 

--- a/compiler/tools/fpp-to-cpp/test/array/AbsTypeArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/AbsTypeArrayAc.ref.cpp
@@ -74,14 +74,14 @@ AbsType ::
 AbsType::ElementType& AbsType ::
   operator[](const U32 i)
 {
-  FW_ASSERT(i < SIZE);
+  FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
   return this->elements[i];
 }
 
 const AbsType::ElementType& AbsType ::
   operator[](const U32 i) const
 {
-  FW_ASSERT(i < SIZE);
+  FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
   return this->elements[i];
 }
 

--- a/compiler/tools/fpp-to-cpp/test/array/BuiltInTypeArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/BuiltInTypeArrayAc.ref.cpp
@@ -74,14 +74,14 @@ BuiltInType ::
 BuiltInType::ElementType& BuiltInType ::
   operator[](const U32 i)
 {
-  FW_ASSERT(i < SIZE);
+  FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
   return this->elements[i];
 }
 
 const BuiltInType::ElementType& BuiltInType ::
   operator[](const U32 i) const
 {
-  FW_ASSERT(i < SIZE);
+  FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
   return this->elements[i];
 }
 

--- a/compiler/tools/fpp-to-cpp/test/array/C_AArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/C_AArrayAc.ref.cpp
@@ -74,14 +74,14 @@ C_A ::
 C_A::ElementType& C_A ::
   operator[](const U32 i)
 {
-  FW_ASSERT(i < SIZE);
+  FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
   return this->elements[i];
 }
 
 const C_A::ElementType& C_A ::
   operator[](const U32 i) const
 {
-  FW_ASSERT(i < SIZE);
+  FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
   return this->elements[i];
 }
 

--- a/compiler/tools/fpp-to-cpp/test/array/Enum1ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/Enum1ArrayAc.ref.cpp
@@ -71,14 +71,14 @@ Enum1 ::
 Enum1::ElementType& Enum1 ::
   operator[](const U32 i)
 {
-  FW_ASSERT(i < SIZE);
+  FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
   return this->elements[i];
 }
 
 const Enum1::ElementType& Enum1 ::
   operator[](const U32 i) const
 {
-  FW_ASSERT(i < SIZE);
+  FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
   return this->elements[i];
 }
 

--- a/compiler/tools/fpp-to-cpp/test/array/Enum2ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/Enum2ArrayAc.ref.cpp
@@ -80,14 +80,14 @@ Enum2 ::
 Enum2::ElementType& Enum2 ::
   operator[](const U32 i)
 {
-  FW_ASSERT(i < SIZE);
+  FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
   return this->elements[i];
 }
 
 const Enum2::ElementType& Enum2 ::
   operator[](const U32 i) const
 {
-  FW_ASSERT(i < SIZE);
+  FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
   return this->elements[i];
 }
 

--- a/compiler/tools/fpp-to-cpp/test/array/HeaderPathArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/HeaderPathArrayAc.ref.cpp
@@ -74,14 +74,14 @@ HeaderPath ::
 HeaderPath::ElementType& HeaderPath ::
   operator[](const U32 i)
 {
-  FW_ASSERT(i < SIZE);
+  FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
   return this->elements[i];
 }
 
 const HeaderPath::ElementType& HeaderPath ::
   operator[](const U32 i) const
 {
-  FW_ASSERT(i < SIZE);
+  FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
   return this->elements[i];
 }
 

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveArrayArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveArrayArrayAc.ref.cpp
@@ -80,14 +80,14 @@ PrimitiveArray ::
 PrimitiveArray::ElementType& PrimitiveArray ::
   operator[](const U32 i)
 {
-  FW_ASSERT(i < SIZE);
+  FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
   return this->elements[i];
 }
 
 const PrimitiveArray::ElementType& PrimitiveArray ::
   operator[](const U32 i) const
 {
-  FW_ASSERT(i < SIZE);
+  FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
   return this->elements[i];
 }
 

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveBoolArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveBoolArrayAc.ref.cpp
@@ -76,14 +76,14 @@ namespace M {
   PrimitiveBool::ElementType& PrimitiveBool ::
     operator[](const U32 i)
   {
-    FW_ASSERT(i < SIZE);
+    FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
     return this->elements[i];
   }
 
   const PrimitiveBool::ElementType& PrimitiveBool ::
     operator[](const U32 i) const
   {
-    FW_ASSERT(i < SIZE);
+    FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
     return this->elements[i];
   }
 

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveF32eArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveF32eArrayAc.ref.cpp
@@ -76,14 +76,14 @@ namespace M {
   PrimitiveF32e::ElementType& PrimitiveF32e ::
     operator[](const U32 i)
   {
-    FW_ASSERT(i < SIZE);
+    FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
     return this->elements[i];
   }
 
   const PrimitiveF32e::ElementType& PrimitiveF32e ::
     operator[](const U32 i) const
   {
-    FW_ASSERT(i < SIZE);
+    FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
     return this->elements[i];
   }
 

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveF32fArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveF32fArrayAc.ref.cpp
@@ -76,14 +76,14 @@ namespace M {
   PrimitiveF32f::ElementType& PrimitiveF32f ::
     operator[](const U32 i)
   {
-    FW_ASSERT(i < SIZE);
+    FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
     return this->elements[i];
   }
 
   const PrimitiveF32f::ElementType& PrimitiveF32f ::
     operator[](const U32 i) const
   {
-    FW_ASSERT(i < SIZE);
+    FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
     return this->elements[i];
   }
 

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveF64ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveF64ArrayAc.ref.cpp
@@ -82,14 +82,14 @@ namespace M {
   PrimitiveF64::ElementType& PrimitiveF64 ::
     operator[](const U32 i)
   {
-    FW_ASSERT(i < SIZE);
+    FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
     return this->elements[i];
   }
 
   const PrimitiveF64::ElementType& PrimitiveF64 ::
     operator[](const U32 i) const
   {
-    FW_ASSERT(i < SIZE);
+    FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
     return this->elements[i];
   }
 

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveI32ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveI32ArrayAc.ref.cpp
@@ -76,14 +76,14 @@ namespace M {
   PrimitiveI32::ElementType& PrimitiveI32 ::
     operator[](const U32 i)
   {
-    FW_ASSERT(i < SIZE);
+    FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
     return this->elements[i];
   }
 
   const PrimitiveI32::ElementType& PrimitiveI32 ::
     operator[](const U32 i) const
   {
-    FW_ASSERT(i < SIZE);
+    FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
     return this->elements[i];
   }
 

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveI64ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveI64ArrayAc.ref.cpp
@@ -76,14 +76,14 @@ namespace M {
   PrimitiveI64::ElementType& PrimitiveI64 ::
     operator[](const U32 i)
   {
-    FW_ASSERT(i < SIZE);
+    FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
     return this->elements[i];
   }
 
   const PrimitiveI64::ElementType& PrimitiveI64 ::
     operator[](const U32 i) const
   {
-    FW_ASSERT(i < SIZE);
+    FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
     return this->elements[i];
   }
 

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveU16ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveU16ArrayAc.ref.cpp
@@ -76,14 +76,14 @@ namespace M {
   PrimitiveU16::ElementType& PrimitiveU16 ::
     operator[](const U32 i)
   {
-    FW_ASSERT(i < SIZE);
+    FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
     return this->elements[i];
   }
 
   const PrimitiveU16::ElementType& PrimitiveU16 ::
     operator[](const U32 i) const
   {
-    FW_ASSERT(i < SIZE);
+    FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
     return this->elements[i];
   }
 

--- a/compiler/tools/fpp-to-cpp/test/array/PrimitiveU8ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/PrimitiveU8ArrayAc.ref.cpp
@@ -76,14 +76,14 @@ namespace M {
   PrimitiveU8::ElementType& PrimitiveU8 ::
     operator[](const U32 i)
   {
-    FW_ASSERT(i < SIZE);
+    FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
     return this->elements[i];
   }
 
   const PrimitiveU8::ElementType& PrimitiveU8 ::
     operator[](const U32 i) const
   {
-    FW_ASSERT(i < SIZE);
+    FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
     return this->elements[i];
   }
 

--- a/compiler/tools/fpp-to-cpp/test/array/SingleElementArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/SingleElementArrayAc.ref.cpp
@@ -57,14 +57,14 @@ SingleElement ::
 SingleElement::ElementType& SingleElement ::
   operator[](const U32 i)
 {
-  FW_ASSERT(i < SIZE);
+  FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
   return this->elements[i];
 }
 
 const SingleElement::ElementType& SingleElement ::
   operator[](const U32 i) const
 {
-  FW_ASSERT(i < SIZE);
+  FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
   return this->elements[i];
 }
 

--- a/compiler/tools/fpp-to-cpp/test/array/String1ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/String1ArrayAc.ref.cpp
@@ -153,14 +153,14 @@ String1 ::
 String1::ElementType& String1 ::
   operator[](const U32 i)
 {
-  FW_ASSERT(i < SIZE);
+  FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
   return this->elements[i];
 }
 
 const String1::ElementType& String1 ::
   operator[](const U32 i) const
 {
-  FW_ASSERT(i < SIZE);
+  FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
   return this->elements[i];
 }
 

--- a/compiler/tools/fpp-to-cpp/test/array/String2ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/String2ArrayAc.ref.cpp
@@ -150,14 +150,14 @@ String2 ::
 String2::ElementType& String2 ::
   operator[](const U32 i)
 {
-  FW_ASSERT(i < SIZE);
+  FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
   return this->elements[i];
 }
 
 const String2::ElementType& String2 ::
   operator[](const U32 i) const
 {
-  FW_ASSERT(i < SIZE);
+  FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
   return this->elements[i];
 }
 

--- a/compiler/tools/fpp-to-cpp/test/array/StringArrayArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/StringArrayArrayAc.ref.cpp
@@ -80,14 +80,14 @@ StringArray ::
 StringArray::ElementType& StringArray ::
   operator[](const U32 i)
 {
-  FW_ASSERT(i < SIZE);
+  FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
   return this->elements[i];
 }
 
 const StringArray::ElementType& StringArray ::
   operator[](const U32 i) const
 {
-  FW_ASSERT(i < SIZE);
+  FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
   return this->elements[i];
 }
 

--- a/compiler/tools/fpp-to-cpp/test/array/Struct1ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/Struct1ArrayAc.ref.cpp
@@ -80,14 +80,14 @@ Struct1 ::
 Struct1::ElementType& Struct1 ::
   operator[](const U32 i)
 {
-  FW_ASSERT(i < SIZE);
+  FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
   return this->elements[i];
 }
 
 const Struct1::ElementType& Struct1 ::
   operator[](const U32 i) const
 {
-  FW_ASSERT(i < SIZE);
+  FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
   return this->elements[i];
 }
 

--- a/compiler/tools/fpp-to-cpp/test/array/Struct2ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/Struct2ArrayAc.ref.cpp
@@ -74,14 +74,14 @@ Struct2 ::
 Struct2::ElementType& Struct2 ::
   operator[](const U32 i)
 {
-  FW_ASSERT(i < SIZE);
+  FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
   return this->elements[i];
 }
 
 const Struct2::ElementType& Struct2 ::
   operator[](const U32 i) const
 {
-  FW_ASSERT(i < SIZE);
+  FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
   return this->elements[i];
 }
 

--- a/compiler/tools/fpp-to-cpp/test/array/Struct3ArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/array/Struct3ArrayAc.ref.cpp
@@ -74,14 +74,14 @@ Struct3 ::
 Struct3::ElementType& Struct3 ::
   operator[](const U32 i)
 {
-  FW_ASSERT(i < SIZE);
+  FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
   return this->elements[i];
 }
 
 const Struct3::ElementType& Struct3 ::
   operator[](const U32 i) const
 {
-  FW_ASSERT(i < SIZE);
+  FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
   return this->elements[i];
 }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/AArrayAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/AArrayAc.ref.cpp
@@ -74,14 +74,14 @@ A ::
 A::ElementType& A ::
   operator[](const U32 i)
 {
-  FW_ASSERT(i < SIZE);
+  FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
   return this->elements[i];
 }
 
 const A::ElementType& A ::
   operator[](const U32 i) const
 {
-  FW_ASSERT(i < SIZE);
+  FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
   return this->elements[i];
 }
 

--- a/docs/users-guide/examples/impl-abs-type/AArrayAc.cpp
+++ b/docs/users-guide/examples/impl-abs-type/AArrayAc.cpp
@@ -91,14 +91,14 @@
   A::ElementType& A ::
     operator[](const U32 i)
   {
-    FW_ASSERT(i < SIZE);
+    FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
     return this->elements[i];
   }
   
   const A::ElementType& A ::
     operator[](const U32 i) const
   {
-    FW_ASSERT(i < SIZE);
+    FW_ASSERT(i < SIZE, static_cast<FwAssertArgType>(i), static_cast<FwAssertArgType>(SIZE));
     return this->elements[i];
   }
   


### PR DESCRIPTION
### Change

Added in the assert the index and the SIZE. Since the assert accepts multiple parameters I think it would help to know the index that makes the assert fail.