### PR TITLE
Added void keyword for unused variables

### DIFF
--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCommands.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCommands.scala
@@ -306,7 +306,12 @@ case class ComponentCommands (
             cmdSeqParam
           ),
           CppDoc.Type("void"),
-          lines("// Defaults to no-op; can be overridden"),
+          lines(
+            s"""|// Defaults to no-op; can be overridden
+                |(void) opCode;
+                |(void) cmdSeq;
+                |"""
+          ),
           CppDoc.Function.Virtual
         )
       )

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveCommandsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveCommandsComponentAc.ref.cpp
@@ -3588,6 +3588,8 @@ void ActiveCommandsComponentBase ::
   )
 {
   // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
 void ActiveCommandsComponentBase ::
@@ -3597,6 +3599,8 @@ void ActiveCommandsComponentBase ::
   )
 {
   // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
 void ActiveCommandsComponentBase ::
@@ -3606,6 +3610,8 @@ void ActiveCommandsComponentBase ::
   )
 {
   // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
 void ActiveCommandsComponentBase ::
@@ -3615,6 +3621,8 @@ void ActiveCommandsComponentBase ::
   )
 {
   // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
 void ActiveCommandsComponentBase ::
@@ -3624,6 +3632,8 @@ void ActiveCommandsComponentBase ::
   )
 {
   // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
 // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.cpp
@@ -4810,6 +4810,8 @@ void ActiveSerialComponentBase ::
   )
 {
   // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
 void ActiveSerialComponentBase ::
@@ -4819,6 +4821,8 @@ void ActiveSerialComponentBase ::
   )
 {
   // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
 void ActiveSerialComponentBase ::
@@ -4828,6 +4832,8 @@ void ActiveSerialComponentBase ::
   )
 {
   // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
 void ActiveSerialComponentBase ::
@@ -4837,6 +4843,8 @@ void ActiveSerialComponentBase ::
   )
 {
   // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
 void ActiveSerialComponentBase ::
@@ -4846,6 +4854,8 @@ void ActiveSerialComponentBase ::
   )
 {
   // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
 // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
@@ -4591,6 +4591,8 @@ namespace M {
     )
   {
     // Defaults to no-op; can be overridden
+    (void) opCode;
+    (void) cmdSeq;
   }
 
   void ActiveTestComponentBase ::
@@ -4600,6 +4602,8 @@ namespace M {
     )
   {
     // Defaults to no-op; can be overridden
+    (void) opCode;
+    (void) cmdSeq;
   }
 
   void ActiveTestComponentBase ::
@@ -4609,6 +4613,8 @@ namespace M {
     )
   {
     // Defaults to no-op; can be overridden
+    (void) opCode;
+    (void) cmdSeq;
   }
 
   void ActiveTestComponentBase ::
@@ -4618,6 +4624,8 @@ namespace M {
     )
   {
     // Defaults to no-op; can be overridden
+    (void) opCode;
+    (void) cmdSeq;
   }
 
   void ActiveTestComponentBase ::
@@ -4627,6 +4635,8 @@ namespace M {
     )
   {
     // Defaults to no-op; can be overridden
+    (void) opCode;
+    (void) cmdSeq;
   }
 
   // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedCommandsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedCommandsComponentAc.ref.cpp
@@ -3588,6 +3588,8 @@ void QueuedCommandsComponentBase ::
   )
 {
   // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
 void QueuedCommandsComponentBase ::
@@ -3597,6 +3599,8 @@ void QueuedCommandsComponentBase ::
   )
 {
   // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
 void QueuedCommandsComponentBase ::
@@ -3606,6 +3610,8 @@ void QueuedCommandsComponentBase ::
   )
 {
   // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
 void QueuedCommandsComponentBase ::
@@ -3615,6 +3621,8 @@ void QueuedCommandsComponentBase ::
   )
 {
   // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
 void QueuedCommandsComponentBase ::
@@ -3624,6 +3632,8 @@ void QueuedCommandsComponentBase ::
   )
 {
   // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
 // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.cpp
@@ -4810,6 +4810,8 @@ void QueuedSerialComponentBase ::
   )
 {
   // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
 void QueuedSerialComponentBase ::
@@ -4819,6 +4821,8 @@ void QueuedSerialComponentBase ::
   )
 {
   // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
 void QueuedSerialComponentBase ::
@@ -4828,6 +4832,8 @@ void QueuedSerialComponentBase ::
   )
 {
   // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
 void QueuedSerialComponentBase ::
@@ -4837,6 +4843,8 @@ void QueuedSerialComponentBase ::
   )
 {
   // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
 void QueuedSerialComponentBase ::
@@ -4846,6 +4854,8 @@ void QueuedSerialComponentBase ::
   )
 {
   // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
 // ----------------------------------------------------------------------

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
@@ -4589,6 +4589,8 @@ void QueuedTestComponentBase ::
   )
 {
   // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
 void QueuedTestComponentBase ::
@@ -4598,6 +4600,8 @@ void QueuedTestComponentBase ::
   )
 {
   // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
 void QueuedTestComponentBase ::
@@ -4607,6 +4611,8 @@ void QueuedTestComponentBase ::
   )
 {
   // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
 void QueuedTestComponentBase ::
@@ -4616,6 +4622,8 @@ void QueuedTestComponentBase ::
   )
 {
   // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
 void QueuedTestComponentBase ::
@@ -4625,6 +4633,8 @@ void QueuedTestComponentBase ::
   )
 {
   // Defaults to no-op; can be overridden
+  (void) opCode;
+  (void) cmdSeq;
 }
 
 // ----------------------------------------------------------------------


### PR DESCRIPTION
In the generated methods `CMD_..._preMsgHook` there were two unused variables. I added `(void)` to remove the warning in case of using `-WPedantic`