### PR TITLE
Add support for Fw::ObjectName

### DIFF
--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCppWriter.scala
@@ -967,12 +967,6 @@ object ComponentCppWriter extends CppWriterUtils {
           },
           Line.blank :: lines(
             s"""|#if FW_OBJECT_NAMES == 1
-                |// The port name consists of this->m_objName and some extra info.
-                |// We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-                |// However, the compiler may assume that this->m_objName fills
-                |// the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-                |// avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-                |// bytes to cover the extra info.
                 |Fw::ObjectName portName;
                 |portName.format(
                 |  "%s_${printName(port)}[%" PRI_PlatformIntType "]",

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentCppWriter.scala
@@ -973,15 +973,13 @@ object ComponentCppWriter extends CppWriterUtils {
                 |// the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
                 |// avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
                 |// bytes to cover the extra info.
-                |char portName[2*FW_OBJ_NAME_MAX_SIZE];
-                |(void) snprintf(
-                |  portName,
-                |  sizeof(portName),
+                |Fw::ObjectName portName;
+                |portName.format(
                 |  "%s_${printName(port)}[%" PRI_PlatformIntType "]",
-                |  this->m_objName,
+                |  this->m_objName.toChar(),
                 |  port
                 |);
-                |this->${variableName(port)}[port].setObjName(portName);
+                |this->${variableName(port)}[port].setObjName(portName.toChar());
                 |#endif
                 |"""
           )

--- a/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentEvents.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/ComponentCppWriter/ComponentEvents.scala
@@ -214,7 +214,7 @@ case class ComponentEvents (
                     |  FW_LOG_TEXT_BUFFER_SIZE,
                     |  _formatString,
                     |#if FW_OBJECT_NAMES == 1
-                    |  this->m_objName,
+                    |  this->m_objName.toChar(),
                     |#endif
                     |"""
               ),

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveAsyncProductPortsOnlyComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveAsyncProductPortsOnlyComponentAc.ref.cpp
@@ -92,15 +92,13 @@ void ActiveAsyncProductPortsOnlyComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_productRecvIn_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_productRecvIn_InputPort[port].setObjName(portName);
+    this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -119,15 +117,13 @@ void ActiveAsyncProductPortsOnlyComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_productRequestOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_productRequestOut_OutputPort[port].setObjName(portName);
+    this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -146,15 +142,13 @@ void ActiveAsyncProductPortsOnlyComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_productSendOut_OutputPort[port].setObjName(portName);
+    this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveAsyncProductPortsOnlyComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveAsyncProductPortsOnlyComponentAc.ref.cpp
@@ -86,12 +86,6 @@ void ActiveAsyncProductPortsOnlyComponentBase ::
     this->m_productRecvIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_productRecvIn_InputPort[%" PRI_PlatformIntType "]",
@@ -111,12 +105,6 @@ void ActiveAsyncProductPortsOnlyComponentBase ::
     this->m_productRequestOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_productRequestOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -136,12 +124,6 @@ void ActiveAsyncProductPortsOnlyComponentBase ::
     this->m_productSendOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveAsyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveAsyncProductsComponentAc.ref.cpp
@@ -257,15 +257,13 @@ void ActiveAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdIn_InputPort[port].setObjName(portName);
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -289,15 +287,13 @@ void ActiveAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_productRecvIn_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_productRecvIn_InputPort[port].setObjName(portName);
+    this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -321,15 +317,13 @@ void ActiveAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsAsync_InputPort[port].setObjName(portName);
+    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -353,15 +347,13 @@ void ActiveAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -385,15 +377,13 @@ void ActiveAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -417,15 +407,13 @@ void ActiveAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -449,15 +437,13 @@ void ActiveAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsSync_InputPort[port].setObjName(portName);
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -481,15 +467,13 @@ void ActiveAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsync_InputPort[port].setObjName(portName);
+    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -513,15 +497,13 @@ void ActiveAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncAssert_InputPort[port].setObjName(portName);
+    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -545,15 +527,13 @@ void ActiveAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName);
+    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -577,15 +557,13 @@ void ActiveAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName);
+    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -609,15 +587,13 @@ void ActiveAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedGuarded_InputPort[port].setObjName(portName);
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -641,15 +617,13 @@ void ActiveAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -673,15 +647,13 @@ void ActiveAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName);
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -705,15 +677,13 @@ void ActiveAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedSync_InputPort[port].setObjName(portName);
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -732,15 +702,13 @@ void ActiveAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName);
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -759,15 +727,13 @@ void ActiveAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName);
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -786,15 +752,13 @@ void ActiveAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_eventOut_OutputPort[port].setObjName(portName);
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -813,15 +777,13 @@ void ActiveAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName);
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -840,15 +802,13 @@ void ActiveAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName);
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -867,15 +827,13 @@ void ActiveAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_productRequestOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_productRequestOut_OutputPort[port].setObjName(portName);
+    this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -894,15 +852,13 @@ void ActiveAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_productSendOut_OutputPort[port].setObjName(portName);
+    this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -922,15 +878,13 @@ void ActiveAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_textEventOut_OutputPort[port].setObjName(portName);
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 #endif
@@ -950,15 +904,13 @@ void ActiveAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName);
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -977,15 +929,13 @@ void ActiveAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_tlmOut_OutputPort[port].setObjName(portName);
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -1004,15 +954,13 @@ void ActiveAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -1031,15 +979,13 @@ void ActiveAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -1058,15 +1004,13 @@ void ActiveAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedOut_OutputPort[port].setObjName(portName);
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -1085,15 +1029,13 @@ void ActiveAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName);
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveAsyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveAsyncProductsComponentAc.ref.cpp
@@ -251,12 +251,6 @@ void ActiveAsyncProductsComponentBase ::
     this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
@@ -281,12 +275,6 @@ void ActiveAsyncProductsComponentBase ::
     this->m_productRecvIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_productRecvIn_InputPort[%" PRI_PlatformIntType "]",
@@ -311,12 +299,6 @@ void ActiveAsyncProductsComponentBase ::
     this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
@@ -341,12 +323,6 @@ void ActiveAsyncProductsComponentBase ::
     this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -371,12 +347,6 @@ void ActiveAsyncProductsComponentBase ::
     this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -401,12 +371,6 @@ void ActiveAsyncProductsComponentBase ::
     this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -431,12 +395,6 @@ void ActiveAsyncProductsComponentBase ::
     this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
@@ -461,12 +419,6 @@ void ActiveAsyncProductsComponentBase ::
     this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
@@ -491,12 +443,6 @@ void ActiveAsyncProductsComponentBase ::
     this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
@@ -521,12 +467,6 @@ void ActiveAsyncProductsComponentBase ::
     this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
@@ -551,12 +491,6 @@ void ActiveAsyncProductsComponentBase ::
     this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
@@ -581,12 +515,6 @@ void ActiveAsyncProductsComponentBase ::
     this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -611,12 +539,6 @@ void ActiveAsyncProductsComponentBase ::
     this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -641,12 +563,6 @@ void ActiveAsyncProductsComponentBase ::
     this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -671,12 +587,6 @@ void ActiveAsyncProductsComponentBase ::
     this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
@@ -696,12 +606,6 @@ void ActiveAsyncProductsComponentBase ::
     this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -721,12 +625,6 @@ void ActiveAsyncProductsComponentBase ::
     this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -746,12 +644,6 @@ void ActiveAsyncProductsComponentBase ::
     this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -771,12 +663,6 @@ void ActiveAsyncProductsComponentBase ::
     this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -796,12 +682,6 @@ void ActiveAsyncProductsComponentBase ::
     this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -821,12 +701,6 @@ void ActiveAsyncProductsComponentBase ::
     this->m_productRequestOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_productRequestOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -846,12 +720,6 @@ void ActiveAsyncProductsComponentBase ::
     this->m_productSendOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -872,12 +740,6 @@ void ActiveAsyncProductsComponentBase ::
     this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -898,12 +760,6 @@ void ActiveAsyncProductsComponentBase ::
     this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -923,12 +779,6 @@ void ActiveAsyncProductsComponentBase ::
     this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -948,12 +798,6 @@ void ActiveAsyncProductsComponentBase ::
     this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -973,12 +817,6 @@ void ActiveAsyncProductsComponentBase ::
     this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -998,12 +836,6 @@ void ActiveAsyncProductsComponentBase ::
     this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -1023,12 +855,6 @@ void ActiveAsyncProductsComponentBase ::
     this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveCommandsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveCommandsComponentAc.ref.cpp
@@ -105,15 +105,13 @@ void ActiveCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdIn_InputPort[port].setObjName(portName);
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -137,15 +135,13 @@ void ActiveCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsAsync_InputPort[port].setObjName(portName);
+    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -169,15 +165,13 @@ void ActiveCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -201,15 +195,13 @@ void ActiveCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -233,15 +225,13 @@ void ActiveCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -265,15 +255,13 @@ void ActiveCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsSync_InputPort[port].setObjName(portName);
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -297,15 +285,13 @@ void ActiveCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsync_InputPort[port].setObjName(portName);
+    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -329,15 +315,13 @@ void ActiveCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncAssert_InputPort[port].setObjName(portName);
+    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -361,15 +345,13 @@ void ActiveCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName);
+    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -393,15 +375,13 @@ void ActiveCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName);
+    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -425,15 +405,13 @@ void ActiveCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedGuarded_InputPort[port].setObjName(portName);
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -457,15 +435,13 @@ void ActiveCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -489,15 +465,13 @@ void ActiveCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName);
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -521,15 +495,13 @@ void ActiveCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedSync_InputPort[port].setObjName(portName);
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -548,15 +520,13 @@ void ActiveCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName);
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -575,15 +545,13 @@ void ActiveCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName);
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -602,15 +570,13 @@ void ActiveCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_eventOut_OutputPort[port].setObjName(portName);
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -629,15 +595,13 @@ void ActiveCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName);
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -656,15 +620,13 @@ void ActiveCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName);
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -684,15 +646,13 @@ void ActiveCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_textEventOut_OutputPort[port].setObjName(portName);
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 #endif
@@ -712,15 +672,13 @@ void ActiveCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName);
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -739,15 +697,13 @@ void ActiveCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_tlmOut_OutputPort[port].setObjName(portName);
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -766,15 +722,13 @@ void ActiveCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -793,15 +747,13 @@ void ActiveCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -820,15 +772,13 @@ void ActiveCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedOut_OutputPort[port].setObjName(portName);
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -847,15 +797,13 @@ void ActiveCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName);
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveCommandsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveCommandsComponentAc.ref.cpp
@@ -99,12 +99,6 @@ void ActiveCommandsComponentBase ::
     this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
@@ -129,12 +123,6 @@ void ActiveCommandsComponentBase ::
     this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
@@ -159,12 +147,6 @@ void ActiveCommandsComponentBase ::
     this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -189,12 +171,6 @@ void ActiveCommandsComponentBase ::
     this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -219,12 +195,6 @@ void ActiveCommandsComponentBase ::
     this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -249,12 +219,6 @@ void ActiveCommandsComponentBase ::
     this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
@@ -279,12 +243,6 @@ void ActiveCommandsComponentBase ::
     this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
@@ -309,12 +267,6 @@ void ActiveCommandsComponentBase ::
     this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
@@ -339,12 +291,6 @@ void ActiveCommandsComponentBase ::
     this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
@@ -369,12 +315,6 @@ void ActiveCommandsComponentBase ::
     this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
@@ -399,12 +339,6 @@ void ActiveCommandsComponentBase ::
     this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -429,12 +363,6 @@ void ActiveCommandsComponentBase ::
     this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -459,12 +387,6 @@ void ActiveCommandsComponentBase ::
     this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -489,12 +411,6 @@ void ActiveCommandsComponentBase ::
     this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
@@ -514,12 +430,6 @@ void ActiveCommandsComponentBase ::
     this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -539,12 +449,6 @@ void ActiveCommandsComponentBase ::
     this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -564,12 +468,6 @@ void ActiveCommandsComponentBase ::
     this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -589,12 +487,6 @@ void ActiveCommandsComponentBase ::
     this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -614,12 +506,6 @@ void ActiveCommandsComponentBase ::
     this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -640,12 +526,6 @@ void ActiveCommandsComponentBase ::
     this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -666,12 +546,6 @@ void ActiveCommandsComponentBase ::
     this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -691,12 +565,6 @@ void ActiveCommandsComponentBase ::
     this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -716,12 +584,6 @@ void ActiveCommandsComponentBase ::
     this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -741,12 +603,6 @@ void ActiveCommandsComponentBase ::
     this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -766,12 +622,6 @@ void ActiveCommandsComponentBase ::
     this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -791,12 +641,6 @@ void ActiveCommandsComponentBase ::
     this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveEventsComponentAc.ref.cpp
@@ -100,15 +100,13 @@ void ActiveEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdIn_InputPort[port].setObjName(portName);
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -132,15 +130,13 @@ void ActiveEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsAsync_InputPort[port].setObjName(portName);
+    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -164,15 +160,13 @@ void ActiveEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -196,15 +190,13 @@ void ActiveEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -228,15 +220,13 @@ void ActiveEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -260,15 +250,13 @@ void ActiveEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsSync_InputPort[port].setObjName(portName);
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -292,15 +280,13 @@ void ActiveEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsync_InputPort[port].setObjName(portName);
+    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -324,15 +310,13 @@ void ActiveEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncAssert_InputPort[port].setObjName(portName);
+    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -356,15 +340,13 @@ void ActiveEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName);
+    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -388,15 +370,13 @@ void ActiveEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName);
+    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -420,15 +400,13 @@ void ActiveEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedGuarded_InputPort[port].setObjName(portName);
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -452,15 +430,13 @@ void ActiveEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -484,15 +460,13 @@ void ActiveEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName);
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -516,15 +490,13 @@ void ActiveEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedSync_InputPort[port].setObjName(portName);
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -543,15 +515,13 @@ void ActiveEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName);
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -570,15 +540,13 @@ void ActiveEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName);
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -597,15 +565,13 @@ void ActiveEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_eventOut_OutputPort[port].setObjName(portName);
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -624,15 +590,13 @@ void ActiveEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName);
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -651,15 +615,13 @@ void ActiveEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName);
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -679,15 +641,13 @@ void ActiveEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_textEventOut_OutputPort[port].setObjName(portName);
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 #endif
@@ -707,15 +667,13 @@ void ActiveEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName);
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -734,15 +692,13 @@ void ActiveEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_tlmOut_OutputPort[port].setObjName(portName);
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -761,15 +717,13 @@ void ActiveEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -788,15 +742,13 @@ void ActiveEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -815,15 +767,13 @@ void ActiveEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedOut_OutputPort[port].setObjName(portName);
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -842,15 +792,13 @@ void ActiveEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName);
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -2595,7 +2543,7 @@ void ActiveEventsComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventActivityHigh "
     );
@@ -2726,7 +2674,7 @@ void ActiveEventsComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventActivityLowThrottled ",
       u32,
@@ -2815,7 +2763,7 @@ void ActiveEventsComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventCommand ",
       str1.toChar(),
@@ -2907,7 +2855,7 @@ void ActiveEventsComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventDiagnostic ",
       eStr.toChar()
@@ -3019,7 +2967,7 @@ void ActiveEventsComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventFatalThrottled ",
       aStr.toChar()
@@ -3110,7 +3058,7 @@ void ActiveEventsComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventWarningHigh ",
       sStr.toChar()
@@ -3190,7 +3138,7 @@ void ActiveEventsComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventWarningLowThrottled "
     );

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveEventsComponentAc.ref.cpp
@@ -94,12 +94,6 @@ void ActiveEventsComponentBase ::
     this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
@@ -124,12 +118,6 @@ void ActiveEventsComponentBase ::
     this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
@@ -154,12 +142,6 @@ void ActiveEventsComponentBase ::
     this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -184,12 +166,6 @@ void ActiveEventsComponentBase ::
     this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -214,12 +190,6 @@ void ActiveEventsComponentBase ::
     this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -244,12 +214,6 @@ void ActiveEventsComponentBase ::
     this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
@@ -274,12 +238,6 @@ void ActiveEventsComponentBase ::
     this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
@@ -304,12 +262,6 @@ void ActiveEventsComponentBase ::
     this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
@@ -334,12 +286,6 @@ void ActiveEventsComponentBase ::
     this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
@@ -364,12 +310,6 @@ void ActiveEventsComponentBase ::
     this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
@@ -394,12 +334,6 @@ void ActiveEventsComponentBase ::
     this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -424,12 +358,6 @@ void ActiveEventsComponentBase ::
     this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -454,12 +382,6 @@ void ActiveEventsComponentBase ::
     this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -484,12 +406,6 @@ void ActiveEventsComponentBase ::
     this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
@@ -509,12 +425,6 @@ void ActiveEventsComponentBase ::
     this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -534,12 +444,6 @@ void ActiveEventsComponentBase ::
     this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -559,12 +463,6 @@ void ActiveEventsComponentBase ::
     this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -584,12 +482,6 @@ void ActiveEventsComponentBase ::
     this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -609,12 +501,6 @@ void ActiveEventsComponentBase ::
     this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -635,12 +521,6 @@ void ActiveEventsComponentBase ::
     this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -661,12 +541,6 @@ void ActiveEventsComponentBase ::
     this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -686,12 +560,6 @@ void ActiveEventsComponentBase ::
     this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -711,12 +579,6 @@ void ActiveEventsComponentBase ::
     this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -736,12 +598,6 @@ void ActiveEventsComponentBase ::
     this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -761,12 +617,6 @@ void ActiveEventsComponentBase ::
     this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -786,12 +636,6 @@ void ActiveEventsComponentBase ::
     this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveGetProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveGetProductsComponentAc.ref.cpp
@@ -255,15 +255,13 @@ void ActiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdIn_InputPort[port].setObjName(portName);
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -287,15 +285,13 @@ void ActiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsAsync_InputPort[port].setObjName(portName);
+    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -319,15 +315,13 @@ void ActiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -351,15 +345,13 @@ void ActiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -383,15 +375,13 @@ void ActiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -415,15 +405,13 @@ void ActiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsSync_InputPort[port].setObjName(portName);
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -447,15 +435,13 @@ void ActiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsync_InputPort[port].setObjName(portName);
+    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -479,15 +465,13 @@ void ActiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncAssert_InputPort[port].setObjName(portName);
+    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -511,15 +495,13 @@ void ActiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName);
+    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -543,15 +525,13 @@ void ActiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName);
+    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -575,15 +555,13 @@ void ActiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedGuarded_InputPort[port].setObjName(portName);
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -607,15 +585,13 @@ void ActiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -639,15 +615,13 @@ void ActiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName);
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -671,15 +645,13 @@ void ActiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedSync_InputPort[port].setObjName(portName);
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -698,15 +670,13 @@ void ActiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName);
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -725,15 +695,13 @@ void ActiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName);
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -752,15 +720,13 @@ void ActiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_eventOut_OutputPort[port].setObjName(portName);
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -779,15 +745,13 @@ void ActiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName);
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -806,15 +770,13 @@ void ActiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName);
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -833,15 +795,13 @@ void ActiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_productGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_productGetOut_OutputPort[port].setObjName(portName);
+    this->m_productGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -860,15 +820,13 @@ void ActiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_productSendOut_OutputPort[port].setObjName(portName);
+    this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -888,15 +846,13 @@ void ActiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_textEventOut_OutputPort[port].setObjName(portName);
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 #endif
@@ -916,15 +872,13 @@ void ActiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName);
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -943,15 +897,13 @@ void ActiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_tlmOut_OutputPort[port].setObjName(portName);
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -970,15 +922,13 @@ void ActiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -997,15 +947,13 @@ void ActiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -1024,15 +972,13 @@ void ActiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedOut_OutputPort[port].setObjName(portName);
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -1051,15 +997,13 @@ void ActiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName);
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveGetProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveGetProductsComponentAc.ref.cpp
@@ -249,12 +249,6 @@ void ActiveGetProductsComponentBase ::
     this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
@@ -279,12 +273,6 @@ void ActiveGetProductsComponentBase ::
     this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
@@ -309,12 +297,6 @@ void ActiveGetProductsComponentBase ::
     this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -339,12 +321,6 @@ void ActiveGetProductsComponentBase ::
     this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -369,12 +345,6 @@ void ActiveGetProductsComponentBase ::
     this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -399,12 +369,6 @@ void ActiveGetProductsComponentBase ::
     this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
@@ -429,12 +393,6 @@ void ActiveGetProductsComponentBase ::
     this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
@@ -459,12 +417,6 @@ void ActiveGetProductsComponentBase ::
     this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
@@ -489,12 +441,6 @@ void ActiveGetProductsComponentBase ::
     this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
@@ -519,12 +465,6 @@ void ActiveGetProductsComponentBase ::
     this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
@@ -549,12 +489,6 @@ void ActiveGetProductsComponentBase ::
     this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -579,12 +513,6 @@ void ActiveGetProductsComponentBase ::
     this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -609,12 +537,6 @@ void ActiveGetProductsComponentBase ::
     this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -639,12 +561,6 @@ void ActiveGetProductsComponentBase ::
     this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
@@ -664,12 +580,6 @@ void ActiveGetProductsComponentBase ::
     this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -689,12 +599,6 @@ void ActiveGetProductsComponentBase ::
     this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -714,12 +618,6 @@ void ActiveGetProductsComponentBase ::
     this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -739,12 +637,6 @@ void ActiveGetProductsComponentBase ::
     this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -764,12 +656,6 @@ void ActiveGetProductsComponentBase ::
     this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -789,12 +675,6 @@ void ActiveGetProductsComponentBase ::
     this->m_productGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_productGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -814,12 +694,6 @@ void ActiveGetProductsComponentBase ::
     this->m_productSendOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -840,12 +714,6 @@ void ActiveGetProductsComponentBase ::
     this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -866,12 +734,6 @@ void ActiveGetProductsComponentBase ::
     this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -891,12 +753,6 @@ void ActiveGetProductsComponentBase ::
     this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -916,12 +772,6 @@ void ActiveGetProductsComponentBase ::
     this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -941,12 +791,6 @@ void ActiveGetProductsComponentBase ::
     this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -966,12 +810,6 @@ void ActiveGetProductsComponentBase ::
     this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -991,12 +829,6 @@ void ActiveGetProductsComponentBase ::
     this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveGuardedProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveGuardedProductsComponentAc.ref.cpp
@@ -255,15 +255,13 @@ void ActiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdIn_InputPort[port].setObjName(portName);
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -287,15 +285,13 @@ void ActiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_productRecvIn_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_productRecvIn_InputPort[port].setObjName(portName);
+    this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -319,15 +315,13 @@ void ActiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsAsync_InputPort[port].setObjName(portName);
+    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -351,15 +345,13 @@ void ActiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -383,15 +375,13 @@ void ActiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -415,15 +405,13 @@ void ActiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -447,15 +435,13 @@ void ActiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsSync_InputPort[port].setObjName(portName);
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -479,15 +465,13 @@ void ActiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsync_InputPort[port].setObjName(portName);
+    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -511,15 +495,13 @@ void ActiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncAssert_InputPort[port].setObjName(portName);
+    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -543,15 +525,13 @@ void ActiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName);
+    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -575,15 +555,13 @@ void ActiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName);
+    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -607,15 +585,13 @@ void ActiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedGuarded_InputPort[port].setObjName(portName);
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -639,15 +615,13 @@ void ActiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -671,15 +645,13 @@ void ActiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName);
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -703,15 +675,13 @@ void ActiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedSync_InputPort[port].setObjName(portName);
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -730,15 +700,13 @@ void ActiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName);
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -757,15 +725,13 @@ void ActiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName);
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -784,15 +750,13 @@ void ActiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_eventOut_OutputPort[port].setObjName(portName);
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -811,15 +775,13 @@ void ActiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName);
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -838,15 +800,13 @@ void ActiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName);
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -865,15 +825,13 @@ void ActiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_productRequestOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_productRequestOut_OutputPort[port].setObjName(portName);
+    this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -892,15 +850,13 @@ void ActiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_productSendOut_OutputPort[port].setObjName(portName);
+    this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -920,15 +876,13 @@ void ActiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_textEventOut_OutputPort[port].setObjName(portName);
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 #endif
@@ -948,15 +902,13 @@ void ActiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName);
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -975,15 +927,13 @@ void ActiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_tlmOut_OutputPort[port].setObjName(portName);
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -1002,15 +952,13 @@ void ActiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -1029,15 +977,13 @@ void ActiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -1056,15 +1002,13 @@ void ActiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedOut_OutputPort[port].setObjName(portName);
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -1083,15 +1027,13 @@ void ActiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName);
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveGuardedProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveGuardedProductsComponentAc.ref.cpp
@@ -249,12 +249,6 @@ void ActiveGuardedProductsComponentBase ::
     this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
@@ -279,12 +273,6 @@ void ActiveGuardedProductsComponentBase ::
     this->m_productRecvIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_productRecvIn_InputPort[%" PRI_PlatformIntType "]",
@@ -309,12 +297,6 @@ void ActiveGuardedProductsComponentBase ::
     this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
@@ -339,12 +321,6 @@ void ActiveGuardedProductsComponentBase ::
     this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -369,12 +345,6 @@ void ActiveGuardedProductsComponentBase ::
     this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -399,12 +369,6 @@ void ActiveGuardedProductsComponentBase ::
     this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -429,12 +393,6 @@ void ActiveGuardedProductsComponentBase ::
     this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
@@ -459,12 +417,6 @@ void ActiveGuardedProductsComponentBase ::
     this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
@@ -489,12 +441,6 @@ void ActiveGuardedProductsComponentBase ::
     this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
@@ -519,12 +465,6 @@ void ActiveGuardedProductsComponentBase ::
     this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
@@ -549,12 +489,6 @@ void ActiveGuardedProductsComponentBase ::
     this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
@@ -579,12 +513,6 @@ void ActiveGuardedProductsComponentBase ::
     this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -609,12 +537,6 @@ void ActiveGuardedProductsComponentBase ::
     this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -639,12 +561,6 @@ void ActiveGuardedProductsComponentBase ::
     this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -669,12 +585,6 @@ void ActiveGuardedProductsComponentBase ::
     this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
@@ -694,12 +604,6 @@ void ActiveGuardedProductsComponentBase ::
     this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -719,12 +623,6 @@ void ActiveGuardedProductsComponentBase ::
     this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -744,12 +642,6 @@ void ActiveGuardedProductsComponentBase ::
     this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -769,12 +661,6 @@ void ActiveGuardedProductsComponentBase ::
     this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -794,12 +680,6 @@ void ActiveGuardedProductsComponentBase ::
     this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -819,12 +699,6 @@ void ActiveGuardedProductsComponentBase ::
     this->m_productRequestOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_productRequestOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -844,12 +718,6 @@ void ActiveGuardedProductsComponentBase ::
     this->m_productSendOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -870,12 +738,6 @@ void ActiveGuardedProductsComponentBase ::
     this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -896,12 +758,6 @@ void ActiveGuardedProductsComponentBase ::
     this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -921,12 +777,6 @@ void ActiveGuardedProductsComponentBase ::
     this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -946,12 +796,6 @@ void ActiveGuardedProductsComponentBase ::
     this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -971,12 +815,6 @@ void ActiveGuardedProductsComponentBase ::
     this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -996,12 +834,6 @@ void ActiveGuardedProductsComponentBase ::
     this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -1021,12 +853,6 @@ void ActiveGuardedProductsComponentBase ::
     this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveNoArgsPortsOnlyComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveNoArgsPortsOnlyComponentAc.ref.cpp
@@ -79,12 +79,6 @@ void ActiveNoArgsPortsOnlyComponentBase ::
     this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
@@ -109,12 +103,6 @@ void ActiveNoArgsPortsOnlyComponentBase ::
     this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -139,12 +127,6 @@ void ActiveNoArgsPortsOnlyComponentBase ::
     this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -169,12 +151,6 @@ void ActiveNoArgsPortsOnlyComponentBase ::
     this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -194,12 +170,6 @@ void ActiveNoArgsPortsOnlyComponentBase ::
     this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -219,12 +189,6 @@ void ActiveNoArgsPortsOnlyComponentBase ::
     this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveNoArgsPortsOnlyComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveNoArgsPortsOnlyComponentAc.ref.cpp
@@ -85,15 +85,13 @@ void ActiveNoArgsPortsOnlyComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsAsync_InputPort[port].setObjName(portName);
+    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -117,15 +115,13 @@ void ActiveNoArgsPortsOnlyComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -149,15 +145,13 @@ void ActiveNoArgsPortsOnlyComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -181,15 +175,13 @@ void ActiveNoArgsPortsOnlyComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -208,15 +200,13 @@ void ActiveNoArgsPortsOnlyComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -235,15 +225,13 @@ void ActiveNoArgsPortsOnlyComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveParamsComponentAc.ref.cpp
@@ -100,15 +100,13 @@ void ActiveParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdIn_InputPort[port].setObjName(portName);
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -132,15 +130,13 @@ void ActiveParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsAsync_InputPort[port].setObjName(portName);
+    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -164,15 +160,13 @@ void ActiveParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -196,15 +190,13 @@ void ActiveParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -228,15 +220,13 @@ void ActiveParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -260,15 +250,13 @@ void ActiveParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsSync_InputPort[port].setObjName(portName);
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -292,15 +280,13 @@ void ActiveParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsync_InputPort[port].setObjName(portName);
+    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -324,15 +310,13 @@ void ActiveParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncAssert_InputPort[port].setObjName(portName);
+    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -356,15 +340,13 @@ void ActiveParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName);
+    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -388,15 +370,13 @@ void ActiveParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName);
+    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -420,15 +400,13 @@ void ActiveParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedGuarded_InputPort[port].setObjName(portName);
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -452,15 +430,13 @@ void ActiveParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -484,15 +460,13 @@ void ActiveParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName);
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -516,15 +490,13 @@ void ActiveParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedSync_InputPort[port].setObjName(portName);
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -543,15 +515,13 @@ void ActiveParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName);
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -570,15 +540,13 @@ void ActiveParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName);
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -597,15 +565,13 @@ void ActiveParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_eventOut_OutputPort[port].setObjName(portName);
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -624,15 +590,13 @@ void ActiveParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName);
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -651,15 +615,13 @@ void ActiveParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName);
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -679,15 +641,13 @@ void ActiveParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_textEventOut_OutputPort[port].setObjName(portName);
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 #endif
@@ -707,15 +667,13 @@ void ActiveParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName);
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -734,15 +692,13 @@ void ActiveParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_tlmOut_OutputPort[port].setObjName(portName);
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -761,15 +717,13 @@ void ActiveParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -788,15 +742,13 @@ void ActiveParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -815,15 +767,13 @@ void ActiveParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedOut_OutputPort[port].setObjName(portName);
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -842,15 +792,13 @@ void ActiveParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName);
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveParamsComponentAc.ref.cpp
@@ -94,12 +94,6 @@ void ActiveParamsComponentBase ::
     this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
@@ -124,12 +118,6 @@ void ActiveParamsComponentBase ::
     this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
@@ -154,12 +142,6 @@ void ActiveParamsComponentBase ::
     this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -184,12 +166,6 @@ void ActiveParamsComponentBase ::
     this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -214,12 +190,6 @@ void ActiveParamsComponentBase ::
     this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -244,12 +214,6 @@ void ActiveParamsComponentBase ::
     this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
@@ -274,12 +238,6 @@ void ActiveParamsComponentBase ::
     this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
@@ -304,12 +262,6 @@ void ActiveParamsComponentBase ::
     this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
@@ -334,12 +286,6 @@ void ActiveParamsComponentBase ::
     this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
@@ -364,12 +310,6 @@ void ActiveParamsComponentBase ::
     this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
@@ -394,12 +334,6 @@ void ActiveParamsComponentBase ::
     this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -424,12 +358,6 @@ void ActiveParamsComponentBase ::
     this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -454,12 +382,6 @@ void ActiveParamsComponentBase ::
     this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -484,12 +406,6 @@ void ActiveParamsComponentBase ::
     this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
@@ -509,12 +425,6 @@ void ActiveParamsComponentBase ::
     this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -534,12 +444,6 @@ void ActiveParamsComponentBase ::
     this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -559,12 +463,6 @@ void ActiveParamsComponentBase ::
     this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -584,12 +482,6 @@ void ActiveParamsComponentBase ::
     this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -609,12 +501,6 @@ void ActiveParamsComponentBase ::
     this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -635,12 +521,6 @@ void ActiveParamsComponentBase ::
     this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -661,12 +541,6 @@ void ActiveParamsComponentBase ::
     this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -686,12 +560,6 @@ void ActiveParamsComponentBase ::
     this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -711,12 +579,6 @@ void ActiveParamsComponentBase ::
     this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -736,12 +598,6 @@ void ActiveParamsComponentBase ::
     this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -761,12 +617,6 @@ void ActiveParamsComponentBase ::
     this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -786,12 +636,6 @@ void ActiveParamsComponentBase ::
     this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.cpp
@@ -133,12 +133,6 @@ void ActiveSerialComponentBase ::
     this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
@@ -163,12 +157,6 @@ void ActiveSerialComponentBase ::
     this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
@@ -193,12 +181,6 @@ void ActiveSerialComponentBase ::
     this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -223,12 +205,6 @@ void ActiveSerialComponentBase ::
     this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -253,12 +229,6 @@ void ActiveSerialComponentBase ::
     this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -283,12 +253,6 @@ void ActiveSerialComponentBase ::
     this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
@@ -313,12 +277,6 @@ void ActiveSerialComponentBase ::
     this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
@@ -343,12 +301,6 @@ void ActiveSerialComponentBase ::
     this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
@@ -373,12 +325,6 @@ void ActiveSerialComponentBase ::
     this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
@@ -403,12 +349,6 @@ void ActiveSerialComponentBase ::
     this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
@@ -433,12 +373,6 @@ void ActiveSerialComponentBase ::
     this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -463,12 +397,6 @@ void ActiveSerialComponentBase ::
     this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -493,12 +421,6 @@ void ActiveSerialComponentBase ::
     this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -523,12 +445,6 @@ void ActiveSerialComponentBase ::
     this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
@@ -553,12 +469,6 @@ void ActiveSerialComponentBase ::
     this->m_serialAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_serialAsync_InputPort[%" PRI_PlatformIntType "]",
@@ -583,12 +493,6 @@ void ActiveSerialComponentBase ::
     this->m_serialAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_serialAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
@@ -613,12 +517,6 @@ void ActiveSerialComponentBase ::
     this->m_serialAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_serialAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
@@ -643,12 +541,6 @@ void ActiveSerialComponentBase ::
     this->m_serialAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_serialAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
@@ -673,12 +565,6 @@ void ActiveSerialComponentBase ::
     this->m_serialGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_serialGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -703,12 +589,6 @@ void ActiveSerialComponentBase ::
     this->m_serialSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_serialSync_InputPort[%" PRI_PlatformIntType "]",
@@ -728,12 +608,6 @@ void ActiveSerialComponentBase ::
     this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -753,12 +627,6 @@ void ActiveSerialComponentBase ::
     this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -778,12 +646,6 @@ void ActiveSerialComponentBase ::
     this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -803,12 +665,6 @@ void ActiveSerialComponentBase ::
     this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -828,12 +684,6 @@ void ActiveSerialComponentBase ::
     this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -854,12 +704,6 @@ void ActiveSerialComponentBase ::
     this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -880,12 +724,6 @@ void ActiveSerialComponentBase ::
     this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -905,12 +743,6 @@ void ActiveSerialComponentBase ::
     this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -930,12 +762,6 @@ void ActiveSerialComponentBase ::
     this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -955,12 +781,6 @@ void ActiveSerialComponentBase ::
     this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -980,12 +800,6 @@ void ActiveSerialComponentBase ::
     this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -1005,12 +819,6 @@ void ActiveSerialComponentBase ::
     this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -1030,12 +838,6 @@ void ActiveSerialComponentBase ::
     this->m_serialOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_serialOut_OutputPort[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveSerialComponentAc.ref.cpp
@@ -139,15 +139,13 @@ void ActiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdIn_InputPort[port].setObjName(portName);
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -171,15 +169,13 @@ void ActiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsAsync_InputPort[port].setObjName(portName);
+    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -203,15 +199,13 @@ void ActiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -235,15 +229,13 @@ void ActiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -267,15 +259,13 @@ void ActiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -299,15 +289,13 @@ void ActiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsSync_InputPort[port].setObjName(portName);
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -331,15 +319,13 @@ void ActiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsync_InputPort[port].setObjName(portName);
+    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -363,15 +349,13 @@ void ActiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncAssert_InputPort[port].setObjName(portName);
+    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -395,15 +379,13 @@ void ActiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName);
+    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -427,15 +409,13 @@ void ActiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName);
+    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -459,15 +439,13 @@ void ActiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedGuarded_InputPort[port].setObjName(portName);
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -491,15 +469,13 @@ void ActiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -523,15 +499,13 @@ void ActiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName);
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -555,15 +529,13 @@ void ActiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedSync_InputPort[port].setObjName(portName);
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -587,15 +559,13 @@ void ActiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_serialAsync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_serialAsync_InputPort[port].setObjName(portName);
+    this->m_serialAsync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -619,15 +589,13 @@ void ActiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_serialAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_serialAsyncAssert_InputPort[port].setObjName(portName);
+    this->m_serialAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -651,15 +619,13 @@ void ActiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_serialAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_serialAsyncBlockPriority_InputPort[port].setObjName(portName);
+    this->m_serialAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -683,15 +649,13 @@ void ActiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_serialAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_serialAsyncDropPriority_InputPort[port].setObjName(portName);
+    this->m_serialAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -715,15 +679,13 @@ void ActiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_serialGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_serialGuarded_InputPort[port].setObjName(portName);
+    this->m_serialGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -747,15 +709,13 @@ void ActiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_serialSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_serialSync_InputPort[port].setObjName(portName);
+    this->m_serialSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -774,15 +734,13 @@ void ActiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName);
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -801,15 +759,13 @@ void ActiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName);
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -828,15 +784,13 @@ void ActiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_eventOut_OutputPort[port].setObjName(portName);
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -855,15 +809,13 @@ void ActiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName);
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -882,15 +834,13 @@ void ActiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName);
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -910,15 +860,13 @@ void ActiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_textEventOut_OutputPort[port].setObjName(portName);
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 #endif
@@ -938,15 +886,13 @@ void ActiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName);
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -965,15 +911,13 @@ void ActiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_tlmOut_OutputPort[port].setObjName(portName);
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -992,15 +936,13 @@ void ActiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -1019,15 +961,13 @@ void ActiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -1046,15 +986,13 @@ void ActiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedOut_OutputPort[port].setObjName(portName);
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -1073,15 +1011,13 @@ void ActiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName);
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -1100,15 +1036,13 @@ void ActiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_serialOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_serialOut_OutputPort[port].setObjName(portName);
+    this->m_serialOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -4905,7 +4839,7 @@ void ActiveSerialComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventActivityHigh "
     );
@@ -5036,7 +4970,7 @@ void ActiveSerialComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventActivityLowThrottled ",
       u32,
@@ -5125,7 +5059,7 @@ void ActiveSerialComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventCommand ",
       str1.toChar(),
@@ -5217,7 +5151,7 @@ void ActiveSerialComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventDiagnostic ",
       eStr.toChar()
@@ -5329,7 +5263,7 @@ void ActiveSerialComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventFatalThrottled ",
       aStr.toChar()
@@ -5420,7 +5354,7 @@ void ActiveSerialComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventWarningHigh ",
       sStr.toChar()
@@ -5500,7 +5434,7 @@ void ActiveSerialComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventWarningLowThrottled "
     );

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveSyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveSyncProductsComponentAc.ref.cpp
@@ -249,12 +249,6 @@ void ActiveSyncProductsComponentBase ::
     this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
@@ -279,12 +273,6 @@ void ActiveSyncProductsComponentBase ::
     this->m_productRecvIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_productRecvIn_InputPort[%" PRI_PlatformIntType "]",
@@ -309,12 +297,6 @@ void ActiveSyncProductsComponentBase ::
     this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
@@ -339,12 +321,6 @@ void ActiveSyncProductsComponentBase ::
     this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -369,12 +345,6 @@ void ActiveSyncProductsComponentBase ::
     this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -399,12 +369,6 @@ void ActiveSyncProductsComponentBase ::
     this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -429,12 +393,6 @@ void ActiveSyncProductsComponentBase ::
     this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
@@ -459,12 +417,6 @@ void ActiveSyncProductsComponentBase ::
     this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
@@ -489,12 +441,6 @@ void ActiveSyncProductsComponentBase ::
     this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
@@ -519,12 +465,6 @@ void ActiveSyncProductsComponentBase ::
     this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
@@ -549,12 +489,6 @@ void ActiveSyncProductsComponentBase ::
     this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
@@ -579,12 +513,6 @@ void ActiveSyncProductsComponentBase ::
     this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -609,12 +537,6 @@ void ActiveSyncProductsComponentBase ::
     this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -639,12 +561,6 @@ void ActiveSyncProductsComponentBase ::
     this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -669,12 +585,6 @@ void ActiveSyncProductsComponentBase ::
     this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
@@ -694,12 +604,6 @@ void ActiveSyncProductsComponentBase ::
     this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -719,12 +623,6 @@ void ActiveSyncProductsComponentBase ::
     this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -744,12 +642,6 @@ void ActiveSyncProductsComponentBase ::
     this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -769,12 +661,6 @@ void ActiveSyncProductsComponentBase ::
     this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -794,12 +680,6 @@ void ActiveSyncProductsComponentBase ::
     this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -819,12 +699,6 @@ void ActiveSyncProductsComponentBase ::
     this->m_productRequestOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_productRequestOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -844,12 +718,6 @@ void ActiveSyncProductsComponentBase ::
     this->m_productSendOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -870,12 +738,6 @@ void ActiveSyncProductsComponentBase ::
     this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -896,12 +758,6 @@ void ActiveSyncProductsComponentBase ::
     this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -921,12 +777,6 @@ void ActiveSyncProductsComponentBase ::
     this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -946,12 +796,6 @@ void ActiveSyncProductsComponentBase ::
     this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -971,12 +815,6 @@ void ActiveSyncProductsComponentBase ::
     this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -996,12 +834,6 @@ void ActiveSyncProductsComponentBase ::
     this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -1021,12 +853,6 @@ void ActiveSyncProductsComponentBase ::
     this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveSyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveSyncProductsComponentAc.ref.cpp
@@ -255,15 +255,13 @@ void ActiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdIn_InputPort[port].setObjName(portName);
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -287,15 +285,13 @@ void ActiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_productRecvIn_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_productRecvIn_InputPort[port].setObjName(portName);
+    this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -319,15 +315,13 @@ void ActiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsAsync_InputPort[port].setObjName(portName);
+    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -351,15 +345,13 @@ void ActiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -383,15 +375,13 @@ void ActiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -415,15 +405,13 @@ void ActiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -447,15 +435,13 @@ void ActiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsSync_InputPort[port].setObjName(portName);
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -479,15 +465,13 @@ void ActiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsync_InputPort[port].setObjName(portName);
+    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -511,15 +495,13 @@ void ActiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncAssert_InputPort[port].setObjName(portName);
+    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -543,15 +525,13 @@ void ActiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName);
+    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -575,15 +555,13 @@ void ActiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName);
+    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -607,15 +585,13 @@ void ActiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedGuarded_InputPort[port].setObjName(portName);
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -639,15 +615,13 @@ void ActiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -671,15 +645,13 @@ void ActiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName);
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -703,15 +675,13 @@ void ActiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedSync_InputPort[port].setObjName(portName);
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -730,15 +700,13 @@ void ActiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName);
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -757,15 +725,13 @@ void ActiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName);
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -784,15 +750,13 @@ void ActiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_eventOut_OutputPort[port].setObjName(portName);
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -811,15 +775,13 @@ void ActiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName);
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -838,15 +800,13 @@ void ActiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName);
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -865,15 +825,13 @@ void ActiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_productRequestOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_productRequestOut_OutputPort[port].setObjName(portName);
+    this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -892,15 +850,13 @@ void ActiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_productSendOut_OutputPort[port].setObjName(portName);
+    this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -920,15 +876,13 @@ void ActiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_textEventOut_OutputPort[port].setObjName(portName);
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 #endif
@@ -948,15 +902,13 @@ void ActiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName);
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -975,15 +927,13 @@ void ActiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_tlmOut_OutputPort[port].setObjName(portName);
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -1002,15 +952,13 @@ void ActiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -1029,15 +977,13 @@ void ActiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -1056,15 +1002,13 @@ void ActiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedOut_OutputPort[port].setObjName(portName);
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -1083,15 +1027,13 @@ void ActiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName);
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTelemetryComponentAc.ref.cpp
@@ -100,15 +100,13 @@ void ActiveTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdIn_InputPort[port].setObjName(portName);
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -132,15 +130,13 @@ void ActiveTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsAsync_InputPort[port].setObjName(portName);
+    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -164,15 +160,13 @@ void ActiveTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -196,15 +190,13 @@ void ActiveTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -228,15 +220,13 @@ void ActiveTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -260,15 +250,13 @@ void ActiveTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsSync_InputPort[port].setObjName(portName);
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -292,15 +280,13 @@ void ActiveTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsync_InputPort[port].setObjName(portName);
+    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -324,15 +310,13 @@ void ActiveTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncAssert_InputPort[port].setObjName(portName);
+    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -356,15 +340,13 @@ void ActiveTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName);
+    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -388,15 +370,13 @@ void ActiveTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName);
+    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -420,15 +400,13 @@ void ActiveTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedGuarded_InputPort[port].setObjName(portName);
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -452,15 +430,13 @@ void ActiveTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -484,15 +460,13 @@ void ActiveTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName);
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -516,15 +490,13 @@ void ActiveTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedSync_InputPort[port].setObjName(portName);
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -543,15 +515,13 @@ void ActiveTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName);
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -570,15 +540,13 @@ void ActiveTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName);
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -597,15 +565,13 @@ void ActiveTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_eventOut_OutputPort[port].setObjName(portName);
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -624,15 +590,13 @@ void ActiveTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName);
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -651,15 +615,13 @@ void ActiveTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName);
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -679,15 +641,13 @@ void ActiveTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_textEventOut_OutputPort[port].setObjName(portName);
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 #endif
@@ -707,15 +667,13 @@ void ActiveTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName);
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -734,15 +692,13 @@ void ActiveTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_tlmOut_OutputPort[port].setObjName(portName);
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -761,15 +717,13 @@ void ActiveTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -788,15 +742,13 @@ void ActiveTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -815,15 +767,13 @@ void ActiveTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedOut_OutputPort[port].setObjName(portName);
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -842,15 +792,13 @@ void ActiveTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName);
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTelemetryComponentAc.ref.cpp
@@ -94,12 +94,6 @@ void ActiveTelemetryComponentBase ::
     this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
@@ -124,12 +118,6 @@ void ActiveTelemetryComponentBase ::
     this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
@@ -154,12 +142,6 @@ void ActiveTelemetryComponentBase ::
     this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -184,12 +166,6 @@ void ActiveTelemetryComponentBase ::
     this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -214,12 +190,6 @@ void ActiveTelemetryComponentBase ::
     this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -244,12 +214,6 @@ void ActiveTelemetryComponentBase ::
     this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
@@ -274,12 +238,6 @@ void ActiveTelemetryComponentBase ::
     this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
@@ -304,12 +262,6 @@ void ActiveTelemetryComponentBase ::
     this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
@@ -334,12 +286,6 @@ void ActiveTelemetryComponentBase ::
     this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
@@ -364,12 +310,6 @@ void ActiveTelemetryComponentBase ::
     this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
@@ -394,12 +334,6 @@ void ActiveTelemetryComponentBase ::
     this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -424,12 +358,6 @@ void ActiveTelemetryComponentBase ::
     this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -454,12 +382,6 @@ void ActiveTelemetryComponentBase ::
     this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -484,12 +406,6 @@ void ActiveTelemetryComponentBase ::
     this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
@@ -509,12 +425,6 @@ void ActiveTelemetryComponentBase ::
     this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -534,12 +444,6 @@ void ActiveTelemetryComponentBase ::
     this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -559,12 +463,6 @@ void ActiveTelemetryComponentBase ::
     this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -584,12 +482,6 @@ void ActiveTelemetryComponentBase ::
     this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -609,12 +501,6 @@ void ActiveTelemetryComponentBase ::
     this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -635,12 +521,6 @@ void ActiveTelemetryComponentBase ::
     this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -661,12 +541,6 @@ void ActiveTelemetryComponentBase ::
     this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -686,12 +560,6 @@ void ActiveTelemetryComponentBase ::
     this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -711,12 +579,6 @@ void ActiveTelemetryComponentBase ::
     this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -736,12 +598,6 @@ void ActiveTelemetryComponentBase ::
     this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -761,12 +617,6 @@ void ActiveTelemetryComponentBase ::
     this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -786,12 +636,6 @@ void ActiveTelemetryComponentBase ::
     this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
@@ -287,12 +287,6 @@ namespace M {
       this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
@@ -317,12 +311,6 @@ namespace M {
       this->m_productRecvIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_productRecvIn_InputPort[%" PRI_PlatformIntType "]",
@@ -347,12 +335,6 @@ namespace M {
       this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
@@ -377,12 +359,6 @@ namespace M {
       this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -407,12 +383,6 @@ namespace M {
       this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -437,12 +407,6 @@ namespace M {
       this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -467,12 +431,6 @@ namespace M {
       this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
@@ -497,12 +455,6 @@ namespace M {
       this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
@@ -527,12 +479,6 @@ namespace M {
       this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
@@ -557,12 +503,6 @@ namespace M {
       this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
@@ -587,12 +527,6 @@ namespace M {
       this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
@@ -617,12 +551,6 @@ namespace M {
       this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -647,12 +575,6 @@ namespace M {
       this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -677,12 +599,6 @@ namespace M {
       this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -707,12 +623,6 @@ namespace M {
       this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
@@ -732,12 +642,6 @@ namespace M {
       this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -757,12 +661,6 @@ namespace M {
       this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -782,12 +680,6 @@ namespace M {
       this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -807,12 +699,6 @@ namespace M {
       this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -832,12 +718,6 @@ namespace M {
       this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -857,12 +737,6 @@ namespace M {
       this->m_productRequestOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_productRequestOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -882,12 +756,6 @@ namespace M {
       this->m_productSendOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -908,12 +776,6 @@ namespace M {
       this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -934,12 +796,6 @@ namespace M {
       this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -959,12 +815,6 @@ namespace M {
       this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -984,12 +834,6 @@ namespace M {
       this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -1009,12 +853,6 @@ namespace M {
       this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -1034,12 +872,6 @@ namespace M {
       this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -1059,12 +891,6 @@ namespace M {
       this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
@@ -293,15 +293,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_cmdIn_InputPort[port].setObjName(portName);
+      this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -325,15 +323,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_productRecvIn_InputPort[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_productRecvIn_InputPort[port].setObjName(portName);
+      this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -357,15 +353,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_noArgsAsync_InputPort[port].setObjName(portName);
+      this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -389,15 +383,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_noArgsGuarded_InputPort[port].setObjName(portName);
+      this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -421,15 +413,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName);
+      this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -453,15 +443,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_noArgsReturnSync_InputPort[port].setObjName(portName);
+      this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -485,15 +473,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_noArgsSync_InputPort[port].setObjName(portName);
+      this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -517,15 +503,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_typedAsync_InputPort[port].setObjName(portName);
+      this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -549,15 +533,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_typedAsyncAssert_InputPort[port].setObjName(portName);
+      this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -581,15 +563,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName);
+      this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -613,15 +593,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName);
+      this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -645,15 +623,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_typedGuarded_InputPort[port].setObjName(portName);
+      this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -677,15 +653,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_typedReturnGuarded_InputPort[port].setObjName(portName);
+      this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -709,15 +683,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_typedReturnSync_InputPort[port].setObjName(portName);
+      this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -741,15 +713,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_typedSync_InputPort[port].setObjName(portName);
+      this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -768,15 +738,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_cmdRegOut_OutputPort[port].setObjName(portName);
+      this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -795,15 +763,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_cmdResponseOut_OutputPort[port].setObjName(portName);
+      this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -822,15 +788,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_eventOut_OutputPort[port].setObjName(portName);
+      this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -849,15 +813,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_prmGetOut_OutputPort[port].setObjName(portName);
+      this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -876,15 +838,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_prmSetOut_OutputPort[port].setObjName(portName);
+      this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -903,15 +863,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_productRequestOut_OutputPort[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_productRequestOut_OutputPort[port].setObjName(portName);
+      this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -930,15 +888,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_productSendOut_OutputPort[port].setObjName(portName);
+      this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -958,15 +914,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_textEventOut_OutputPort[port].setObjName(portName);
+      this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 #endif
@@ -986,15 +940,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_timeGetOut_OutputPort[port].setObjName(portName);
+      this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -1013,15 +965,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_tlmOut_OutputPort[port].setObjName(portName);
+      this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -1040,15 +990,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_noArgsOut_OutputPort[port].setObjName(portName);
+      this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -1067,15 +1015,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_noArgsReturnOut_OutputPort[port].setObjName(portName);
+      this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -1094,15 +1040,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_typedOut_OutputPort[port].setObjName(portName);
+      this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -1121,15 +1065,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_typedReturnOut_OutputPort[port].setObjName(portName);
+      this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -4686,7 +4628,7 @@ namespace M {
         FW_LOG_TEXT_BUFFER_SIZE,
         _formatString,
 #if FW_OBJECT_NAMES == 1
-        this->m_objName,
+        this->m_objName.toChar(),
 #endif
         "EventActivityHigh "
       );
@@ -4817,7 +4759,7 @@ namespace M {
         FW_LOG_TEXT_BUFFER_SIZE,
         _formatString,
 #if FW_OBJECT_NAMES == 1
-        this->m_objName,
+        this->m_objName.toChar(),
 #endif
         "EventActivityLowThrottled ",
         u32,
@@ -4906,7 +4848,7 @@ namespace M {
         FW_LOG_TEXT_BUFFER_SIZE,
         _formatString,
 #if FW_OBJECT_NAMES == 1
-        this->m_objName,
+        this->m_objName.toChar(),
 #endif
         "EventCommand ",
         str1.toChar(),
@@ -4998,7 +4940,7 @@ namespace M {
         FW_LOG_TEXT_BUFFER_SIZE,
         _formatString,
 #if FW_OBJECT_NAMES == 1
-        this->m_objName,
+        this->m_objName.toChar(),
 #endif
         "EventDiagnostic ",
         eStr.toChar()
@@ -5110,7 +5052,7 @@ namespace M {
         FW_LOG_TEXT_BUFFER_SIZE,
         _formatString,
 #if FW_OBJECT_NAMES == 1
-        this->m_objName,
+        this->m_objName.toChar(),
 #endif
         "EventFatalThrottled ",
         aStr.toChar()
@@ -5201,7 +5143,7 @@ namespace M {
         FW_LOG_TEXT_BUFFER_SIZE,
         _formatString,
 #if FW_OBJECT_NAMES == 1
-        this->m_objName,
+        this->m_objName.toChar(),
 #endif
         "EventWarningHigh ",
         sStr.toChar()
@@ -5281,7 +5223,7 @@ namespace M {
         FW_LOG_TEXT_BUFFER_SIZE,
         _formatString,
 #if FW_OBJECT_NAMES == 1
-        this->m_objName,
+        this->m_objName.toChar(),
 #endif
         "EventWarningLowThrottled "
       );

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveCommandsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveCommandsComponentAc.ref.cpp
@@ -36,12 +36,6 @@ void PassiveCommandsComponentBase ::
     this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
@@ -66,12 +60,6 @@ void PassiveCommandsComponentBase ::
     this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -96,12 +84,6 @@ void PassiveCommandsComponentBase ::
     this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -126,12 +108,6 @@ void PassiveCommandsComponentBase ::
     this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -156,12 +132,6 @@ void PassiveCommandsComponentBase ::
     this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
@@ -186,12 +156,6 @@ void PassiveCommandsComponentBase ::
     this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -216,12 +180,6 @@ void PassiveCommandsComponentBase ::
     this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -246,12 +204,6 @@ void PassiveCommandsComponentBase ::
     this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -276,12 +228,6 @@ void PassiveCommandsComponentBase ::
     this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
@@ -301,12 +247,6 @@ void PassiveCommandsComponentBase ::
     this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -326,12 +266,6 @@ void PassiveCommandsComponentBase ::
     this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -351,12 +285,6 @@ void PassiveCommandsComponentBase ::
     this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -376,12 +304,6 @@ void PassiveCommandsComponentBase ::
     this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -401,12 +323,6 @@ void PassiveCommandsComponentBase ::
     this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -427,12 +343,6 @@ void PassiveCommandsComponentBase ::
     this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -453,12 +363,6 @@ void PassiveCommandsComponentBase ::
     this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -478,12 +382,6 @@ void PassiveCommandsComponentBase ::
     this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -503,12 +401,6 @@ void PassiveCommandsComponentBase ::
     this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -528,12 +420,6 @@ void PassiveCommandsComponentBase ::
     this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -553,12 +439,6 @@ void PassiveCommandsComponentBase ::
     this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -578,12 +458,6 @@ void PassiveCommandsComponentBase ::
     this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveCommandsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveCommandsComponentAc.ref.cpp
@@ -42,15 +42,13 @@ void PassiveCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdIn_InputPort[port].setObjName(portName);
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -74,15 +72,13 @@ void PassiveCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -106,15 +102,13 @@ void PassiveCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -138,15 +132,13 @@ void PassiveCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -170,15 +162,13 @@ void PassiveCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsSync_InputPort[port].setObjName(portName);
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -202,15 +192,13 @@ void PassiveCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedGuarded_InputPort[port].setObjName(portName);
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -234,15 +222,13 @@ void PassiveCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -266,15 +252,13 @@ void PassiveCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName);
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -298,15 +282,13 @@ void PassiveCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedSync_InputPort[port].setObjName(portName);
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -325,15 +307,13 @@ void PassiveCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName);
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -352,15 +332,13 @@ void PassiveCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName);
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -379,15 +357,13 @@ void PassiveCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_eventOut_OutputPort[port].setObjName(portName);
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -406,15 +382,13 @@ void PassiveCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName);
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -433,15 +407,13 @@ void PassiveCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName);
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -461,15 +433,13 @@ void PassiveCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_textEventOut_OutputPort[port].setObjName(portName);
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 #endif
@@ -489,15 +459,13 @@ void PassiveCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName);
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -516,15 +484,13 @@ void PassiveCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_tlmOut_OutputPort[port].setObjName(portName);
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -543,15 +509,13 @@ void PassiveCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -570,15 +534,13 @@ void PassiveCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -597,15 +559,13 @@ void PassiveCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedOut_OutputPort[port].setObjName(portName);
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -624,15 +584,13 @@ void PassiveCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName);
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveEventsComponentAc.ref.cpp
@@ -36,12 +36,6 @@ void PassiveEventsComponentBase ::
     this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
@@ -66,12 +60,6 @@ void PassiveEventsComponentBase ::
     this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -96,12 +84,6 @@ void PassiveEventsComponentBase ::
     this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -126,12 +108,6 @@ void PassiveEventsComponentBase ::
     this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -156,12 +132,6 @@ void PassiveEventsComponentBase ::
     this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
@@ -186,12 +156,6 @@ void PassiveEventsComponentBase ::
     this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -216,12 +180,6 @@ void PassiveEventsComponentBase ::
     this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -246,12 +204,6 @@ void PassiveEventsComponentBase ::
     this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -276,12 +228,6 @@ void PassiveEventsComponentBase ::
     this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
@@ -301,12 +247,6 @@ void PassiveEventsComponentBase ::
     this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -326,12 +266,6 @@ void PassiveEventsComponentBase ::
     this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -351,12 +285,6 @@ void PassiveEventsComponentBase ::
     this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -376,12 +304,6 @@ void PassiveEventsComponentBase ::
     this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -401,12 +323,6 @@ void PassiveEventsComponentBase ::
     this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -427,12 +343,6 @@ void PassiveEventsComponentBase ::
     this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -453,12 +363,6 @@ void PassiveEventsComponentBase ::
     this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -478,12 +382,6 @@ void PassiveEventsComponentBase ::
     this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -503,12 +401,6 @@ void PassiveEventsComponentBase ::
     this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -528,12 +420,6 @@ void PassiveEventsComponentBase ::
     this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -553,12 +439,6 @@ void PassiveEventsComponentBase ::
     this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -578,12 +458,6 @@ void PassiveEventsComponentBase ::
     this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveEventsComponentAc.ref.cpp
@@ -42,15 +42,13 @@ void PassiveEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdIn_InputPort[port].setObjName(portName);
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -74,15 +72,13 @@ void PassiveEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -106,15 +102,13 @@ void PassiveEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -138,15 +132,13 @@ void PassiveEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -170,15 +162,13 @@ void PassiveEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsSync_InputPort[port].setObjName(portName);
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -202,15 +192,13 @@ void PassiveEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedGuarded_InputPort[port].setObjName(portName);
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -234,15 +222,13 @@ void PassiveEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -266,15 +252,13 @@ void PassiveEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName);
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -298,15 +282,13 @@ void PassiveEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedSync_InputPort[port].setObjName(portName);
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -325,15 +307,13 @@ void PassiveEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName);
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -352,15 +332,13 @@ void PassiveEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName);
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -379,15 +357,13 @@ void PassiveEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_eventOut_OutputPort[port].setObjName(portName);
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -406,15 +382,13 @@ void PassiveEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName);
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -433,15 +407,13 @@ void PassiveEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName);
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -461,15 +433,13 @@ void PassiveEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_textEventOut_OutputPort[port].setObjName(portName);
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 #endif
@@ -489,15 +459,13 @@ void PassiveEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName);
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -516,15 +484,13 @@ void PassiveEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_tlmOut_OutputPort[port].setObjName(portName);
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -543,15 +509,13 @@ void PassiveEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -570,15 +534,13 @@ void PassiveEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -597,15 +559,13 @@ void PassiveEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedOut_OutputPort[port].setObjName(portName);
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -624,15 +584,13 @@ void PassiveEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName);
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 }
@@ -1736,7 +1694,7 @@ void PassiveEventsComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventActivityHigh "
     );
@@ -1867,7 +1825,7 @@ void PassiveEventsComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventActivityLowThrottled ",
       u32,
@@ -1956,7 +1914,7 @@ void PassiveEventsComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventCommand ",
       str1.toChar(),
@@ -2048,7 +2006,7 @@ void PassiveEventsComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventDiagnostic ",
       eStr.toChar()
@@ -2160,7 +2118,7 @@ void PassiveEventsComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventFatalThrottled ",
       aStr.toChar()
@@ -2251,7 +2209,7 @@ void PassiveEventsComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventWarningHigh ",
       sStr.toChar()
@@ -2331,7 +2289,7 @@ void PassiveEventsComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventWarningLowThrottled "
     );

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveGetProductPortsOnlyComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveGetProductPortsOnlyComponentAc.ref.cpp
@@ -37,15 +37,13 @@ void PassiveGetProductPortsOnlyComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_productGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_productGetOut_OutputPort[port].setObjName(portName);
+    this->m_productGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -64,15 +62,13 @@ void PassiveGetProductPortsOnlyComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_productSendOut_OutputPort[port].setObjName(portName);
+    this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveGetProductPortsOnlyComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveGetProductPortsOnlyComponentAc.ref.cpp
@@ -31,12 +31,6 @@ void PassiveGetProductPortsOnlyComponentBase ::
     this->m_productGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_productGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -56,12 +50,6 @@ void PassiveGetProductPortsOnlyComponentBase ::
     this->m_productSendOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveGetProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveGetProductsComponentAc.ref.cpp
@@ -191,12 +191,6 @@ void PassiveGetProductsComponentBase ::
     this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
@@ -221,12 +215,6 @@ void PassiveGetProductsComponentBase ::
     this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -251,12 +239,6 @@ void PassiveGetProductsComponentBase ::
     this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -281,12 +263,6 @@ void PassiveGetProductsComponentBase ::
     this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -311,12 +287,6 @@ void PassiveGetProductsComponentBase ::
     this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
@@ -341,12 +311,6 @@ void PassiveGetProductsComponentBase ::
     this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -371,12 +335,6 @@ void PassiveGetProductsComponentBase ::
     this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -401,12 +359,6 @@ void PassiveGetProductsComponentBase ::
     this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -431,12 +383,6 @@ void PassiveGetProductsComponentBase ::
     this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
@@ -456,12 +402,6 @@ void PassiveGetProductsComponentBase ::
     this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -481,12 +421,6 @@ void PassiveGetProductsComponentBase ::
     this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -506,12 +440,6 @@ void PassiveGetProductsComponentBase ::
     this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -531,12 +459,6 @@ void PassiveGetProductsComponentBase ::
     this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -556,12 +478,6 @@ void PassiveGetProductsComponentBase ::
     this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -581,12 +497,6 @@ void PassiveGetProductsComponentBase ::
     this->m_productGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_productGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -606,12 +516,6 @@ void PassiveGetProductsComponentBase ::
     this->m_productSendOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -632,12 +536,6 @@ void PassiveGetProductsComponentBase ::
     this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -658,12 +556,6 @@ void PassiveGetProductsComponentBase ::
     this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -683,12 +575,6 @@ void PassiveGetProductsComponentBase ::
     this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -708,12 +594,6 @@ void PassiveGetProductsComponentBase ::
     this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -733,12 +613,6 @@ void PassiveGetProductsComponentBase ::
     this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -758,12 +632,6 @@ void PassiveGetProductsComponentBase ::
     this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -783,12 +651,6 @@ void PassiveGetProductsComponentBase ::
     this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveGetProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveGetProductsComponentAc.ref.cpp
@@ -197,15 +197,13 @@ void PassiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdIn_InputPort[port].setObjName(portName);
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -229,15 +227,13 @@ void PassiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -261,15 +257,13 @@ void PassiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -293,15 +287,13 @@ void PassiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -325,15 +317,13 @@ void PassiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsSync_InputPort[port].setObjName(portName);
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -357,15 +347,13 @@ void PassiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedGuarded_InputPort[port].setObjName(portName);
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -389,15 +377,13 @@ void PassiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -421,15 +407,13 @@ void PassiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName);
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -453,15 +437,13 @@ void PassiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedSync_InputPort[port].setObjName(portName);
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -480,15 +462,13 @@ void PassiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName);
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -507,15 +487,13 @@ void PassiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName);
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -534,15 +512,13 @@ void PassiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_eventOut_OutputPort[port].setObjName(portName);
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -561,15 +537,13 @@ void PassiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName);
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -588,15 +562,13 @@ void PassiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName);
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -615,15 +587,13 @@ void PassiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_productGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_productGetOut_OutputPort[port].setObjName(portName);
+    this->m_productGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -642,15 +612,13 @@ void PassiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_productSendOut_OutputPort[port].setObjName(portName);
+    this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -670,15 +638,13 @@ void PassiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_textEventOut_OutputPort[port].setObjName(portName);
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 #endif
@@ -698,15 +664,13 @@ void PassiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName);
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -725,15 +689,13 @@ void PassiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_tlmOut_OutputPort[port].setObjName(portName);
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -752,15 +714,13 @@ void PassiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -779,15 +739,13 @@ void PassiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -806,15 +764,13 @@ void PassiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedOut_OutputPort[port].setObjName(portName);
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -833,15 +789,13 @@ void PassiveGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName);
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveGuardedProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveGuardedProductsComponentAc.ref.cpp
@@ -191,12 +191,6 @@ void PassiveGuardedProductsComponentBase ::
     this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
@@ -221,12 +215,6 @@ void PassiveGuardedProductsComponentBase ::
     this->m_productRecvIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_productRecvIn_InputPort[%" PRI_PlatformIntType "]",
@@ -251,12 +239,6 @@ void PassiveGuardedProductsComponentBase ::
     this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -281,12 +263,6 @@ void PassiveGuardedProductsComponentBase ::
     this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -311,12 +287,6 @@ void PassiveGuardedProductsComponentBase ::
     this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -341,12 +311,6 @@ void PassiveGuardedProductsComponentBase ::
     this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
@@ -371,12 +335,6 @@ void PassiveGuardedProductsComponentBase ::
     this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -401,12 +359,6 @@ void PassiveGuardedProductsComponentBase ::
     this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -431,12 +383,6 @@ void PassiveGuardedProductsComponentBase ::
     this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -461,12 +407,6 @@ void PassiveGuardedProductsComponentBase ::
     this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
@@ -486,12 +426,6 @@ void PassiveGuardedProductsComponentBase ::
     this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -511,12 +445,6 @@ void PassiveGuardedProductsComponentBase ::
     this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -536,12 +464,6 @@ void PassiveGuardedProductsComponentBase ::
     this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -561,12 +483,6 @@ void PassiveGuardedProductsComponentBase ::
     this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -586,12 +502,6 @@ void PassiveGuardedProductsComponentBase ::
     this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -611,12 +521,6 @@ void PassiveGuardedProductsComponentBase ::
     this->m_productRequestOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_productRequestOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -636,12 +540,6 @@ void PassiveGuardedProductsComponentBase ::
     this->m_productSendOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -662,12 +560,6 @@ void PassiveGuardedProductsComponentBase ::
     this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -688,12 +580,6 @@ void PassiveGuardedProductsComponentBase ::
     this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -713,12 +599,6 @@ void PassiveGuardedProductsComponentBase ::
     this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -738,12 +618,6 @@ void PassiveGuardedProductsComponentBase ::
     this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -763,12 +637,6 @@ void PassiveGuardedProductsComponentBase ::
     this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -788,12 +656,6 @@ void PassiveGuardedProductsComponentBase ::
     this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -813,12 +675,6 @@ void PassiveGuardedProductsComponentBase ::
     this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveGuardedProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveGuardedProductsComponentAc.ref.cpp
@@ -197,15 +197,13 @@ void PassiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdIn_InputPort[port].setObjName(portName);
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -229,15 +227,13 @@ void PassiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_productRecvIn_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_productRecvIn_InputPort[port].setObjName(portName);
+    this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -261,15 +257,13 @@ void PassiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -293,15 +287,13 @@ void PassiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -325,15 +317,13 @@ void PassiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -357,15 +347,13 @@ void PassiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsSync_InputPort[port].setObjName(portName);
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -389,15 +377,13 @@ void PassiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedGuarded_InputPort[port].setObjName(portName);
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -421,15 +407,13 @@ void PassiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -453,15 +437,13 @@ void PassiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName);
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -485,15 +467,13 @@ void PassiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedSync_InputPort[port].setObjName(portName);
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -512,15 +492,13 @@ void PassiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName);
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -539,15 +517,13 @@ void PassiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName);
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -566,15 +542,13 @@ void PassiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_eventOut_OutputPort[port].setObjName(portName);
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -593,15 +567,13 @@ void PassiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName);
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -620,15 +592,13 @@ void PassiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName);
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -647,15 +617,13 @@ void PassiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_productRequestOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_productRequestOut_OutputPort[port].setObjName(portName);
+    this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -674,15 +642,13 @@ void PassiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_productSendOut_OutputPort[port].setObjName(portName);
+    this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -702,15 +668,13 @@ void PassiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_textEventOut_OutputPort[port].setObjName(portName);
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 #endif
@@ -730,15 +694,13 @@ void PassiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName);
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -757,15 +719,13 @@ void PassiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_tlmOut_OutputPort[port].setObjName(portName);
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -784,15 +744,13 @@ void PassiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -811,15 +769,13 @@ void PassiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -838,15 +794,13 @@ void PassiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedOut_OutputPort[port].setObjName(portName);
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -865,15 +819,13 @@ void PassiveGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName);
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveParamsComponentAc.ref.cpp
@@ -36,12 +36,6 @@ void PassiveParamsComponentBase ::
     this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
@@ -66,12 +60,6 @@ void PassiveParamsComponentBase ::
     this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -96,12 +84,6 @@ void PassiveParamsComponentBase ::
     this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -126,12 +108,6 @@ void PassiveParamsComponentBase ::
     this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -156,12 +132,6 @@ void PassiveParamsComponentBase ::
     this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
@@ -186,12 +156,6 @@ void PassiveParamsComponentBase ::
     this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -216,12 +180,6 @@ void PassiveParamsComponentBase ::
     this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -246,12 +204,6 @@ void PassiveParamsComponentBase ::
     this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -276,12 +228,6 @@ void PassiveParamsComponentBase ::
     this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
@@ -301,12 +247,6 @@ void PassiveParamsComponentBase ::
     this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -326,12 +266,6 @@ void PassiveParamsComponentBase ::
     this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -351,12 +285,6 @@ void PassiveParamsComponentBase ::
     this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -376,12 +304,6 @@ void PassiveParamsComponentBase ::
     this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -401,12 +323,6 @@ void PassiveParamsComponentBase ::
     this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -427,12 +343,6 @@ void PassiveParamsComponentBase ::
     this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -453,12 +363,6 @@ void PassiveParamsComponentBase ::
     this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -478,12 +382,6 @@ void PassiveParamsComponentBase ::
     this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -503,12 +401,6 @@ void PassiveParamsComponentBase ::
     this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -528,12 +420,6 @@ void PassiveParamsComponentBase ::
     this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -553,12 +439,6 @@ void PassiveParamsComponentBase ::
     this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -578,12 +458,6 @@ void PassiveParamsComponentBase ::
     this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveParamsComponentAc.ref.cpp
@@ -42,15 +42,13 @@ void PassiveParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdIn_InputPort[port].setObjName(portName);
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -74,15 +72,13 @@ void PassiveParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -106,15 +102,13 @@ void PassiveParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -138,15 +132,13 @@ void PassiveParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -170,15 +162,13 @@ void PassiveParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsSync_InputPort[port].setObjName(portName);
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -202,15 +192,13 @@ void PassiveParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedGuarded_InputPort[port].setObjName(portName);
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -234,15 +222,13 @@ void PassiveParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -266,15 +252,13 @@ void PassiveParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName);
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -298,15 +282,13 @@ void PassiveParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedSync_InputPort[port].setObjName(portName);
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -325,15 +307,13 @@ void PassiveParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName);
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -352,15 +332,13 @@ void PassiveParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName);
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -379,15 +357,13 @@ void PassiveParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_eventOut_OutputPort[port].setObjName(portName);
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -406,15 +382,13 @@ void PassiveParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName);
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -433,15 +407,13 @@ void PassiveParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName);
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -461,15 +433,13 @@ void PassiveParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_textEventOut_OutputPort[port].setObjName(portName);
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 #endif
@@ -489,15 +459,13 @@ void PassiveParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName);
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -516,15 +484,13 @@ void PassiveParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_tlmOut_OutputPort[port].setObjName(portName);
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -543,15 +509,13 @@ void PassiveParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -570,15 +534,13 @@ void PassiveParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -597,15 +559,13 @@ void PassiveParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedOut_OutputPort[port].setObjName(portName);
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -624,15 +584,13 @@ void PassiveParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName);
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.cpp
@@ -36,12 +36,6 @@ void PassiveSerialComponentBase ::
     this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
@@ -66,12 +60,6 @@ void PassiveSerialComponentBase ::
     this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -96,12 +84,6 @@ void PassiveSerialComponentBase ::
     this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -126,12 +108,6 @@ void PassiveSerialComponentBase ::
     this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -156,12 +132,6 @@ void PassiveSerialComponentBase ::
     this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
@@ -186,12 +156,6 @@ void PassiveSerialComponentBase ::
     this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -216,12 +180,6 @@ void PassiveSerialComponentBase ::
     this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -246,12 +204,6 @@ void PassiveSerialComponentBase ::
     this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -276,12 +228,6 @@ void PassiveSerialComponentBase ::
     this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
@@ -306,12 +252,6 @@ void PassiveSerialComponentBase ::
     this->m_serialGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_serialGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -336,12 +276,6 @@ void PassiveSerialComponentBase ::
     this->m_serialSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_serialSync_InputPort[%" PRI_PlatformIntType "]",
@@ -361,12 +295,6 @@ void PassiveSerialComponentBase ::
     this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -386,12 +314,6 @@ void PassiveSerialComponentBase ::
     this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -411,12 +333,6 @@ void PassiveSerialComponentBase ::
     this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -436,12 +352,6 @@ void PassiveSerialComponentBase ::
     this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -461,12 +371,6 @@ void PassiveSerialComponentBase ::
     this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -487,12 +391,6 @@ void PassiveSerialComponentBase ::
     this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -513,12 +411,6 @@ void PassiveSerialComponentBase ::
     this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -538,12 +430,6 @@ void PassiveSerialComponentBase ::
     this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -563,12 +449,6 @@ void PassiveSerialComponentBase ::
     this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -588,12 +468,6 @@ void PassiveSerialComponentBase ::
     this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -613,12 +487,6 @@ void PassiveSerialComponentBase ::
     this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -638,12 +506,6 @@ void PassiveSerialComponentBase ::
     this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -663,12 +525,6 @@ void PassiveSerialComponentBase ::
     this->m_serialOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_serialOut_OutputPort[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveSerialComponentAc.ref.cpp
@@ -42,15 +42,13 @@ void PassiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdIn_InputPort[port].setObjName(portName);
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -74,15 +72,13 @@ void PassiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -106,15 +102,13 @@ void PassiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -138,15 +132,13 @@ void PassiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -170,15 +162,13 @@ void PassiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsSync_InputPort[port].setObjName(portName);
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -202,15 +192,13 @@ void PassiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedGuarded_InputPort[port].setObjName(portName);
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -234,15 +222,13 @@ void PassiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -266,15 +252,13 @@ void PassiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName);
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -298,15 +282,13 @@ void PassiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedSync_InputPort[port].setObjName(portName);
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -330,15 +312,13 @@ void PassiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_serialGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_serialGuarded_InputPort[port].setObjName(portName);
+    this->m_serialGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -362,15 +342,13 @@ void PassiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_serialSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_serialSync_InputPort[port].setObjName(portName);
+    this->m_serialSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -389,15 +367,13 @@ void PassiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName);
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -416,15 +392,13 @@ void PassiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName);
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -443,15 +417,13 @@ void PassiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_eventOut_OutputPort[port].setObjName(portName);
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -470,15 +442,13 @@ void PassiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName);
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -497,15 +467,13 @@ void PassiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName);
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -525,15 +493,13 @@ void PassiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_textEventOut_OutputPort[port].setObjName(portName);
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 #endif
@@ -553,15 +519,13 @@ void PassiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName);
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -580,15 +544,13 @@ void PassiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_tlmOut_OutputPort[port].setObjName(portName);
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -607,15 +569,13 @@ void PassiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -634,15 +594,13 @@ void PassiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -661,15 +619,13 @@ void PassiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedOut_OutputPort[port].setObjName(portName);
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -688,15 +644,13 @@ void PassiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName);
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -715,15 +669,13 @@ void PassiveSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_serialOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_serialOut_OutputPort[port].setObjName(portName);
+    this->m_serialOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 }
@@ -2929,7 +2881,7 @@ void PassiveSerialComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventActivityHigh "
     );
@@ -3060,7 +3012,7 @@ void PassiveSerialComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventActivityLowThrottled ",
       u32,
@@ -3149,7 +3101,7 @@ void PassiveSerialComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventCommand ",
       str1.toChar(),
@@ -3241,7 +3193,7 @@ void PassiveSerialComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventDiagnostic ",
       eStr.toChar()
@@ -3353,7 +3305,7 @@ void PassiveSerialComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventFatalThrottled ",
       aStr.toChar()
@@ -3444,7 +3396,7 @@ void PassiveSerialComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventWarningHigh ",
       sStr.toChar()
@@ -3524,7 +3476,7 @@ void PassiveSerialComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventWarningLowThrottled "
     );

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveSyncProductPortsOnlyComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveSyncProductPortsOnlyComponentAc.ref.cpp
@@ -42,15 +42,13 @@ void PassiveSyncProductPortsOnlyComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_productRecvIn_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_productRecvIn_InputPort[port].setObjName(portName);
+    this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -69,15 +67,13 @@ void PassiveSyncProductPortsOnlyComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_productRequestOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_productRequestOut_OutputPort[port].setObjName(portName);
+    this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -96,15 +92,13 @@ void PassiveSyncProductPortsOnlyComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_productSendOut_OutputPort[port].setObjName(portName);
+    this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveSyncProductPortsOnlyComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveSyncProductPortsOnlyComponentAc.ref.cpp
@@ -36,12 +36,6 @@ void PassiveSyncProductPortsOnlyComponentBase ::
     this->m_productRecvIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_productRecvIn_InputPort[%" PRI_PlatformIntType "]",
@@ -61,12 +55,6 @@ void PassiveSyncProductPortsOnlyComponentBase ::
     this->m_productRequestOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_productRequestOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -86,12 +74,6 @@ void PassiveSyncProductPortsOnlyComponentBase ::
     this->m_productSendOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveSyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveSyncProductsComponentAc.ref.cpp
@@ -191,12 +191,6 @@ void PassiveSyncProductsComponentBase ::
     this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
@@ -221,12 +215,6 @@ void PassiveSyncProductsComponentBase ::
     this->m_productRecvIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_productRecvIn_InputPort[%" PRI_PlatformIntType "]",
@@ -251,12 +239,6 @@ void PassiveSyncProductsComponentBase ::
     this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -281,12 +263,6 @@ void PassiveSyncProductsComponentBase ::
     this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -311,12 +287,6 @@ void PassiveSyncProductsComponentBase ::
     this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -341,12 +311,6 @@ void PassiveSyncProductsComponentBase ::
     this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
@@ -371,12 +335,6 @@ void PassiveSyncProductsComponentBase ::
     this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -401,12 +359,6 @@ void PassiveSyncProductsComponentBase ::
     this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -431,12 +383,6 @@ void PassiveSyncProductsComponentBase ::
     this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -461,12 +407,6 @@ void PassiveSyncProductsComponentBase ::
     this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
@@ -486,12 +426,6 @@ void PassiveSyncProductsComponentBase ::
     this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -511,12 +445,6 @@ void PassiveSyncProductsComponentBase ::
     this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -536,12 +464,6 @@ void PassiveSyncProductsComponentBase ::
     this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -561,12 +483,6 @@ void PassiveSyncProductsComponentBase ::
     this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -586,12 +502,6 @@ void PassiveSyncProductsComponentBase ::
     this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -611,12 +521,6 @@ void PassiveSyncProductsComponentBase ::
     this->m_productRequestOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_productRequestOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -636,12 +540,6 @@ void PassiveSyncProductsComponentBase ::
     this->m_productSendOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -662,12 +560,6 @@ void PassiveSyncProductsComponentBase ::
     this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -688,12 +580,6 @@ void PassiveSyncProductsComponentBase ::
     this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -713,12 +599,6 @@ void PassiveSyncProductsComponentBase ::
     this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -738,12 +618,6 @@ void PassiveSyncProductsComponentBase ::
     this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -763,12 +637,6 @@ void PassiveSyncProductsComponentBase ::
     this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -788,12 +656,6 @@ void PassiveSyncProductsComponentBase ::
     this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -813,12 +675,6 @@ void PassiveSyncProductsComponentBase ::
     this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveSyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveSyncProductsComponentAc.ref.cpp
@@ -197,15 +197,13 @@ void PassiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdIn_InputPort[port].setObjName(portName);
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -229,15 +227,13 @@ void PassiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_productRecvIn_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_productRecvIn_InputPort[port].setObjName(portName);
+    this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -261,15 +257,13 @@ void PassiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -293,15 +287,13 @@ void PassiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -325,15 +317,13 @@ void PassiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -357,15 +347,13 @@ void PassiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsSync_InputPort[port].setObjName(portName);
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -389,15 +377,13 @@ void PassiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedGuarded_InputPort[port].setObjName(portName);
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -421,15 +407,13 @@ void PassiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -453,15 +437,13 @@ void PassiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName);
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -485,15 +467,13 @@ void PassiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedSync_InputPort[port].setObjName(portName);
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -512,15 +492,13 @@ void PassiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName);
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -539,15 +517,13 @@ void PassiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName);
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -566,15 +542,13 @@ void PassiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_eventOut_OutputPort[port].setObjName(portName);
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -593,15 +567,13 @@ void PassiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName);
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -620,15 +592,13 @@ void PassiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName);
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -647,15 +617,13 @@ void PassiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_productRequestOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_productRequestOut_OutputPort[port].setObjName(portName);
+    this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -674,15 +642,13 @@ void PassiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_productSendOut_OutputPort[port].setObjName(portName);
+    this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -702,15 +668,13 @@ void PassiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_textEventOut_OutputPort[port].setObjName(portName);
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 #endif
@@ -730,15 +694,13 @@ void PassiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName);
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -757,15 +719,13 @@ void PassiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_tlmOut_OutputPort[port].setObjName(portName);
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -784,15 +744,13 @@ void PassiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -811,15 +769,13 @@ void PassiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -838,15 +794,13 @@ void PassiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedOut_OutputPort[port].setObjName(portName);
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -865,15 +819,13 @@ void PassiveSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName);
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTelemetryComponentAc.ref.cpp
@@ -36,12 +36,6 @@ void PassiveTelemetryComponentBase ::
     this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
@@ -66,12 +60,6 @@ void PassiveTelemetryComponentBase ::
     this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -96,12 +84,6 @@ void PassiveTelemetryComponentBase ::
     this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -126,12 +108,6 @@ void PassiveTelemetryComponentBase ::
     this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -156,12 +132,6 @@ void PassiveTelemetryComponentBase ::
     this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
@@ -186,12 +156,6 @@ void PassiveTelemetryComponentBase ::
     this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -216,12 +180,6 @@ void PassiveTelemetryComponentBase ::
     this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -246,12 +204,6 @@ void PassiveTelemetryComponentBase ::
     this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -276,12 +228,6 @@ void PassiveTelemetryComponentBase ::
     this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
@@ -301,12 +247,6 @@ void PassiveTelemetryComponentBase ::
     this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -326,12 +266,6 @@ void PassiveTelemetryComponentBase ::
     this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -351,12 +285,6 @@ void PassiveTelemetryComponentBase ::
     this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -376,12 +304,6 @@ void PassiveTelemetryComponentBase ::
     this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -401,12 +323,6 @@ void PassiveTelemetryComponentBase ::
     this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -427,12 +343,6 @@ void PassiveTelemetryComponentBase ::
     this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -453,12 +363,6 @@ void PassiveTelemetryComponentBase ::
     this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -478,12 +382,6 @@ void PassiveTelemetryComponentBase ::
     this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -503,12 +401,6 @@ void PassiveTelemetryComponentBase ::
     this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -528,12 +420,6 @@ void PassiveTelemetryComponentBase ::
     this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -553,12 +439,6 @@ void PassiveTelemetryComponentBase ::
     this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -578,12 +458,6 @@ void PassiveTelemetryComponentBase ::
     this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTelemetryComponentAc.ref.cpp
@@ -42,15 +42,13 @@ void PassiveTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdIn_InputPort[port].setObjName(portName);
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -74,15 +72,13 @@ void PassiveTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -106,15 +102,13 @@ void PassiveTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -138,15 +132,13 @@ void PassiveTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -170,15 +162,13 @@ void PassiveTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsSync_InputPort[port].setObjName(portName);
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -202,15 +192,13 @@ void PassiveTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedGuarded_InputPort[port].setObjName(portName);
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -234,15 +222,13 @@ void PassiveTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -266,15 +252,13 @@ void PassiveTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName);
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -298,15 +282,13 @@ void PassiveTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedSync_InputPort[port].setObjName(portName);
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -325,15 +307,13 @@ void PassiveTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName);
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -352,15 +332,13 @@ void PassiveTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName);
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -379,15 +357,13 @@ void PassiveTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_eventOut_OutputPort[port].setObjName(portName);
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -406,15 +382,13 @@ void PassiveTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName);
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -433,15 +407,13 @@ void PassiveTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName);
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -461,15 +433,13 @@ void PassiveTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_textEventOut_OutputPort[port].setObjName(portName);
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 #endif
@@ -489,15 +459,13 @@ void PassiveTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName);
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -516,15 +484,13 @@ void PassiveTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_tlmOut_OutputPort[port].setObjName(portName);
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -543,15 +509,13 @@ void PassiveTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -570,15 +534,13 @@ void PassiveTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -597,15 +559,13 @@ void PassiveTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedOut_OutputPort[port].setObjName(portName);
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -624,15 +584,13 @@ void PassiveTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName);
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.cpp
@@ -197,15 +197,13 @@ void PassiveTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdIn_InputPort[port].setObjName(portName);
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -229,15 +227,13 @@ void PassiveTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_productRecvIn_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_productRecvIn_InputPort[port].setObjName(portName);
+    this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -261,15 +257,13 @@ void PassiveTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -293,15 +287,13 @@ void PassiveTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -325,15 +317,13 @@ void PassiveTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -357,15 +347,13 @@ void PassiveTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsSync_InputPort[port].setObjName(portName);
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -389,15 +377,13 @@ void PassiveTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedGuarded_InputPort[port].setObjName(portName);
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -421,15 +407,13 @@ void PassiveTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -453,15 +437,13 @@ void PassiveTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName);
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -485,15 +467,13 @@ void PassiveTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedSync_InputPort[port].setObjName(portName);
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -512,15 +492,13 @@ void PassiveTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName);
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -539,15 +517,13 @@ void PassiveTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName);
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -566,15 +542,13 @@ void PassiveTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_eventOut_OutputPort[port].setObjName(portName);
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -593,15 +567,13 @@ void PassiveTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName);
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -620,15 +592,13 @@ void PassiveTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName);
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -647,15 +617,13 @@ void PassiveTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_productRequestOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_productRequestOut_OutputPort[port].setObjName(portName);
+    this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -674,15 +642,13 @@ void PassiveTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_productSendOut_OutputPort[port].setObjName(portName);
+    this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -702,15 +668,13 @@ void PassiveTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_textEventOut_OutputPort[port].setObjName(portName);
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 #endif
@@ -730,15 +694,13 @@ void PassiveTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName);
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -757,15 +719,13 @@ void PassiveTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_tlmOut_OutputPort[port].setObjName(portName);
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -784,15 +744,13 @@ void PassiveTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -811,15 +769,13 @@ void PassiveTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -838,15 +794,13 @@ void PassiveTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedOut_OutputPort[port].setObjName(portName);
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -865,15 +819,13 @@ void PassiveTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName);
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 }
@@ -3114,7 +3066,7 @@ void PassiveTestComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventActivityHigh "
     );
@@ -3245,7 +3197,7 @@ void PassiveTestComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventActivityLowThrottled ",
       u32,
@@ -3334,7 +3286,7 @@ void PassiveTestComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventCommand ",
       str1.toChar(),
@@ -3426,7 +3378,7 @@ void PassiveTestComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventDiagnostic ",
       eStr.toChar()
@@ -3538,7 +3490,7 @@ void PassiveTestComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventFatalThrottled ",
       aStr.toChar()
@@ -3629,7 +3581,7 @@ void PassiveTestComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventWarningHigh ",
       sStr.toChar()
@@ -3709,7 +3661,7 @@ void PassiveTestComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventWarningLowThrottled "
     );

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.cpp
@@ -191,12 +191,6 @@ void PassiveTestComponentBase ::
     this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
@@ -221,12 +215,6 @@ void PassiveTestComponentBase ::
     this->m_productRecvIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_productRecvIn_InputPort[%" PRI_PlatformIntType "]",
@@ -251,12 +239,6 @@ void PassiveTestComponentBase ::
     this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -281,12 +263,6 @@ void PassiveTestComponentBase ::
     this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -311,12 +287,6 @@ void PassiveTestComponentBase ::
     this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -341,12 +311,6 @@ void PassiveTestComponentBase ::
     this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
@@ -371,12 +335,6 @@ void PassiveTestComponentBase ::
     this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -401,12 +359,6 @@ void PassiveTestComponentBase ::
     this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -431,12 +383,6 @@ void PassiveTestComponentBase ::
     this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -461,12 +407,6 @@ void PassiveTestComponentBase ::
     this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
@@ -486,12 +426,6 @@ void PassiveTestComponentBase ::
     this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -511,12 +445,6 @@ void PassiveTestComponentBase ::
     this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -536,12 +464,6 @@ void PassiveTestComponentBase ::
     this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -561,12 +483,6 @@ void PassiveTestComponentBase ::
     this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -586,12 +502,6 @@ void PassiveTestComponentBase ::
     this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -611,12 +521,6 @@ void PassiveTestComponentBase ::
     this->m_productRequestOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_productRequestOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -636,12 +540,6 @@ void PassiveTestComponentBase ::
     this->m_productSendOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -662,12 +560,6 @@ void PassiveTestComponentBase ::
     this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -688,12 +580,6 @@ void PassiveTestComponentBase ::
     this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -713,12 +599,6 @@ void PassiveTestComponentBase ::
     this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -738,12 +618,6 @@ void PassiveTestComponentBase ::
     this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -763,12 +637,6 @@ void PassiveTestComponentBase ::
     this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -788,12 +656,6 @@ void PassiveTestComponentBase ::
     this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -813,12 +675,6 @@ void PassiveTestComponentBase ::
     this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedAsyncProductPortsOnlyComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedAsyncProductPortsOnlyComponentAc.ref.cpp
@@ -92,15 +92,13 @@ void QueuedAsyncProductPortsOnlyComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_productRecvIn_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_productRecvIn_InputPort[port].setObjName(portName);
+    this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -119,15 +117,13 @@ void QueuedAsyncProductPortsOnlyComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_productRequestOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_productRequestOut_OutputPort[port].setObjName(portName);
+    this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -146,15 +142,13 @@ void QueuedAsyncProductPortsOnlyComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_productSendOut_OutputPort[port].setObjName(portName);
+    this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedAsyncProductPortsOnlyComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedAsyncProductPortsOnlyComponentAc.ref.cpp
@@ -86,12 +86,6 @@ void QueuedAsyncProductPortsOnlyComponentBase ::
     this->m_productRecvIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_productRecvIn_InputPort[%" PRI_PlatformIntType "]",
@@ -111,12 +105,6 @@ void QueuedAsyncProductPortsOnlyComponentBase ::
     this->m_productRequestOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_productRequestOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -136,12 +124,6 @@ void QueuedAsyncProductPortsOnlyComponentBase ::
     this->m_productSendOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedAsyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedAsyncProductsComponentAc.ref.cpp
@@ -257,15 +257,13 @@ void QueuedAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdIn_InputPort[port].setObjName(portName);
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -289,15 +287,13 @@ void QueuedAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_productRecvIn_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_productRecvIn_InputPort[port].setObjName(portName);
+    this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -321,15 +317,13 @@ void QueuedAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsAsync_InputPort[port].setObjName(portName);
+    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -353,15 +347,13 @@ void QueuedAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -385,15 +377,13 @@ void QueuedAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -417,15 +407,13 @@ void QueuedAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -449,15 +437,13 @@ void QueuedAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsSync_InputPort[port].setObjName(portName);
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -481,15 +467,13 @@ void QueuedAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsync_InputPort[port].setObjName(portName);
+    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -513,15 +497,13 @@ void QueuedAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncAssert_InputPort[port].setObjName(portName);
+    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -545,15 +527,13 @@ void QueuedAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName);
+    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -577,15 +557,13 @@ void QueuedAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName);
+    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -609,15 +587,13 @@ void QueuedAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedGuarded_InputPort[port].setObjName(portName);
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -641,15 +617,13 @@ void QueuedAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -673,15 +647,13 @@ void QueuedAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName);
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -705,15 +677,13 @@ void QueuedAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedSync_InputPort[port].setObjName(portName);
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -732,15 +702,13 @@ void QueuedAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName);
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -759,15 +727,13 @@ void QueuedAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName);
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -786,15 +752,13 @@ void QueuedAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_eventOut_OutputPort[port].setObjName(portName);
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -813,15 +777,13 @@ void QueuedAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName);
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -840,15 +802,13 @@ void QueuedAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName);
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -867,15 +827,13 @@ void QueuedAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_productRequestOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_productRequestOut_OutputPort[port].setObjName(portName);
+    this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -894,15 +852,13 @@ void QueuedAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_productSendOut_OutputPort[port].setObjName(portName);
+    this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -922,15 +878,13 @@ void QueuedAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_textEventOut_OutputPort[port].setObjName(portName);
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 #endif
@@ -950,15 +904,13 @@ void QueuedAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName);
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -977,15 +929,13 @@ void QueuedAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_tlmOut_OutputPort[port].setObjName(portName);
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -1004,15 +954,13 @@ void QueuedAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -1031,15 +979,13 @@ void QueuedAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -1058,15 +1004,13 @@ void QueuedAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedOut_OutputPort[port].setObjName(portName);
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -1085,15 +1029,13 @@ void QueuedAsyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName);
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedAsyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedAsyncProductsComponentAc.ref.cpp
@@ -251,12 +251,6 @@ void QueuedAsyncProductsComponentBase ::
     this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
@@ -281,12 +275,6 @@ void QueuedAsyncProductsComponentBase ::
     this->m_productRecvIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_productRecvIn_InputPort[%" PRI_PlatformIntType "]",
@@ -311,12 +299,6 @@ void QueuedAsyncProductsComponentBase ::
     this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
@@ -341,12 +323,6 @@ void QueuedAsyncProductsComponentBase ::
     this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -371,12 +347,6 @@ void QueuedAsyncProductsComponentBase ::
     this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -401,12 +371,6 @@ void QueuedAsyncProductsComponentBase ::
     this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -431,12 +395,6 @@ void QueuedAsyncProductsComponentBase ::
     this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
@@ -461,12 +419,6 @@ void QueuedAsyncProductsComponentBase ::
     this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
@@ -491,12 +443,6 @@ void QueuedAsyncProductsComponentBase ::
     this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
@@ -521,12 +467,6 @@ void QueuedAsyncProductsComponentBase ::
     this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
@@ -551,12 +491,6 @@ void QueuedAsyncProductsComponentBase ::
     this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
@@ -581,12 +515,6 @@ void QueuedAsyncProductsComponentBase ::
     this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -611,12 +539,6 @@ void QueuedAsyncProductsComponentBase ::
     this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -641,12 +563,6 @@ void QueuedAsyncProductsComponentBase ::
     this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -671,12 +587,6 @@ void QueuedAsyncProductsComponentBase ::
     this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
@@ -696,12 +606,6 @@ void QueuedAsyncProductsComponentBase ::
     this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -721,12 +625,6 @@ void QueuedAsyncProductsComponentBase ::
     this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -746,12 +644,6 @@ void QueuedAsyncProductsComponentBase ::
     this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -771,12 +663,6 @@ void QueuedAsyncProductsComponentBase ::
     this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -796,12 +682,6 @@ void QueuedAsyncProductsComponentBase ::
     this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -821,12 +701,6 @@ void QueuedAsyncProductsComponentBase ::
     this->m_productRequestOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_productRequestOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -846,12 +720,6 @@ void QueuedAsyncProductsComponentBase ::
     this->m_productSendOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -872,12 +740,6 @@ void QueuedAsyncProductsComponentBase ::
     this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -898,12 +760,6 @@ void QueuedAsyncProductsComponentBase ::
     this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -923,12 +779,6 @@ void QueuedAsyncProductsComponentBase ::
     this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -948,12 +798,6 @@ void QueuedAsyncProductsComponentBase ::
     this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -973,12 +817,6 @@ void QueuedAsyncProductsComponentBase ::
     this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -998,12 +836,6 @@ void QueuedAsyncProductsComponentBase ::
     this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -1023,12 +855,6 @@ void QueuedAsyncProductsComponentBase ::
     this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedCommandsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedCommandsComponentAc.ref.cpp
@@ -105,15 +105,13 @@ void QueuedCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdIn_InputPort[port].setObjName(portName);
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -137,15 +135,13 @@ void QueuedCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsAsync_InputPort[port].setObjName(portName);
+    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -169,15 +165,13 @@ void QueuedCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -201,15 +195,13 @@ void QueuedCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -233,15 +225,13 @@ void QueuedCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -265,15 +255,13 @@ void QueuedCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsSync_InputPort[port].setObjName(portName);
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -297,15 +285,13 @@ void QueuedCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsync_InputPort[port].setObjName(portName);
+    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -329,15 +315,13 @@ void QueuedCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncAssert_InputPort[port].setObjName(portName);
+    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -361,15 +345,13 @@ void QueuedCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName);
+    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -393,15 +375,13 @@ void QueuedCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName);
+    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -425,15 +405,13 @@ void QueuedCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedGuarded_InputPort[port].setObjName(portName);
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -457,15 +435,13 @@ void QueuedCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -489,15 +465,13 @@ void QueuedCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName);
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -521,15 +495,13 @@ void QueuedCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedSync_InputPort[port].setObjName(portName);
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -548,15 +520,13 @@ void QueuedCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName);
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -575,15 +545,13 @@ void QueuedCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName);
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -602,15 +570,13 @@ void QueuedCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_eventOut_OutputPort[port].setObjName(portName);
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -629,15 +595,13 @@ void QueuedCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName);
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -656,15 +620,13 @@ void QueuedCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName);
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -684,15 +646,13 @@ void QueuedCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_textEventOut_OutputPort[port].setObjName(portName);
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 #endif
@@ -712,15 +672,13 @@ void QueuedCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName);
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -739,15 +697,13 @@ void QueuedCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_tlmOut_OutputPort[port].setObjName(portName);
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -766,15 +722,13 @@ void QueuedCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -793,15 +747,13 @@ void QueuedCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -820,15 +772,13 @@ void QueuedCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedOut_OutputPort[port].setObjName(portName);
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -847,15 +797,13 @@ void QueuedCommandsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName);
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedCommandsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedCommandsComponentAc.ref.cpp
@@ -99,12 +99,6 @@ void QueuedCommandsComponentBase ::
     this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
@@ -129,12 +123,6 @@ void QueuedCommandsComponentBase ::
     this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
@@ -159,12 +147,6 @@ void QueuedCommandsComponentBase ::
     this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -189,12 +171,6 @@ void QueuedCommandsComponentBase ::
     this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -219,12 +195,6 @@ void QueuedCommandsComponentBase ::
     this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -249,12 +219,6 @@ void QueuedCommandsComponentBase ::
     this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
@@ -279,12 +243,6 @@ void QueuedCommandsComponentBase ::
     this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
@@ -309,12 +267,6 @@ void QueuedCommandsComponentBase ::
     this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
@@ -339,12 +291,6 @@ void QueuedCommandsComponentBase ::
     this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
@@ -369,12 +315,6 @@ void QueuedCommandsComponentBase ::
     this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
@@ -399,12 +339,6 @@ void QueuedCommandsComponentBase ::
     this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -429,12 +363,6 @@ void QueuedCommandsComponentBase ::
     this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -459,12 +387,6 @@ void QueuedCommandsComponentBase ::
     this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -489,12 +411,6 @@ void QueuedCommandsComponentBase ::
     this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
@@ -514,12 +430,6 @@ void QueuedCommandsComponentBase ::
     this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -539,12 +449,6 @@ void QueuedCommandsComponentBase ::
     this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -564,12 +468,6 @@ void QueuedCommandsComponentBase ::
     this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -589,12 +487,6 @@ void QueuedCommandsComponentBase ::
     this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -614,12 +506,6 @@ void QueuedCommandsComponentBase ::
     this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -640,12 +526,6 @@ void QueuedCommandsComponentBase ::
     this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -666,12 +546,6 @@ void QueuedCommandsComponentBase ::
     this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -691,12 +565,6 @@ void QueuedCommandsComponentBase ::
     this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -716,12 +584,6 @@ void QueuedCommandsComponentBase ::
     this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -741,12 +603,6 @@ void QueuedCommandsComponentBase ::
     this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -766,12 +622,6 @@ void QueuedCommandsComponentBase ::
     this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -791,12 +641,6 @@ void QueuedCommandsComponentBase ::
     this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedEventsComponentAc.ref.cpp
@@ -94,12 +94,6 @@ void QueuedEventsComponentBase ::
     this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
@@ -124,12 +118,6 @@ void QueuedEventsComponentBase ::
     this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
@@ -154,12 +142,6 @@ void QueuedEventsComponentBase ::
     this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -184,12 +166,6 @@ void QueuedEventsComponentBase ::
     this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -214,12 +190,6 @@ void QueuedEventsComponentBase ::
     this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -244,12 +214,6 @@ void QueuedEventsComponentBase ::
     this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
@@ -274,12 +238,6 @@ void QueuedEventsComponentBase ::
     this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
@@ -304,12 +262,6 @@ void QueuedEventsComponentBase ::
     this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
@@ -334,12 +286,6 @@ void QueuedEventsComponentBase ::
     this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
@@ -364,12 +310,6 @@ void QueuedEventsComponentBase ::
     this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
@@ -394,12 +334,6 @@ void QueuedEventsComponentBase ::
     this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -424,12 +358,6 @@ void QueuedEventsComponentBase ::
     this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -454,12 +382,6 @@ void QueuedEventsComponentBase ::
     this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -484,12 +406,6 @@ void QueuedEventsComponentBase ::
     this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
@@ -509,12 +425,6 @@ void QueuedEventsComponentBase ::
     this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -534,12 +444,6 @@ void QueuedEventsComponentBase ::
     this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -559,12 +463,6 @@ void QueuedEventsComponentBase ::
     this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -584,12 +482,6 @@ void QueuedEventsComponentBase ::
     this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -609,12 +501,6 @@ void QueuedEventsComponentBase ::
     this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -635,12 +521,6 @@ void QueuedEventsComponentBase ::
     this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -661,12 +541,6 @@ void QueuedEventsComponentBase ::
     this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -686,12 +560,6 @@ void QueuedEventsComponentBase ::
     this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -711,12 +579,6 @@ void QueuedEventsComponentBase ::
     this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -736,12 +598,6 @@ void QueuedEventsComponentBase ::
     this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -761,12 +617,6 @@ void QueuedEventsComponentBase ::
     this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -786,12 +636,6 @@ void QueuedEventsComponentBase ::
     this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedEventsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedEventsComponentAc.ref.cpp
@@ -100,15 +100,13 @@ void QueuedEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdIn_InputPort[port].setObjName(portName);
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -132,15 +130,13 @@ void QueuedEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsAsync_InputPort[port].setObjName(portName);
+    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -164,15 +160,13 @@ void QueuedEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -196,15 +190,13 @@ void QueuedEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -228,15 +220,13 @@ void QueuedEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -260,15 +250,13 @@ void QueuedEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsSync_InputPort[port].setObjName(portName);
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -292,15 +280,13 @@ void QueuedEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsync_InputPort[port].setObjName(portName);
+    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -324,15 +310,13 @@ void QueuedEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncAssert_InputPort[port].setObjName(portName);
+    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -356,15 +340,13 @@ void QueuedEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName);
+    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -388,15 +370,13 @@ void QueuedEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName);
+    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -420,15 +400,13 @@ void QueuedEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedGuarded_InputPort[port].setObjName(portName);
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -452,15 +430,13 @@ void QueuedEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -484,15 +460,13 @@ void QueuedEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName);
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -516,15 +490,13 @@ void QueuedEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedSync_InputPort[port].setObjName(portName);
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -543,15 +515,13 @@ void QueuedEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName);
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -570,15 +540,13 @@ void QueuedEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName);
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -597,15 +565,13 @@ void QueuedEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_eventOut_OutputPort[port].setObjName(portName);
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -624,15 +590,13 @@ void QueuedEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName);
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -651,15 +615,13 @@ void QueuedEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName);
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -679,15 +641,13 @@ void QueuedEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_textEventOut_OutputPort[port].setObjName(portName);
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 #endif
@@ -707,15 +667,13 @@ void QueuedEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName);
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -734,15 +692,13 @@ void QueuedEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_tlmOut_OutputPort[port].setObjName(portName);
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -761,15 +717,13 @@ void QueuedEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -788,15 +742,13 @@ void QueuedEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -815,15 +767,13 @@ void QueuedEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedOut_OutputPort[port].setObjName(portName);
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -842,15 +792,13 @@ void QueuedEventsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName);
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -2595,7 +2543,7 @@ void QueuedEventsComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventActivityHigh "
     );
@@ -2726,7 +2674,7 @@ void QueuedEventsComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventActivityLowThrottled ",
       u32,
@@ -2815,7 +2763,7 @@ void QueuedEventsComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventCommand ",
       str1.toChar(),
@@ -2907,7 +2855,7 @@ void QueuedEventsComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventDiagnostic ",
       eStr.toChar()
@@ -3019,7 +2967,7 @@ void QueuedEventsComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventFatalThrottled ",
       aStr.toChar()
@@ -3110,7 +3058,7 @@ void QueuedEventsComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventWarningHigh ",
       sStr.toChar()
@@ -3190,7 +3138,7 @@ void QueuedEventsComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventWarningLowThrottled "
     );

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedGetProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedGetProductsComponentAc.ref.cpp
@@ -255,15 +255,13 @@ void QueuedGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdIn_InputPort[port].setObjName(portName);
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -287,15 +285,13 @@ void QueuedGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsAsync_InputPort[port].setObjName(portName);
+    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -319,15 +315,13 @@ void QueuedGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -351,15 +345,13 @@ void QueuedGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -383,15 +375,13 @@ void QueuedGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -415,15 +405,13 @@ void QueuedGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsSync_InputPort[port].setObjName(portName);
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -447,15 +435,13 @@ void QueuedGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsync_InputPort[port].setObjName(portName);
+    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -479,15 +465,13 @@ void QueuedGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncAssert_InputPort[port].setObjName(portName);
+    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -511,15 +495,13 @@ void QueuedGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName);
+    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -543,15 +525,13 @@ void QueuedGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName);
+    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -575,15 +555,13 @@ void QueuedGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedGuarded_InputPort[port].setObjName(portName);
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -607,15 +585,13 @@ void QueuedGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -639,15 +615,13 @@ void QueuedGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName);
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -671,15 +645,13 @@ void QueuedGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedSync_InputPort[port].setObjName(portName);
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -698,15 +670,13 @@ void QueuedGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName);
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -725,15 +695,13 @@ void QueuedGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName);
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -752,15 +720,13 @@ void QueuedGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_eventOut_OutputPort[port].setObjName(portName);
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -779,15 +745,13 @@ void QueuedGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName);
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -806,15 +770,13 @@ void QueuedGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName);
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -833,15 +795,13 @@ void QueuedGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_productGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_productGetOut_OutputPort[port].setObjName(portName);
+    this->m_productGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -860,15 +820,13 @@ void QueuedGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_productSendOut_OutputPort[port].setObjName(portName);
+    this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -888,15 +846,13 @@ void QueuedGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_textEventOut_OutputPort[port].setObjName(portName);
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 #endif
@@ -916,15 +872,13 @@ void QueuedGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName);
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -943,15 +897,13 @@ void QueuedGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_tlmOut_OutputPort[port].setObjName(portName);
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -970,15 +922,13 @@ void QueuedGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -997,15 +947,13 @@ void QueuedGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -1024,15 +972,13 @@ void QueuedGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedOut_OutputPort[port].setObjName(portName);
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -1051,15 +997,13 @@ void QueuedGetProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName);
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedGetProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedGetProductsComponentAc.ref.cpp
@@ -249,12 +249,6 @@ void QueuedGetProductsComponentBase ::
     this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
@@ -279,12 +273,6 @@ void QueuedGetProductsComponentBase ::
     this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
@@ -309,12 +297,6 @@ void QueuedGetProductsComponentBase ::
     this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -339,12 +321,6 @@ void QueuedGetProductsComponentBase ::
     this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -369,12 +345,6 @@ void QueuedGetProductsComponentBase ::
     this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -399,12 +369,6 @@ void QueuedGetProductsComponentBase ::
     this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
@@ -429,12 +393,6 @@ void QueuedGetProductsComponentBase ::
     this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
@@ -459,12 +417,6 @@ void QueuedGetProductsComponentBase ::
     this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
@@ -489,12 +441,6 @@ void QueuedGetProductsComponentBase ::
     this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
@@ -519,12 +465,6 @@ void QueuedGetProductsComponentBase ::
     this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
@@ -549,12 +489,6 @@ void QueuedGetProductsComponentBase ::
     this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -579,12 +513,6 @@ void QueuedGetProductsComponentBase ::
     this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -609,12 +537,6 @@ void QueuedGetProductsComponentBase ::
     this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -639,12 +561,6 @@ void QueuedGetProductsComponentBase ::
     this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
@@ -664,12 +580,6 @@ void QueuedGetProductsComponentBase ::
     this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -689,12 +599,6 @@ void QueuedGetProductsComponentBase ::
     this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -714,12 +618,6 @@ void QueuedGetProductsComponentBase ::
     this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -739,12 +637,6 @@ void QueuedGetProductsComponentBase ::
     this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -764,12 +656,6 @@ void QueuedGetProductsComponentBase ::
     this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -789,12 +675,6 @@ void QueuedGetProductsComponentBase ::
     this->m_productGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_productGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -814,12 +694,6 @@ void QueuedGetProductsComponentBase ::
     this->m_productSendOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -840,12 +714,6 @@ void QueuedGetProductsComponentBase ::
     this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -866,12 +734,6 @@ void QueuedGetProductsComponentBase ::
     this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -891,12 +753,6 @@ void QueuedGetProductsComponentBase ::
     this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -916,12 +772,6 @@ void QueuedGetProductsComponentBase ::
     this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -941,12 +791,6 @@ void QueuedGetProductsComponentBase ::
     this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -966,12 +810,6 @@ void QueuedGetProductsComponentBase ::
     this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -991,12 +829,6 @@ void QueuedGetProductsComponentBase ::
     this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedGuardedProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedGuardedProductsComponentAc.ref.cpp
@@ -249,12 +249,6 @@ void QueuedGuardedProductsComponentBase ::
     this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
@@ -279,12 +273,6 @@ void QueuedGuardedProductsComponentBase ::
     this->m_productRecvIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_productRecvIn_InputPort[%" PRI_PlatformIntType "]",
@@ -309,12 +297,6 @@ void QueuedGuardedProductsComponentBase ::
     this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
@@ -339,12 +321,6 @@ void QueuedGuardedProductsComponentBase ::
     this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -369,12 +345,6 @@ void QueuedGuardedProductsComponentBase ::
     this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -399,12 +369,6 @@ void QueuedGuardedProductsComponentBase ::
     this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -429,12 +393,6 @@ void QueuedGuardedProductsComponentBase ::
     this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
@@ -459,12 +417,6 @@ void QueuedGuardedProductsComponentBase ::
     this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
@@ -489,12 +441,6 @@ void QueuedGuardedProductsComponentBase ::
     this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
@@ -519,12 +465,6 @@ void QueuedGuardedProductsComponentBase ::
     this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
@@ -549,12 +489,6 @@ void QueuedGuardedProductsComponentBase ::
     this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
@@ -579,12 +513,6 @@ void QueuedGuardedProductsComponentBase ::
     this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -609,12 +537,6 @@ void QueuedGuardedProductsComponentBase ::
     this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -639,12 +561,6 @@ void QueuedGuardedProductsComponentBase ::
     this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -669,12 +585,6 @@ void QueuedGuardedProductsComponentBase ::
     this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
@@ -694,12 +604,6 @@ void QueuedGuardedProductsComponentBase ::
     this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -719,12 +623,6 @@ void QueuedGuardedProductsComponentBase ::
     this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -744,12 +642,6 @@ void QueuedGuardedProductsComponentBase ::
     this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -769,12 +661,6 @@ void QueuedGuardedProductsComponentBase ::
     this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -794,12 +680,6 @@ void QueuedGuardedProductsComponentBase ::
     this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -819,12 +699,6 @@ void QueuedGuardedProductsComponentBase ::
     this->m_productRequestOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_productRequestOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -844,12 +718,6 @@ void QueuedGuardedProductsComponentBase ::
     this->m_productSendOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -870,12 +738,6 @@ void QueuedGuardedProductsComponentBase ::
     this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -896,12 +758,6 @@ void QueuedGuardedProductsComponentBase ::
     this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -921,12 +777,6 @@ void QueuedGuardedProductsComponentBase ::
     this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -946,12 +796,6 @@ void QueuedGuardedProductsComponentBase ::
     this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -971,12 +815,6 @@ void QueuedGuardedProductsComponentBase ::
     this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -996,12 +834,6 @@ void QueuedGuardedProductsComponentBase ::
     this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -1021,12 +853,6 @@ void QueuedGuardedProductsComponentBase ::
     this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedGuardedProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedGuardedProductsComponentAc.ref.cpp
@@ -255,15 +255,13 @@ void QueuedGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdIn_InputPort[port].setObjName(portName);
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -287,15 +285,13 @@ void QueuedGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_productRecvIn_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_productRecvIn_InputPort[port].setObjName(portName);
+    this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -319,15 +315,13 @@ void QueuedGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsAsync_InputPort[port].setObjName(portName);
+    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -351,15 +345,13 @@ void QueuedGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -383,15 +375,13 @@ void QueuedGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -415,15 +405,13 @@ void QueuedGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -447,15 +435,13 @@ void QueuedGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsSync_InputPort[port].setObjName(portName);
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -479,15 +465,13 @@ void QueuedGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsync_InputPort[port].setObjName(portName);
+    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -511,15 +495,13 @@ void QueuedGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncAssert_InputPort[port].setObjName(portName);
+    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -543,15 +525,13 @@ void QueuedGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName);
+    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -575,15 +555,13 @@ void QueuedGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName);
+    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -607,15 +585,13 @@ void QueuedGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedGuarded_InputPort[port].setObjName(portName);
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -639,15 +615,13 @@ void QueuedGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -671,15 +645,13 @@ void QueuedGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName);
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -703,15 +675,13 @@ void QueuedGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedSync_InputPort[port].setObjName(portName);
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -730,15 +700,13 @@ void QueuedGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName);
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -757,15 +725,13 @@ void QueuedGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName);
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -784,15 +750,13 @@ void QueuedGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_eventOut_OutputPort[port].setObjName(portName);
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -811,15 +775,13 @@ void QueuedGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName);
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -838,15 +800,13 @@ void QueuedGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName);
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -865,15 +825,13 @@ void QueuedGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_productRequestOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_productRequestOut_OutputPort[port].setObjName(portName);
+    this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -892,15 +850,13 @@ void QueuedGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_productSendOut_OutputPort[port].setObjName(portName);
+    this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -920,15 +876,13 @@ void QueuedGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_textEventOut_OutputPort[port].setObjName(portName);
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 #endif
@@ -948,15 +902,13 @@ void QueuedGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName);
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -975,15 +927,13 @@ void QueuedGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_tlmOut_OutputPort[port].setObjName(portName);
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -1002,15 +952,13 @@ void QueuedGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -1029,15 +977,13 @@ void QueuedGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -1056,15 +1002,13 @@ void QueuedGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedOut_OutputPort[port].setObjName(portName);
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -1083,15 +1027,13 @@ void QueuedGuardedProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName);
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedNoArgsPortsOnlyComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedNoArgsPortsOnlyComponentAc.ref.cpp
@@ -79,12 +79,6 @@ void QueuedNoArgsPortsOnlyComponentBase ::
     this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
@@ -109,12 +103,6 @@ void QueuedNoArgsPortsOnlyComponentBase ::
     this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -139,12 +127,6 @@ void QueuedNoArgsPortsOnlyComponentBase ::
     this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -169,12 +151,6 @@ void QueuedNoArgsPortsOnlyComponentBase ::
     this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -194,12 +170,6 @@ void QueuedNoArgsPortsOnlyComponentBase ::
     this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -219,12 +189,6 @@ void QueuedNoArgsPortsOnlyComponentBase ::
     this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedNoArgsPortsOnlyComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedNoArgsPortsOnlyComponentAc.ref.cpp
@@ -85,15 +85,13 @@ void QueuedNoArgsPortsOnlyComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsAsync_InputPort[port].setObjName(portName);
+    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -117,15 +115,13 @@ void QueuedNoArgsPortsOnlyComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -149,15 +145,13 @@ void QueuedNoArgsPortsOnlyComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -181,15 +175,13 @@ void QueuedNoArgsPortsOnlyComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -208,15 +200,13 @@ void QueuedNoArgsPortsOnlyComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -235,15 +225,13 @@ void QueuedNoArgsPortsOnlyComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedParamsComponentAc.ref.cpp
@@ -100,15 +100,13 @@ void QueuedParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdIn_InputPort[port].setObjName(portName);
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -132,15 +130,13 @@ void QueuedParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsAsync_InputPort[port].setObjName(portName);
+    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -164,15 +160,13 @@ void QueuedParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -196,15 +190,13 @@ void QueuedParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -228,15 +220,13 @@ void QueuedParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -260,15 +250,13 @@ void QueuedParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsSync_InputPort[port].setObjName(portName);
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -292,15 +280,13 @@ void QueuedParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsync_InputPort[port].setObjName(portName);
+    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -324,15 +310,13 @@ void QueuedParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncAssert_InputPort[port].setObjName(portName);
+    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -356,15 +340,13 @@ void QueuedParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName);
+    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -388,15 +370,13 @@ void QueuedParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName);
+    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -420,15 +400,13 @@ void QueuedParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedGuarded_InputPort[port].setObjName(portName);
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -452,15 +430,13 @@ void QueuedParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -484,15 +460,13 @@ void QueuedParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName);
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -516,15 +490,13 @@ void QueuedParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedSync_InputPort[port].setObjName(portName);
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -543,15 +515,13 @@ void QueuedParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName);
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -570,15 +540,13 @@ void QueuedParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName);
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -597,15 +565,13 @@ void QueuedParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_eventOut_OutputPort[port].setObjName(portName);
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -624,15 +590,13 @@ void QueuedParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName);
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -651,15 +615,13 @@ void QueuedParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName);
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -679,15 +641,13 @@ void QueuedParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_textEventOut_OutputPort[port].setObjName(portName);
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 #endif
@@ -707,15 +667,13 @@ void QueuedParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName);
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -734,15 +692,13 @@ void QueuedParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_tlmOut_OutputPort[port].setObjName(portName);
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -761,15 +717,13 @@ void QueuedParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -788,15 +742,13 @@ void QueuedParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -815,15 +767,13 @@ void QueuedParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedOut_OutputPort[port].setObjName(portName);
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -842,15 +792,13 @@ void QueuedParamsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName);
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedParamsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedParamsComponentAc.ref.cpp
@@ -94,12 +94,6 @@ void QueuedParamsComponentBase ::
     this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
@@ -124,12 +118,6 @@ void QueuedParamsComponentBase ::
     this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
@@ -154,12 +142,6 @@ void QueuedParamsComponentBase ::
     this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -184,12 +166,6 @@ void QueuedParamsComponentBase ::
     this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -214,12 +190,6 @@ void QueuedParamsComponentBase ::
     this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -244,12 +214,6 @@ void QueuedParamsComponentBase ::
     this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
@@ -274,12 +238,6 @@ void QueuedParamsComponentBase ::
     this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
@@ -304,12 +262,6 @@ void QueuedParamsComponentBase ::
     this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
@@ -334,12 +286,6 @@ void QueuedParamsComponentBase ::
     this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
@@ -364,12 +310,6 @@ void QueuedParamsComponentBase ::
     this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
@@ -394,12 +334,6 @@ void QueuedParamsComponentBase ::
     this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -424,12 +358,6 @@ void QueuedParamsComponentBase ::
     this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -454,12 +382,6 @@ void QueuedParamsComponentBase ::
     this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -484,12 +406,6 @@ void QueuedParamsComponentBase ::
     this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
@@ -509,12 +425,6 @@ void QueuedParamsComponentBase ::
     this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -534,12 +444,6 @@ void QueuedParamsComponentBase ::
     this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -559,12 +463,6 @@ void QueuedParamsComponentBase ::
     this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -584,12 +482,6 @@ void QueuedParamsComponentBase ::
     this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -609,12 +501,6 @@ void QueuedParamsComponentBase ::
     this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -635,12 +521,6 @@ void QueuedParamsComponentBase ::
     this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -661,12 +541,6 @@ void QueuedParamsComponentBase ::
     this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -686,12 +560,6 @@ void QueuedParamsComponentBase ::
     this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -711,12 +579,6 @@ void QueuedParamsComponentBase ::
     this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -736,12 +598,6 @@ void QueuedParamsComponentBase ::
     this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -761,12 +617,6 @@ void QueuedParamsComponentBase ::
     this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -786,12 +636,6 @@ void QueuedParamsComponentBase ::
     this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.cpp
@@ -133,12 +133,6 @@ void QueuedSerialComponentBase ::
     this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
@@ -163,12 +157,6 @@ void QueuedSerialComponentBase ::
     this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
@@ -193,12 +181,6 @@ void QueuedSerialComponentBase ::
     this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -223,12 +205,6 @@ void QueuedSerialComponentBase ::
     this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -253,12 +229,6 @@ void QueuedSerialComponentBase ::
     this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -283,12 +253,6 @@ void QueuedSerialComponentBase ::
     this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
@@ -313,12 +277,6 @@ void QueuedSerialComponentBase ::
     this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
@@ -343,12 +301,6 @@ void QueuedSerialComponentBase ::
     this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
@@ -373,12 +325,6 @@ void QueuedSerialComponentBase ::
     this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
@@ -403,12 +349,6 @@ void QueuedSerialComponentBase ::
     this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
@@ -433,12 +373,6 @@ void QueuedSerialComponentBase ::
     this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -463,12 +397,6 @@ void QueuedSerialComponentBase ::
     this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -493,12 +421,6 @@ void QueuedSerialComponentBase ::
     this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -523,12 +445,6 @@ void QueuedSerialComponentBase ::
     this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
@@ -553,12 +469,6 @@ void QueuedSerialComponentBase ::
     this->m_serialAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_serialAsync_InputPort[%" PRI_PlatformIntType "]",
@@ -583,12 +493,6 @@ void QueuedSerialComponentBase ::
     this->m_serialAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_serialAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
@@ -613,12 +517,6 @@ void QueuedSerialComponentBase ::
     this->m_serialAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_serialAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
@@ -643,12 +541,6 @@ void QueuedSerialComponentBase ::
     this->m_serialAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_serialAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
@@ -673,12 +565,6 @@ void QueuedSerialComponentBase ::
     this->m_serialGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_serialGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -703,12 +589,6 @@ void QueuedSerialComponentBase ::
     this->m_serialSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_serialSync_InputPort[%" PRI_PlatformIntType "]",
@@ -728,12 +608,6 @@ void QueuedSerialComponentBase ::
     this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -753,12 +627,6 @@ void QueuedSerialComponentBase ::
     this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -778,12 +646,6 @@ void QueuedSerialComponentBase ::
     this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -803,12 +665,6 @@ void QueuedSerialComponentBase ::
     this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -828,12 +684,6 @@ void QueuedSerialComponentBase ::
     this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -854,12 +704,6 @@ void QueuedSerialComponentBase ::
     this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -880,12 +724,6 @@ void QueuedSerialComponentBase ::
     this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -905,12 +743,6 @@ void QueuedSerialComponentBase ::
     this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -930,12 +762,6 @@ void QueuedSerialComponentBase ::
     this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -955,12 +781,6 @@ void QueuedSerialComponentBase ::
     this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -980,12 +800,6 @@ void QueuedSerialComponentBase ::
     this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -1005,12 +819,6 @@ void QueuedSerialComponentBase ::
     this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -1030,12 +838,6 @@ void QueuedSerialComponentBase ::
     this->m_serialOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_serialOut_OutputPort[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedSerialComponentAc.ref.cpp
@@ -139,15 +139,13 @@ void QueuedSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdIn_InputPort[port].setObjName(portName);
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -171,15 +169,13 @@ void QueuedSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsAsync_InputPort[port].setObjName(portName);
+    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -203,15 +199,13 @@ void QueuedSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -235,15 +229,13 @@ void QueuedSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -267,15 +259,13 @@ void QueuedSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -299,15 +289,13 @@ void QueuedSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsSync_InputPort[port].setObjName(portName);
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -331,15 +319,13 @@ void QueuedSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsync_InputPort[port].setObjName(portName);
+    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -363,15 +349,13 @@ void QueuedSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncAssert_InputPort[port].setObjName(portName);
+    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -395,15 +379,13 @@ void QueuedSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName);
+    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -427,15 +409,13 @@ void QueuedSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName);
+    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -459,15 +439,13 @@ void QueuedSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedGuarded_InputPort[port].setObjName(portName);
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -491,15 +469,13 @@ void QueuedSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -523,15 +499,13 @@ void QueuedSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName);
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -555,15 +529,13 @@ void QueuedSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedSync_InputPort[port].setObjName(portName);
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -587,15 +559,13 @@ void QueuedSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_serialAsync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_serialAsync_InputPort[port].setObjName(portName);
+    this->m_serialAsync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -619,15 +589,13 @@ void QueuedSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_serialAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_serialAsyncAssert_InputPort[port].setObjName(portName);
+    this->m_serialAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -651,15 +619,13 @@ void QueuedSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_serialAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_serialAsyncBlockPriority_InputPort[port].setObjName(portName);
+    this->m_serialAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -683,15 +649,13 @@ void QueuedSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_serialAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_serialAsyncDropPriority_InputPort[port].setObjName(portName);
+    this->m_serialAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -715,15 +679,13 @@ void QueuedSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_serialGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_serialGuarded_InputPort[port].setObjName(portName);
+    this->m_serialGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -747,15 +709,13 @@ void QueuedSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_serialSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_serialSync_InputPort[port].setObjName(portName);
+    this->m_serialSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -774,15 +734,13 @@ void QueuedSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName);
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -801,15 +759,13 @@ void QueuedSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName);
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -828,15 +784,13 @@ void QueuedSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_eventOut_OutputPort[port].setObjName(portName);
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -855,15 +809,13 @@ void QueuedSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName);
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -882,15 +834,13 @@ void QueuedSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName);
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -910,15 +860,13 @@ void QueuedSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_textEventOut_OutputPort[port].setObjName(portName);
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 #endif
@@ -938,15 +886,13 @@ void QueuedSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName);
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -965,15 +911,13 @@ void QueuedSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_tlmOut_OutputPort[port].setObjName(portName);
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -992,15 +936,13 @@ void QueuedSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -1019,15 +961,13 @@ void QueuedSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -1046,15 +986,13 @@ void QueuedSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedOut_OutputPort[port].setObjName(portName);
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -1073,15 +1011,13 @@ void QueuedSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName);
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -1100,15 +1036,13 @@ void QueuedSerialComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_serialOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_serialOut_OutputPort[port].setObjName(portName);
+    this->m_serialOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -4905,7 +4839,7 @@ void QueuedSerialComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventActivityHigh "
     );
@@ -5036,7 +4970,7 @@ void QueuedSerialComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventActivityLowThrottled ",
       u32,
@@ -5125,7 +5059,7 @@ void QueuedSerialComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventCommand ",
       str1.toChar(),
@@ -5217,7 +5151,7 @@ void QueuedSerialComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventDiagnostic ",
       eStr.toChar()
@@ -5329,7 +5263,7 @@ void QueuedSerialComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventFatalThrottled ",
       aStr.toChar()
@@ -5420,7 +5354,7 @@ void QueuedSerialComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventWarningHigh ",
       sStr.toChar()
@@ -5500,7 +5434,7 @@ void QueuedSerialComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventWarningLowThrottled "
     );

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedSyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedSyncProductsComponentAc.ref.cpp
@@ -255,15 +255,13 @@ void QueuedSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdIn_InputPort[port].setObjName(portName);
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -287,15 +285,13 @@ void QueuedSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_productRecvIn_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_productRecvIn_InputPort[port].setObjName(portName);
+    this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -319,15 +315,13 @@ void QueuedSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsAsync_InputPort[port].setObjName(portName);
+    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -351,15 +345,13 @@ void QueuedSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -383,15 +375,13 @@ void QueuedSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -415,15 +405,13 @@ void QueuedSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -447,15 +435,13 @@ void QueuedSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsSync_InputPort[port].setObjName(portName);
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -479,15 +465,13 @@ void QueuedSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsync_InputPort[port].setObjName(portName);
+    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -511,15 +495,13 @@ void QueuedSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncAssert_InputPort[port].setObjName(portName);
+    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -543,15 +525,13 @@ void QueuedSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName);
+    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -575,15 +555,13 @@ void QueuedSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName);
+    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -607,15 +585,13 @@ void QueuedSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedGuarded_InputPort[port].setObjName(portName);
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -639,15 +615,13 @@ void QueuedSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -671,15 +645,13 @@ void QueuedSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName);
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -703,15 +675,13 @@ void QueuedSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedSync_InputPort[port].setObjName(portName);
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -730,15 +700,13 @@ void QueuedSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName);
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -757,15 +725,13 @@ void QueuedSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName);
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -784,15 +750,13 @@ void QueuedSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_eventOut_OutputPort[port].setObjName(portName);
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -811,15 +775,13 @@ void QueuedSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName);
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -838,15 +800,13 @@ void QueuedSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName);
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -865,15 +825,13 @@ void QueuedSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_productRequestOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_productRequestOut_OutputPort[port].setObjName(portName);
+    this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -892,15 +850,13 @@ void QueuedSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_productSendOut_OutputPort[port].setObjName(portName);
+    this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -920,15 +876,13 @@ void QueuedSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_textEventOut_OutputPort[port].setObjName(portName);
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 #endif
@@ -948,15 +902,13 @@ void QueuedSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName);
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -975,15 +927,13 @@ void QueuedSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_tlmOut_OutputPort[port].setObjName(portName);
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -1002,15 +952,13 @@ void QueuedSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -1029,15 +977,13 @@ void QueuedSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -1056,15 +1002,13 @@ void QueuedSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedOut_OutputPort[port].setObjName(portName);
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -1083,15 +1027,13 @@ void QueuedSyncProductsComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName);
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedSyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedSyncProductsComponentAc.ref.cpp
@@ -249,12 +249,6 @@ void QueuedSyncProductsComponentBase ::
     this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
@@ -279,12 +273,6 @@ void QueuedSyncProductsComponentBase ::
     this->m_productRecvIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_productRecvIn_InputPort[%" PRI_PlatformIntType "]",
@@ -309,12 +297,6 @@ void QueuedSyncProductsComponentBase ::
     this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
@@ -339,12 +321,6 @@ void QueuedSyncProductsComponentBase ::
     this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -369,12 +345,6 @@ void QueuedSyncProductsComponentBase ::
     this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -399,12 +369,6 @@ void QueuedSyncProductsComponentBase ::
     this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -429,12 +393,6 @@ void QueuedSyncProductsComponentBase ::
     this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
@@ -459,12 +417,6 @@ void QueuedSyncProductsComponentBase ::
     this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
@@ -489,12 +441,6 @@ void QueuedSyncProductsComponentBase ::
     this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
@@ -519,12 +465,6 @@ void QueuedSyncProductsComponentBase ::
     this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
@@ -549,12 +489,6 @@ void QueuedSyncProductsComponentBase ::
     this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
@@ -579,12 +513,6 @@ void QueuedSyncProductsComponentBase ::
     this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -609,12 +537,6 @@ void QueuedSyncProductsComponentBase ::
     this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -639,12 +561,6 @@ void QueuedSyncProductsComponentBase ::
     this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -669,12 +585,6 @@ void QueuedSyncProductsComponentBase ::
     this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
@@ -694,12 +604,6 @@ void QueuedSyncProductsComponentBase ::
     this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -719,12 +623,6 @@ void QueuedSyncProductsComponentBase ::
     this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -744,12 +642,6 @@ void QueuedSyncProductsComponentBase ::
     this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -769,12 +661,6 @@ void QueuedSyncProductsComponentBase ::
     this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -794,12 +680,6 @@ void QueuedSyncProductsComponentBase ::
     this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -819,12 +699,6 @@ void QueuedSyncProductsComponentBase ::
     this->m_productRequestOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_productRequestOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -844,12 +718,6 @@ void QueuedSyncProductsComponentBase ::
     this->m_productSendOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -870,12 +738,6 @@ void QueuedSyncProductsComponentBase ::
     this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -896,12 +758,6 @@ void QueuedSyncProductsComponentBase ::
     this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -921,12 +777,6 @@ void QueuedSyncProductsComponentBase ::
     this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -946,12 +796,6 @@ void QueuedSyncProductsComponentBase ::
     this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -971,12 +815,6 @@ void QueuedSyncProductsComponentBase ::
     this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -996,12 +834,6 @@ void QueuedSyncProductsComponentBase ::
     this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -1021,12 +853,6 @@ void QueuedSyncProductsComponentBase ::
     this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTelemetryComponentAc.ref.cpp
@@ -100,15 +100,13 @@ void QueuedTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdIn_InputPort[port].setObjName(portName);
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -132,15 +130,13 @@ void QueuedTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsAsync_InputPort[port].setObjName(portName);
+    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -164,15 +160,13 @@ void QueuedTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -196,15 +190,13 @@ void QueuedTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -228,15 +220,13 @@ void QueuedTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -260,15 +250,13 @@ void QueuedTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsSync_InputPort[port].setObjName(portName);
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -292,15 +280,13 @@ void QueuedTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsync_InputPort[port].setObjName(portName);
+    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -324,15 +310,13 @@ void QueuedTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncAssert_InputPort[port].setObjName(portName);
+    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -356,15 +340,13 @@ void QueuedTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName);
+    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -388,15 +370,13 @@ void QueuedTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName);
+    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -420,15 +400,13 @@ void QueuedTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedGuarded_InputPort[port].setObjName(portName);
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -452,15 +430,13 @@ void QueuedTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -484,15 +460,13 @@ void QueuedTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName);
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -516,15 +490,13 @@ void QueuedTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedSync_InputPort[port].setObjName(portName);
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -543,15 +515,13 @@ void QueuedTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName);
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -570,15 +540,13 @@ void QueuedTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName);
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -597,15 +565,13 @@ void QueuedTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_eventOut_OutputPort[port].setObjName(portName);
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -624,15 +590,13 @@ void QueuedTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName);
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -651,15 +615,13 @@ void QueuedTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName);
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -679,15 +641,13 @@ void QueuedTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_textEventOut_OutputPort[port].setObjName(portName);
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 #endif
@@ -707,15 +667,13 @@ void QueuedTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName);
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -734,15 +692,13 @@ void QueuedTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_tlmOut_OutputPort[port].setObjName(portName);
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -761,15 +717,13 @@ void QueuedTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -788,15 +742,13 @@ void QueuedTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -815,15 +767,13 @@ void QueuedTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedOut_OutputPort[port].setObjName(portName);
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -842,15 +792,13 @@ void QueuedTelemetryComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName);
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTelemetryComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTelemetryComponentAc.ref.cpp
@@ -94,12 +94,6 @@ void QueuedTelemetryComponentBase ::
     this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
@@ -124,12 +118,6 @@ void QueuedTelemetryComponentBase ::
     this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
@@ -154,12 +142,6 @@ void QueuedTelemetryComponentBase ::
     this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -184,12 +166,6 @@ void QueuedTelemetryComponentBase ::
     this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -214,12 +190,6 @@ void QueuedTelemetryComponentBase ::
     this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -244,12 +214,6 @@ void QueuedTelemetryComponentBase ::
     this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
@@ -274,12 +238,6 @@ void QueuedTelemetryComponentBase ::
     this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
@@ -304,12 +262,6 @@ void QueuedTelemetryComponentBase ::
     this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
@@ -334,12 +286,6 @@ void QueuedTelemetryComponentBase ::
     this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
@@ -364,12 +310,6 @@ void QueuedTelemetryComponentBase ::
     this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
@@ -394,12 +334,6 @@ void QueuedTelemetryComponentBase ::
     this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -424,12 +358,6 @@ void QueuedTelemetryComponentBase ::
     this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -454,12 +382,6 @@ void QueuedTelemetryComponentBase ::
     this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -484,12 +406,6 @@ void QueuedTelemetryComponentBase ::
     this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
@@ -509,12 +425,6 @@ void QueuedTelemetryComponentBase ::
     this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -534,12 +444,6 @@ void QueuedTelemetryComponentBase ::
     this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -559,12 +463,6 @@ void QueuedTelemetryComponentBase ::
     this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -584,12 +482,6 @@ void QueuedTelemetryComponentBase ::
     this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -609,12 +501,6 @@ void QueuedTelemetryComponentBase ::
     this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -635,12 +521,6 @@ void QueuedTelemetryComponentBase ::
     this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -661,12 +541,6 @@ void QueuedTelemetryComponentBase ::
     this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -686,12 +560,6 @@ void QueuedTelemetryComponentBase ::
     this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -711,12 +579,6 @@ void QueuedTelemetryComponentBase ::
     this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -736,12 +598,6 @@ void QueuedTelemetryComponentBase ::
     this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -761,12 +617,6 @@ void QueuedTelemetryComponentBase ::
     this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -786,12 +636,6 @@ void QueuedTelemetryComponentBase ::
     this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
@@ -291,15 +291,13 @@ void QueuedTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdIn_InputPort[port].setObjName(portName);
+    this->m_cmdIn_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -323,15 +321,13 @@ void QueuedTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_productRecvIn_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_productRecvIn_InputPort[port].setObjName(portName);
+    this->m_productRecvIn_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -355,15 +351,13 @@ void QueuedTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsAsync_InputPort[port].setObjName(portName);
+    this->m_noArgsAsync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -387,15 +381,13 @@ void QueuedTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -419,15 +411,13 @@ void QueuedTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -451,15 +441,13 @@ void QueuedTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnSync_InputPort[port].setObjName(portName);
+    this->m_noArgsReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -483,15 +471,13 @@ void QueuedTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsSync_InputPort[port].setObjName(portName);
+    this->m_noArgsSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -515,15 +501,13 @@ void QueuedTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsync_InputPort[port].setObjName(portName);
+    this->m_typedAsync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -547,15 +531,13 @@ void QueuedTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncAssert_InputPort[port].setObjName(portName);
+    this->m_typedAsyncAssert_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -579,15 +561,13 @@ void QueuedTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName);
+    this->m_typedAsyncBlockPriority_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -611,15 +591,13 @@ void QueuedTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName);
+    this->m_typedAsyncDropPriority_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -643,15 +621,13 @@ void QueuedTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedGuarded_InputPort[port].setObjName(portName);
+    this->m_typedGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -675,15 +651,13 @@ void QueuedTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnGuarded_InputPort[port].setObjName(portName);
+    this->m_typedReturnGuarded_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -707,15 +681,13 @@ void QueuedTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnSync_InputPort[port].setObjName(portName);
+    this->m_typedReturnSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -739,15 +711,13 @@ void QueuedTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedSync_InputPort[port].setObjName(portName);
+    this->m_typedSync_InputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -766,15 +736,13 @@ void QueuedTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdRegOut_OutputPort[port].setObjName(portName);
+    this->m_cmdRegOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -793,15 +761,13 @@ void QueuedTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_cmdResponseOut_OutputPort[port].setObjName(portName);
+    this->m_cmdResponseOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -820,15 +786,13 @@ void QueuedTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_eventOut_OutputPort[port].setObjName(portName);
+    this->m_eventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -847,15 +811,13 @@ void QueuedTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmGetOut_OutputPort[port].setObjName(portName);
+    this->m_prmGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -874,15 +836,13 @@ void QueuedTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_prmSetOut_OutputPort[port].setObjName(portName);
+    this->m_prmSetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -901,15 +861,13 @@ void QueuedTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_productRequestOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_productRequestOut_OutputPort[port].setObjName(portName);
+    this->m_productRequestOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -928,15 +886,13 @@ void QueuedTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_productSendOut_OutputPort[port].setObjName(portName);
+    this->m_productSendOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -956,15 +912,13 @@ void QueuedTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_textEventOut_OutputPort[port].setObjName(portName);
+    this->m_textEventOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 #endif
@@ -984,15 +938,13 @@ void QueuedTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_timeGetOut_OutputPort[port].setObjName(portName);
+    this->m_timeGetOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -1011,15 +963,13 @@ void QueuedTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_tlmOut_OutputPort[port].setObjName(portName);
+    this->m_tlmOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -1038,15 +988,13 @@ void QueuedTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -1065,15 +1013,13 @@ void QueuedTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName);
+    this->m_noArgsReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -1092,15 +1038,13 @@ void QueuedTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedOut_OutputPort[port].setObjName(portName);
+    this->m_typedOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -1119,15 +1063,13 @@ void QueuedTestComponentBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_typedReturnOut_OutputPort[port].setObjName(portName);
+    this->m_typedReturnOut_OutputPort[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -4684,7 +4626,7 @@ void QueuedTestComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventActivityHigh "
     );
@@ -4815,7 +4757,7 @@ void QueuedTestComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventActivityLowThrottled ",
       u32,
@@ -4904,7 +4846,7 @@ void QueuedTestComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventCommand ",
       str1.toChar(),
@@ -4996,7 +4938,7 @@ void QueuedTestComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventDiagnostic ",
       eStr.toChar()
@@ -5108,7 +5050,7 @@ void QueuedTestComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventFatalThrottled ",
       aStr.toChar()
@@ -5199,7 +5141,7 @@ void QueuedTestComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventWarningHigh ",
       sStr.toChar()
@@ -5279,7 +5221,7 @@ void QueuedTestComponentBase ::
       FW_LOG_TEXT_BUFFER_SIZE,
       _formatString,
 #if FW_OBJECT_NAMES == 1
-      this->m_objName,
+      this->m_objName.toChar(),
 #endif
       "EventWarningLowThrottled "
     );

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
@@ -285,12 +285,6 @@ void QueuedTestComponentBase ::
     this->m_cmdIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdIn_InputPort[%" PRI_PlatformIntType "]",
@@ -315,12 +309,6 @@ void QueuedTestComponentBase ::
     this->m_productRecvIn_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_productRecvIn_InputPort[%" PRI_PlatformIntType "]",
@@ -345,12 +333,6 @@ void QueuedTestComponentBase ::
     this->m_noArgsAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsAsync_InputPort[%" PRI_PlatformIntType "]",
@@ -375,12 +357,6 @@ void QueuedTestComponentBase ::
     this->m_noArgsGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -405,12 +381,6 @@ void QueuedTestComponentBase ::
     this->m_noArgsReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -435,12 +405,6 @@ void QueuedTestComponentBase ::
     this->m_noArgsReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -465,12 +429,6 @@ void QueuedTestComponentBase ::
     this->m_noArgsSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsSync_InputPort[%" PRI_PlatformIntType "]",
@@ -495,12 +453,6 @@ void QueuedTestComponentBase ::
     this->m_typedAsync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsync_InputPort[%" PRI_PlatformIntType "]",
@@ -525,12 +477,6 @@ void QueuedTestComponentBase ::
     this->m_typedAsyncAssert_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncAssert_InputPort[%" PRI_PlatformIntType "]",
@@ -555,12 +501,6 @@ void QueuedTestComponentBase ::
     this->m_typedAsyncBlockPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncBlockPriority_InputPort[%" PRI_PlatformIntType "]",
@@ -585,12 +525,6 @@ void QueuedTestComponentBase ::
     this->m_typedAsyncDropPriority_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedAsyncDropPriority_InputPort[%" PRI_PlatformIntType "]",
@@ -615,12 +549,6 @@ void QueuedTestComponentBase ::
     this->m_typedGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -645,12 +573,6 @@ void QueuedTestComponentBase ::
     this->m_typedReturnGuarded_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnGuarded_InputPort[%" PRI_PlatformIntType "]",
@@ -675,12 +597,6 @@ void QueuedTestComponentBase ::
     this->m_typedReturnSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnSync_InputPort[%" PRI_PlatformIntType "]",
@@ -705,12 +621,6 @@ void QueuedTestComponentBase ::
     this->m_typedSync_InputPort[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedSync_InputPort[%" PRI_PlatformIntType "]",
@@ -730,12 +640,6 @@ void QueuedTestComponentBase ::
     this->m_cmdRegOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdRegOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -755,12 +659,6 @@ void QueuedTestComponentBase ::
     this->m_cmdResponseOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_cmdResponseOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -780,12 +678,6 @@ void QueuedTestComponentBase ::
     this->m_eventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_eventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -805,12 +697,6 @@ void QueuedTestComponentBase ::
     this->m_prmGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -830,12 +716,6 @@ void QueuedTestComponentBase ::
     this->m_prmSetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_prmSetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -855,12 +735,6 @@ void QueuedTestComponentBase ::
     this->m_productRequestOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_productRequestOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -880,12 +754,6 @@ void QueuedTestComponentBase ::
     this->m_productSendOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_productSendOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -906,12 +774,6 @@ void QueuedTestComponentBase ::
     this->m_textEventOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_textEventOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -932,12 +794,6 @@ void QueuedTestComponentBase ::
     this->m_timeGetOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_timeGetOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -957,12 +813,6 @@ void QueuedTestComponentBase ::
     this->m_tlmOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_tlmOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -982,12 +832,6 @@ void QueuedTestComponentBase ::
     this->m_noArgsOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -1007,12 +851,6 @@ void QueuedTestComponentBase ::
     this->m_noArgsReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_noArgsReturnOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -1032,12 +870,6 @@ void QueuedTestComponentBase ::
     this->m_typedOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedOut_OutputPort[%" PRI_PlatformIntType "]",
@@ -1057,12 +889,6 @@ void QueuedTestComponentBase ::
     this->m_typedReturnOut_OutputPort[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_typedReturnOut_OutputPort[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveAsyncProductsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveAsyncProductsTesterBase.ref.cpp
@@ -39,15 +39,13 @@ void ActiveAsyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_productRequestOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_productRequestOut[port].setObjName(portName);
+    this->m_from_productRequestOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -71,15 +69,13 @@ void ActiveAsyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_productSendOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_productSendOut[port].setObjName(portName);
+    this->m_from_productSendOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -103,15 +99,13 @@ void ActiveAsyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_timeGetOut[port].setObjName(portName);
+    this->m_from_timeGetOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -135,15 +129,13 @@ void ActiveAsyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsOut[port].setObjName(portName);
+    this->m_from_noArgsOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -167,15 +159,13 @@ void ActiveAsyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsReturnOut[port].setObjName(portName);
+    this->m_from_noArgsReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -199,15 +189,13 @@ void ActiveAsyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedOut[port].setObjName(portName);
+    this->m_from_typedOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -231,15 +219,13 @@ void ActiveAsyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedReturnOut[port].setObjName(portName);
+    this->m_from_typedReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -258,15 +244,13 @@ void ActiveAsyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_productRecvIn[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_productRecvIn[port].setObjName(portName);
+    this->m_to_productRecvIn[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -285,15 +269,13 @@ void ActiveAsyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsAsync[port].setObjName(portName);
+    this->m_to_noArgsAsync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -312,15 +294,13 @@ void ActiveAsyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsGuarded[port].setObjName(portName);
+    this->m_to_noArgsGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -339,15 +319,13 @@ void ActiveAsyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnGuarded[port].setObjName(portName);
+    this->m_to_noArgsReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -366,15 +344,13 @@ void ActiveAsyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnSync[port].setObjName(portName);
+    this->m_to_noArgsReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -393,15 +369,13 @@ void ActiveAsyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsSync[port].setObjName(portName);
+    this->m_to_noArgsSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -420,15 +394,13 @@ void ActiveAsyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsync[port].setObjName(portName);
+    this->m_to_typedAsync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -447,15 +419,13 @@ void ActiveAsyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncAssert[port].setObjName(portName);
+    this->m_to_typedAsyncAssert[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -474,15 +444,13 @@ void ActiveAsyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncBlockPriority[port].setObjName(portName);
+    this->m_to_typedAsyncBlockPriority[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -501,15 +469,13 @@ void ActiveAsyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncDropPriority[port].setObjName(portName);
+    this->m_to_typedAsyncDropPriority[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -528,15 +494,13 @@ void ActiveAsyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedGuarded[port].setObjName(portName);
+    this->m_to_typedGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -555,15 +519,13 @@ void ActiveAsyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnGuarded[port].setObjName(portName);
+    this->m_to_typedReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -582,15 +544,13 @@ void ActiveAsyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnSync[port].setObjName(portName);
+    this->m_to_typedReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -609,15 +569,13 @@ void ActiveAsyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedSync[port].setObjName(portName);
+    this->m_to_typedSync[port].setObjName(portName.toChar());
 #endif
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveAsyncProductsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveAsyncProductsTesterBase.ref.cpp
@@ -33,12 +33,6 @@ void ActiveAsyncProductsTesterBase ::
     this->m_from_productRequestOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_productRequestOut[%" PRI_PlatformIntType "]",
@@ -63,12 +57,6 @@ void ActiveAsyncProductsTesterBase ::
     this->m_from_productSendOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_productSendOut[%" PRI_PlatformIntType "]",
@@ -93,12 +81,6 @@ void ActiveAsyncProductsTesterBase ::
     this->m_from_timeGetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
@@ -123,12 +105,6 @@ void ActiveAsyncProductsTesterBase ::
     this->m_from_noArgsOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
@@ -153,12 +129,6 @@ void ActiveAsyncProductsTesterBase ::
     this->m_from_noArgsReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
@@ -183,12 +153,6 @@ void ActiveAsyncProductsTesterBase ::
     this->m_from_typedOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
@@ -213,12 +177,6 @@ void ActiveAsyncProductsTesterBase ::
     this->m_from_typedReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
@@ -238,12 +196,6 @@ void ActiveAsyncProductsTesterBase ::
     this->m_to_productRecvIn[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_productRecvIn[%" PRI_PlatformIntType "]",
@@ -263,12 +215,6 @@ void ActiveAsyncProductsTesterBase ::
     this->m_to_noArgsAsync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
@@ -288,12 +234,6 @@ void ActiveAsyncProductsTesterBase ::
     this->m_to_noArgsGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
@@ -313,12 +253,6 @@ void ActiveAsyncProductsTesterBase ::
     this->m_to_noArgsReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
@@ -338,12 +272,6 @@ void ActiveAsyncProductsTesterBase ::
     this->m_to_noArgsReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
@@ -363,12 +291,6 @@ void ActiveAsyncProductsTesterBase ::
     this->m_to_noArgsSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
@@ -388,12 +310,6 @@ void ActiveAsyncProductsTesterBase ::
     this->m_to_typedAsync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsync[%" PRI_PlatformIntType "]",
@@ -413,12 +329,6 @@ void ActiveAsyncProductsTesterBase ::
     this->m_to_typedAsyncAssert[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
@@ -438,12 +348,6 @@ void ActiveAsyncProductsTesterBase ::
     this->m_to_typedAsyncBlockPriority[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
@@ -463,12 +367,6 @@ void ActiveAsyncProductsTesterBase ::
     this->m_to_typedAsyncDropPriority[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
@@ -488,12 +386,6 @@ void ActiveAsyncProductsTesterBase ::
     this->m_to_typedGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
@@ -513,12 +405,6 @@ void ActiveAsyncProductsTesterBase ::
     this->m_to_typedReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
@@ -538,12 +424,6 @@ void ActiveAsyncProductsTesterBase ::
     this->m_to_typedReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
@@ -563,12 +443,6 @@ void ActiveAsyncProductsTesterBase ::
     this->m_to_typedSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveCommandsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveCommandsTesterBase.ref.cpp
@@ -39,15 +39,13 @@ void ActiveCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_cmdRegOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_cmdRegOut[port].setObjName(portName);
+    this->m_from_cmdRegOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -71,15 +69,13 @@ void ActiveCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_cmdResponseOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_cmdResponseOut[port].setObjName(portName);
+    this->m_from_cmdResponseOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -103,15 +99,13 @@ void ActiveCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_timeGetOut[port].setObjName(portName);
+    this->m_from_timeGetOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -135,15 +129,13 @@ void ActiveCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsOut[port].setObjName(portName);
+    this->m_from_noArgsOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -167,15 +159,13 @@ void ActiveCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsReturnOut[port].setObjName(portName);
+    this->m_from_noArgsReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -199,15 +189,13 @@ void ActiveCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedOut[port].setObjName(portName);
+    this->m_from_typedOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -231,15 +219,13 @@ void ActiveCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedReturnOut[port].setObjName(portName);
+    this->m_from_typedReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -258,15 +244,13 @@ void ActiveCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_cmdIn[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_cmdIn[port].setObjName(portName);
+    this->m_to_cmdIn[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -285,15 +269,13 @@ void ActiveCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsAsync[port].setObjName(portName);
+    this->m_to_noArgsAsync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -312,15 +294,13 @@ void ActiveCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsGuarded[port].setObjName(portName);
+    this->m_to_noArgsGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -339,15 +319,13 @@ void ActiveCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnGuarded[port].setObjName(portName);
+    this->m_to_noArgsReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -366,15 +344,13 @@ void ActiveCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnSync[port].setObjName(portName);
+    this->m_to_noArgsReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -393,15 +369,13 @@ void ActiveCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsSync[port].setObjName(portName);
+    this->m_to_noArgsSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -420,15 +394,13 @@ void ActiveCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsync[port].setObjName(portName);
+    this->m_to_typedAsync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -447,15 +419,13 @@ void ActiveCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncAssert[port].setObjName(portName);
+    this->m_to_typedAsyncAssert[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -474,15 +444,13 @@ void ActiveCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncBlockPriority[port].setObjName(portName);
+    this->m_to_typedAsyncBlockPriority[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -501,15 +469,13 @@ void ActiveCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncDropPriority[port].setObjName(portName);
+    this->m_to_typedAsyncDropPriority[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -528,15 +494,13 @@ void ActiveCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedGuarded[port].setObjName(portName);
+    this->m_to_typedGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -555,15 +519,13 @@ void ActiveCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnGuarded[port].setObjName(portName);
+    this->m_to_typedReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -582,15 +544,13 @@ void ActiveCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnSync[port].setObjName(portName);
+    this->m_to_typedReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -609,15 +569,13 @@ void ActiveCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedSync[port].setObjName(portName);
+    this->m_to_typedSync[port].setObjName(portName.toChar());
 #endif
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveCommandsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveCommandsTesterBase.ref.cpp
@@ -33,12 +33,6 @@ void ActiveCommandsTesterBase ::
     this->m_from_cmdRegOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_cmdRegOut[%" PRI_PlatformIntType "]",
@@ -63,12 +57,6 @@ void ActiveCommandsTesterBase ::
     this->m_from_cmdResponseOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_cmdResponseOut[%" PRI_PlatformIntType "]",
@@ -93,12 +81,6 @@ void ActiveCommandsTesterBase ::
     this->m_from_timeGetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
@@ -123,12 +105,6 @@ void ActiveCommandsTesterBase ::
     this->m_from_noArgsOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
@@ -153,12 +129,6 @@ void ActiveCommandsTesterBase ::
     this->m_from_noArgsReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
@@ -183,12 +153,6 @@ void ActiveCommandsTesterBase ::
     this->m_from_typedOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
@@ -213,12 +177,6 @@ void ActiveCommandsTesterBase ::
     this->m_from_typedReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
@@ -238,12 +196,6 @@ void ActiveCommandsTesterBase ::
     this->m_to_cmdIn[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_cmdIn[%" PRI_PlatformIntType "]",
@@ -263,12 +215,6 @@ void ActiveCommandsTesterBase ::
     this->m_to_noArgsAsync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
@@ -288,12 +234,6 @@ void ActiveCommandsTesterBase ::
     this->m_to_noArgsGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
@@ -313,12 +253,6 @@ void ActiveCommandsTesterBase ::
     this->m_to_noArgsReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
@@ -338,12 +272,6 @@ void ActiveCommandsTesterBase ::
     this->m_to_noArgsReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
@@ -363,12 +291,6 @@ void ActiveCommandsTesterBase ::
     this->m_to_noArgsSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
@@ -388,12 +310,6 @@ void ActiveCommandsTesterBase ::
     this->m_to_typedAsync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsync[%" PRI_PlatformIntType "]",
@@ -413,12 +329,6 @@ void ActiveCommandsTesterBase ::
     this->m_to_typedAsyncAssert[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
@@ -438,12 +348,6 @@ void ActiveCommandsTesterBase ::
     this->m_to_typedAsyncBlockPriority[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
@@ -463,12 +367,6 @@ void ActiveCommandsTesterBase ::
     this->m_to_typedAsyncDropPriority[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
@@ -488,12 +386,6 @@ void ActiveCommandsTesterBase ::
     this->m_to_typedGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
@@ -513,12 +405,6 @@ void ActiveCommandsTesterBase ::
     this->m_to_typedReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
@@ -538,12 +424,6 @@ void ActiveCommandsTesterBase ::
     this->m_to_typedReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
@@ -563,12 +443,6 @@ void ActiveCommandsTesterBase ::
     this->m_to_typedSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveEventsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveEventsTesterBase.ref.cpp
@@ -33,12 +33,6 @@ void ActiveEventsTesterBase ::
     this->m_from_eventOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_eventOut[%" PRI_PlatformIntType "]",
@@ -64,12 +58,6 @@ void ActiveEventsTesterBase ::
     this->m_from_textEventOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_textEventOut[%" PRI_PlatformIntType "]",
@@ -95,12 +83,6 @@ void ActiveEventsTesterBase ::
     this->m_from_timeGetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
@@ -125,12 +107,6 @@ void ActiveEventsTesterBase ::
     this->m_from_noArgsOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
@@ -155,12 +131,6 @@ void ActiveEventsTesterBase ::
     this->m_from_noArgsReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
@@ -185,12 +155,6 @@ void ActiveEventsTesterBase ::
     this->m_from_typedOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
@@ -215,12 +179,6 @@ void ActiveEventsTesterBase ::
     this->m_from_typedReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
@@ -240,12 +198,6 @@ void ActiveEventsTesterBase ::
     this->m_to_noArgsAsync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
@@ -265,12 +217,6 @@ void ActiveEventsTesterBase ::
     this->m_to_noArgsGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
@@ -290,12 +236,6 @@ void ActiveEventsTesterBase ::
     this->m_to_noArgsReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
@@ -315,12 +255,6 @@ void ActiveEventsTesterBase ::
     this->m_to_noArgsReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
@@ -340,12 +274,6 @@ void ActiveEventsTesterBase ::
     this->m_to_noArgsSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
@@ -365,12 +293,6 @@ void ActiveEventsTesterBase ::
     this->m_to_typedAsync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsync[%" PRI_PlatformIntType "]",
@@ -390,12 +312,6 @@ void ActiveEventsTesterBase ::
     this->m_to_typedAsyncAssert[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
@@ -415,12 +331,6 @@ void ActiveEventsTesterBase ::
     this->m_to_typedAsyncBlockPriority[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
@@ -440,12 +350,6 @@ void ActiveEventsTesterBase ::
     this->m_to_typedAsyncDropPriority[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
@@ -465,12 +369,6 @@ void ActiveEventsTesterBase ::
     this->m_to_typedGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
@@ -490,12 +388,6 @@ void ActiveEventsTesterBase ::
     this->m_to_typedReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
@@ -515,12 +407,6 @@ void ActiveEventsTesterBase ::
     this->m_to_typedReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
@@ -540,12 +426,6 @@ void ActiveEventsTesterBase ::
     this->m_to_typedSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveEventsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveEventsTesterBase.ref.cpp
@@ -39,15 +39,13 @@ void ActiveEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_eventOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_eventOut[port].setObjName(portName);
+    this->m_from_eventOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -72,15 +70,13 @@ void ActiveEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_textEventOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_textEventOut[port].setObjName(portName);
+    this->m_from_textEventOut[port].setObjName(portName.toChar());
 #endif
   }
 #endif
@@ -105,15 +101,13 @@ void ActiveEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_timeGetOut[port].setObjName(portName);
+    this->m_from_timeGetOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -137,15 +131,13 @@ void ActiveEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsOut[port].setObjName(portName);
+    this->m_from_noArgsOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -169,15 +161,13 @@ void ActiveEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsReturnOut[port].setObjName(portName);
+    this->m_from_noArgsReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -201,15 +191,13 @@ void ActiveEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedOut[port].setObjName(portName);
+    this->m_from_typedOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -233,15 +221,13 @@ void ActiveEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedReturnOut[port].setObjName(portName);
+    this->m_from_typedReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -260,15 +246,13 @@ void ActiveEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsAsync[port].setObjName(portName);
+    this->m_to_noArgsAsync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -287,15 +271,13 @@ void ActiveEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsGuarded[port].setObjName(portName);
+    this->m_to_noArgsGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -314,15 +296,13 @@ void ActiveEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnGuarded[port].setObjName(portName);
+    this->m_to_noArgsReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -341,15 +321,13 @@ void ActiveEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnSync[port].setObjName(portName);
+    this->m_to_noArgsReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -368,15 +346,13 @@ void ActiveEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsSync[port].setObjName(portName);
+    this->m_to_noArgsSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -395,15 +371,13 @@ void ActiveEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsync[port].setObjName(portName);
+    this->m_to_typedAsync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -422,15 +396,13 @@ void ActiveEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncAssert[port].setObjName(portName);
+    this->m_to_typedAsyncAssert[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -449,15 +421,13 @@ void ActiveEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncBlockPriority[port].setObjName(portName);
+    this->m_to_typedAsyncBlockPriority[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -476,15 +446,13 @@ void ActiveEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncDropPriority[port].setObjName(portName);
+    this->m_to_typedAsyncDropPriority[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -503,15 +471,13 @@ void ActiveEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedGuarded[port].setObjName(portName);
+    this->m_to_typedGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -530,15 +496,13 @@ void ActiveEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnGuarded[port].setObjName(portName);
+    this->m_to_typedReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -557,15 +521,13 @@ void ActiveEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnSync[port].setObjName(portName);
+    this->m_to_typedReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -584,15 +546,13 @@ void ActiveEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedSync[port].setObjName(portName);
+    this->m_to_typedSync[port].setObjName(portName.toChar());
 #endif
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveGetProductsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveGetProductsTesterBase.ref.cpp
@@ -33,12 +33,6 @@ void ActiveGetProductsTesterBase ::
     this->m_from_productGetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_productGetOut[%" PRI_PlatformIntType "]",
@@ -63,12 +57,6 @@ void ActiveGetProductsTesterBase ::
     this->m_from_productSendOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_productSendOut[%" PRI_PlatformIntType "]",
@@ -93,12 +81,6 @@ void ActiveGetProductsTesterBase ::
     this->m_from_timeGetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
@@ -123,12 +105,6 @@ void ActiveGetProductsTesterBase ::
     this->m_from_noArgsOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
@@ -153,12 +129,6 @@ void ActiveGetProductsTesterBase ::
     this->m_from_noArgsReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
@@ -183,12 +153,6 @@ void ActiveGetProductsTesterBase ::
     this->m_from_typedOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
@@ -213,12 +177,6 @@ void ActiveGetProductsTesterBase ::
     this->m_from_typedReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
@@ -238,12 +196,6 @@ void ActiveGetProductsTesterBase ::
     this->m_to_noArgsAsync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
@@ -263,12 +215,6 @@ void ActiveGetProductsTesterBase ::
     this->m_to_noArgsGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
@@ -288,12 +234,6 @@ void ActiveGetProductsTesterBase ::
     this->m_to_noArgsReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
@@ -313,12 +253,6 @@ void ActiveGetProductsTesterBase ::
     this->m_to_noArgsReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
@@ -338,12 +272,6 @@ void ActiveGetProductsTesterBase ::
     this->m_to_noArgsSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
@@ -363,12 +291,6 @@ void ActiveGetProductsTesterBase ::
     this->m_to_typedAsync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsync[%" PRI_PlatformIntType "]",
@@ -388,12 +310,6 @@ void ActiveGetProductsTesterBase ::
     this->m_to_typedAsyncAssert[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
@@ -413,12 +329,6 @@ void ActiveGetProductsTesterBase ::
     this->m_to_typedAsyncBlockPriority[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
@@ -438,12 +348,6 @@ void ActiveGetProductsTesterBase ::
     this->m_to_typedAsyncDropPriority[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
@@ -463,12 +367,6 @@ void ActiveGetProductsTesterBase ::
     this->m_to_typedGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
@@ -488,12 +386,6 @@ void ActiveGetProductsTesterBase ::
     this->m_to_typedReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
@@ -513,12 +405,6 @@ void ActiveGetProductsTesterBase ::
     this->m_to_typedReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
@@ -538,12 +424,6 @@ void ActiveGetProductsTesterBase ::
     this->m_to_typedSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveGetProductsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveGetProductsTesterBase.ref.cpp
@@ -39,15 +39,13 @@ void ActiveGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_productGetOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_productGetOut[port].setObjName(portName);
+    this->m_from_productGetOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -71,15 +69,13 @@ void ActiveGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_productSendOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_productSendOut[port].setObjName(portName);
+    this->m_from_productSendOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -103,15 +99,13 @@ void ActiveGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_timeGetOut[port].setObjName(portName);
+    this->m_from_timeGetOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -135,15 +129,13 @@ void ActiveGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsOut[port].setObjName(portName);
+    this->m_from_noArgsOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -167,15 +159,13 @@ void ActiveGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsReturnOut[port].setObjName(portName);
+    this->m_from_noArgsReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -199,15 +189,13 @@ void ActiveGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedOut[port].setObjName(portName);
+    this->m_from_typedOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -231,15 +219,13 @@ void ActiveGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedReturnOut[port].setObjName(portName);
+    this->m_from_typedReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -258,15 +244,13 @@ void ActiveGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsAsync[port].setObjName(portName);
+    this->m_to_noArgsAsync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -285,15 +269,13 @@ void ActiveGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsGuarded[port].setObjName(portName);
+    this->m_to_noArgsGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -312,15 +294,13 @@ void ActiveGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnGuarded[port].setObjName(portName);
+    this->m_to_noArgsReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -339,15 +319,13 @@ void ActiveGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnSync[port].setObjName(portName);
+    this->m_to_noArgsReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -366,15 +344,13 @@ void ActiveGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsSync[port].setObjName(portName);
+    this->m_to_noArgsSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -393,15 +369,13 @@ void ActiveGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsync[port].setObjName(portName);
+    this->m_to_typedAsync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -420,15 +394,13 @@ void ActiveGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncAssert[port].setObjName(portName);
+    this->m_to_typedAsyncAssert[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -447,15 +419,13 @@ void ActiveGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncBlockPriority[port].setObjName(portName);
+    this->m_to_typedAsyncBlockPriority[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -474,15 +444,13 @@ void ActiveGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncDropPriority[port].setObjName(portName);
+    this->m_to_typedAsyncDropPriority[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -501,15 +469,13 @@ void ActiveGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedGuarded[port].setObjName(portName);
+    this->m_to_typedGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -528,15 +494,13 @@ void ActiveGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnGuarded[port].setObjName(portName);
+    this->m_to_typedReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -555,15 +519,13 @@ void ActiveGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnSync[port].setObjName(portName);
+    this->m_to_typedReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -582,15 +544,13 @@ void ActiveGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedSync[port].setObjName(portName);
+    this->m_to_typedSync[port].setObjName(portName.toChar());
 #endif
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveGuardedProductsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveGuardedProductsTesterBase.ref.cpp
@@ -33,12 +33,6 @@ void ActiveGuardedProductsTesterBase ::
     this->m_from_productRequestOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_productRequestOut[%" PRI_PlatformIntType "]",
@@ -63,12 +57,6 @@ void ActiveGuardedProductsTesterBase ::
     this->m_from_productSendOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_productSendOut[%" PRI_PlatformIntType "]",
@@ -93,12 +81,6 @@ void ActiveGuardedProductsTesterBase ::
     this->m_from_timeGetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
@@ -123,12 +105,6 @@ void ActiveGuardedProductsTesterBase ::
     this->m_from_noArgsOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
@@ -153,12 +129,6 @@ void ActiveGuardedProductsTesterBase ::
     this->m_from_noArgsReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
@@ -183,12 +153,6 @@ void ActiveGuardedProductsTesterBase ::
     this->m_from_typedOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
@@ -213,12 +177,6 @@ void ActiveGuardedProductsTesterBase ::
     this->m_from_typedReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
@@ -238,12 +196,6 @@ void ActiveGuardedProductsTesterBase ::
     this->m_to_productRecvIn[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_productRecvIn[%" PRI_PlatformIntType "]",
@@ -263,12 +215,6 @@ void ActiveGuardedProductsTesterBase ::
     this->m_to_noArgsAsync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
@@ -288,12 +234,6 @@ void ActiveGuardedProductsTesterBase ::
     this->m_to_noArgsGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
@@ -313,12 +253,6 @@ void ActiveGuardedProductsTesterBase ::
     this->m_to_noArgsReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
@@ -338,12 +272,6 @@ void ActiveGuardedProductsTesterBase ::
     this->m_to_noArgsReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
@@ -363,12 +291,6 @@ void ActiveGuardedProductsTesterBase ::
     this->m_to_noArgsSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
@@ -388,12 +310,6 @@ void ActiveGuardedProductsTesterBase ::
     this->m_to_typedAsync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsync[%" PRI_PlatformIntType "]",
@@ -413,12 +329,6 @@ void ActiveGuardedProductsTesterBase ::
     this->m_to_typedAsyncAssert[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
@@ -438,12 +348,6 @@ void ActiveGuardedProductsTesterBase ::
     this->m_to_typedAsyncBlockPriority[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
@@ -463,12 +367,6 @@ void ActiveGuardedProductsTesterBase ::
     this->m_to_typedAsyncDropPriority[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
@@ -488,12 +386,6 @@ void ActiveGuardedProductsTesterBase ::
     this->m_to_typedGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
@@ -513,12 +405,6 @@ void ActiveGuardedProductsTesterBase ::
     this->m_to_typedReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
@@ -538,12 +424,6 @@ void ActiveGuardedProductsTesterBase ::
     this->m_to_typedReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
@@ -563,12 +443,6 @@ void ActiveGuardedProductsTesterBase ::
     this->m_to_typedSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveGuardedProductsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveGuardedProductsTesterBase.ref.cpp
@@ -39,15 +39,13 @@ void ActiveGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_productRequestOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_productRequestOut[port].setObjName(portName);
+    this->m_from_productRequestOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -71,15 +69,13 @@ void ActiveGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_productSendOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_productSendOut[port].setObjName(portName);
+    this->m_from_productSendOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -103,15 +99,13 @@ void ActiveGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_timeGetOut[port].setObjName(portName);
+    this->m_from_timeGetOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -135,15 +129,13 @@ void ActiveGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsOut[port].setObjName(portName);
+    this->m_from_noArgsOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -167,15 +159,13 @@ void ActiveGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsReturnOut[port].setObjName(portName);
+    this->m_from_noArgsReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -199,15 +189,13 @@ void ActiveGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedOut[port].setObjName(portName);
+    this->m_from_typedOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -231,15 +219,13 @@ void ActiveGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedReturnOut[port].setObjName(portName);
+    this->m_from_typedReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -258,15 +244,13 @@ void ActiveGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_productRecvIn[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_productRecvIn[port].setObjName(portName);
+    this->m_to_productRecvIn[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -285,15 +269,13 @@ void ActiveGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsAsync[port].setObjName(portName);
+    this->m_to_noArgsAsync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -312,15 +294,13 @@ void ActiveGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsGuarded[port].setObjName(portName);
+    this->m_to_noArgsGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -339,15 +319,13 @@ void ActiveGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnGuarded[port].setObjName(portName);
+    this->m_to_noArgsReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -366,15 +344,13 @@ void ActiveGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnSync[port].setObjName(portName);
+    this->m_to_noArgsReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -393,15 +369,13 @@ void ActiveGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsSync[port].setObjName(portName);
+    this->m_to_noArgsSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -420,15 +394,13 @@ void ActiveGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsync[port].setObjName(portName);
+    this->m_to_typedAsync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -447,15 +419,13 @@ void ActiveGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncAssert[port].setObjName(portName);
+    this->m_to_typedAsyncAssert[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -474,15 +444,13 @@ void ActiveGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncBlockPriority[port].setObjName(portName);
+    this->m_to_typedAsyncBlockPriority[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -501,15 +469,13 @@ void ActiveGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncDropPriority[port].setObjName(portName);
+    this->m_to_typedAsyncDropPriority[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -528,15 +494,13 @@ void ActiveGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedGuarded[port].setObjName(portName);
+    this->m_to_typedGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -555,15 +519,13 @@ void ActiveGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnGuarded[port].setObjName(portName);
+    this->m_to_typedReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -582,15 +544,13 @@ void ActiveGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnSync[port].setObjName(portName);
+    this->m_to_typedReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -609,15 +569,13 @@ void ActiveGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedSync[port].setObjName(portName);
+    this->m_to_typedSync[port].setObjName(portName.toChar());
 #endif
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveNoArgsPortsOnlyTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveNoArgsPortsOnlyTesterBase.ref.cpp
@@ -33,12 +33,6 @@ void ActiveNoArgsPortsOnlyTesterBase ::
     this->m_from_noArgsOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
@@ -63,12 +57,6 @@ void ActiveNoArgsPortsOnlyTesterBase ::
     this->m_from_noArgsReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
@@ -88,12 +76,6 @@ void ActiveNoArgsPortsOnlyTesterBase ::
     this->m_to_noArgsAsync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
@@ -113,12 +95,6 @@ void ActiveNoArgsPortsOnlyTesterBase ::
     this->m_to_noArgsGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
@@ -138,12 +114,6 @@ void ActiveNoArgsPortsOnlyTesterBase ::
     this->m_to_noArgsReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
@@ -163,12 +133,6 @@ void ActiveNoArgsPortsOnlyTesterBase ::
     this->m_to_noArgsReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveNoArgsPortsOnlyTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveNoArgsPortsOnlyTesterBase.ref.cpp
@@ -39,15 +39,13 @@ void ActiveNoArgsPortsOnlyTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsOut[port].setObjName(portName);
+    this->m_from_noArgsOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -71,15 +69,13 @@ void ActiveNoArgsPortsOnlyTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsReturnOut[port].setObjName(portName);
+    this->m_from_noArgsReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -98,15 +94,13 @@ void ActiveNoArgsPortsOnlyTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsAsync[port].setObjName(portName);
+    this->m_to_noArgsAsync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -125,15 +119,13 @@ void ActiveNoArgsPortsOnlyTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsGuarded[port].setObjName(portName);
+    this->m_to_noArgsGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -152,15 +144,13 @@ void ActiveNoArgsPortsOnlyTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnGuarded[port].setObjName(portName);
+    this->m_to_noArgsReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -179,15 +169,13 @@ void ActiveNoArgsPortsOnlyTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnSync[port].setObjName(portName);
+    this->m_to_noArgsReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveParamsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveParamsTesterBase.ref.cpp
@@ -33,12 +33,6 @@ void ActiveParamsTesterBase ::
     this->m_from_cmdRegOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_cmdRegOut[%" PRI_PlatformIntType "]",
@@ -63,12 +57,6 @@ void ActiveParamsTesterBase ::
     this->m_from_cmdResponseOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_cmdResponseOut[%" PRI_PlatformIntType "]",
@@ -93,12 +81,6 @@ void ActiveParamsTesterBase ::
     this->m_from_prmGetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_prmGetOut[%" PRI_PlatformIntType "]",
@@ -123,12 +105,6 @@ void ActiveParamsTesterBase ::
     this->m_from_prmSetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_prmSetOut[%" PRI_PlatformIntType "]",
@@ -153,12 +129,6 @@ void ActiveParamsTesterBase ::
     this->m_from_timeGetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
@@ -183,12 +153,6 @@ void ActiveParamsTesterBase ::
     this->m_from_noArgsOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
@@ -213,12 +177,6 @@ void ActiveParamsTesterBase ::
     this->m_from_noArgsReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
@@ -243,12 +201,6 @@ void ActiveParamsTesterBase ::
     this->m_from_typedOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
@@ -273,12 +225,6 @@ void ActiveParamsTesterBase ::
     this->m_from_typedReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
@@ -298,12 +244,6 @@ void ActiveParamsTesterBase ::
     this->m_to_cmdIn[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_cmdIn[%" PRI_PlatformIntType "]",
@@ -323,12 +263,6 @@ void ActiveParamsTesterBase ::
     this->m_to_noArgsAsync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
@@ -348,12 +282,6 @@ void ActiveParamsTesterBase ::
     this->m_to_noArgsGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
@@ -373,12 +301,6 @@ void ActiveParamsTesterBase ::
     this->m_to_noArgsReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
@@ -398,12 +320,6 @@ void ActiveParamsTesterBase ::
     this->m_to_noArgsReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
@@ -423,12 +339,6 @@ void ActiveParamsTesterBase ::
     this->m_to_noArgsSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
@@ -448,12 +358,6 @@ void ActiveParamsTesterBase ::
     this->m_to_typedAsync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsync[%" PRI_PlatformIntType "]",
@@ -473,12 +377,6 @@ void ActiveParamsTesterBase ::
     this->m_to_typedAsyncAssert[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
@@ -498,12 +396,6 @@ void ActiveParamsTesterBase ::
     this->m_to_typedAsyncBlockPriority[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
@@ -523,12 +415,6 @@ void ActiveParamsTesterBase ::
     this->m_to_typedAsyncDropPriority[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
@@ -548,12 +434,6 @@ void ActiveParamsTesterBase ::
     this->m_to_typedGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
@@ -573,12 +453,6 @@ void ActiveParamsTesterBase ::
     this->m_to_typedReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
@@ -598,12 +472,6 @@ void ActiveParamsTesterBase ::
     this->m_to_typedReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
@@ -623,12 +491,6 @@ void ActiveParamsTesterBase ::
     this->m_to_typedSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveParamsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveParamsTesterBase.ref.cpp
@@ -39,15 +39,13 @@ void ActiveParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_cmdRegOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_cmdRegOut[port].setObjName(portName);
+    this->m_from_cmdRegOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -71,15 +69,13 @@ void ActiveParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_cmdResponseOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_cmdResponseOut[port].setObjName(portName);
+    this->m_from_cmdResponseOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -103,15 +99,13 @@ void ActiveParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_prmGetOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_prmGetOut[port].setObjName(portName);
+    this->m_from_prmGetOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -135,15 +129,13 @@ void ActiveParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_prmSetOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_prmSetOut[port].setObjName(portName);
+    this->m_from_prmSetOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -167,15 +159,13 @@ void ActiveParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_timeGetOut[port].setObjName(portName);
+    this->m_from_timeGetOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -199,15 +189,13 @@ void ActiveParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsOut[port].setObjName(portName);
+    this->m_from_noArgsOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -231,15 +219,13 @@ void ActiveParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsReturnOut[port].setObjName(portName);
+    this->m_from_noArgsReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -263,15 +249,13 @@ void ActiveParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedOut[port].setObjName(portName);
+    this->m_from_typedOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -295,15 +279,13 @@ void ActiveParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedReturnOut[port].setObjName(portName);
+    this->m_from_typedReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -322,15 +304,13 @@ void ActiveParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_cmdIn[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_cmdIn[port].setObjName(portName);
+    this->m_to_cmdIn[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -349,15 +329,13 @@ void ActiveParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsAsync[port].setObjName(portName);
+    this->m_to_noArgsAsync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -376,15 +354,13 @@ void ActiveParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsGuarded[port].setObjName(portName);
+    this->m_to_noArgsGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -403,15 +379,13 @@ void ActiveParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnGuarded[port].setObjName(portName);
+    this->m_to_noArgsReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -430,15 +404,13 @@ void ActiveParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnSync[port].setObjName(portName);
+    this->m_to_noArgsReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -457,15 +429,13 @@ void ActiveParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsSync[port].setObjName(portName);
+    this->m_to_noArgsSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -484,15 +454,13 @@ void ActiveParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsync[port].setObjName(portName);
+    this->m_to_typedAsync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -511,15 +479,13 @@ void ActiveParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncAssert[port].setObjName(portName);
+    this->m_to_typedAsyncAssert[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -538,15 +504,13 @@ void ActiveParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncBlockPriority[port].setObjName(portName);
+    this->m_to_typedAsyncBlockPriority[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -565,15 +529,13 @@ void ActiveParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncDropPriority[port].setObjName(portName);
+    this->m_to_typedAsyncDropPriority[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -592,15 +554,13 @@ void ActiveParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedGuarded[port].setObjName(portName);
+    this->m_to_typedGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -619,15 +579,13 @@ void ActiveParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnGuarded[port].setObjName(portName);
+    this->m_to_typedReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -646,15 +604,13 @@ void ActiveParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnSync[port].setObjName(portName);
+    this->m_to_typedReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -673,15 +629,13 @@ void ActiveParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedSync[port].setObjName(portName);
+    this->m_to_typedSync[port].setObjName(portName.toChar());
 #endif
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.cpp
@@ -33,12 +33,6 @@ void ActiveSerialTesterBase ::
     this->m_from_cmdRegOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_cmdRegOut[%" PRI_PlatformIntType "]",
@@ -63,12 +57,6 @@ void ActiveSerialTesterBase ::
     this->m_from_cmdResponseOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_cmdResponseOut[%" PRI_PlatformIntType "]",
@@ -93,12 +81,6 @@ void ActiveSerialTesterBase ::
     this->m_from_eventOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_eventOut[%" PRI_PlatformIntType "]",
@@ -123,12 +105,6 @@ void ActiveSerialTesterBase ::
     this->m_from_prmGetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_prmGetOut[%" PRI_PlatformIntType "]",
@@ -153,12 +129,6 @@ void ActiveSerialTesterBase ::
     this->m_from_prmSetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_prmSetOut[%" PRI_PlatformIntType "]",
@@ -184,12 +154,6 @@ void ActiveSerialTesterBase ::
     this->m_from_textEventOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_textEventOut[%" PRI_PlatformIntType "]",
@@ -215,12 +179,6 @@ void ActiveSerialTesterBase ::
     this->m_from_timeGetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
@@ -245,12 +203,6 @@ void ActiveSerialTesterBase ::
     this->m_from_tlmOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_tlmOut[%" PRI_PlatformIntType "]",
@@ -275,12 +227,6 @@ void ActiveSerialTesterBase ::
     this->m_from_noArgsOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
@@ -305,12 +251,6 @@ void ActiveSerialTesterBase ::
     this->m_from_noArgsReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
@@ -335,12 +275,6 @@ void ActiveSerialTesterBase ::
     this->m_from_typedOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
@@ -365,12 +299,6 @@ void ActiveSerialTesterBase ::
     this->m_from_typedReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
@@ -395,12 +323,6 @@ void ActiveSerialTesterBase ::
     this->m_from_serialOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_serialOut[%" PRI_PlatformIntType "]",
@@ -420,12 +342,6 @@ void ActiveSerialTesterBase ::
     this->m_to_cmdIn[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_cmdIn[%" PRI_PlatformIntType "]",
@@ -445,12 +361,6 @@ void ActiveSerialTesterBase ::
     this->m_to_noArgsAsync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
@@ -470,12 +380,6 @@ void ActiveSerialTesterBase ::
     this->m_to_noArgsGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
@@ -495,12 +399,6 @@ void ActiveSerialTesterBase ::
     this->m_to_noArgsReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
@@ -520,12 +418,6 @@ void ActiveSerialTesterBase ::
     this->m_to_noArgsReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
@@ -545,12 +437,6 @@ void ActiveSerialTesterBase ::
     this->m_to_noArgsSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
@@ -570,12 +456,6 @@ void ActiveSerialTesterBase ::
     this->m_to_typedAsync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsync[%" PRI_PlatformIntType "]",
@@ -595,12 +475,6 @@ void ActiveSerialTesterBase ::
     this->m_to_typedAsyncAssert[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
@@ -620,12 +494,6 @@ void ActiveSerialTesterBase ::
     this->m_to_typedAsyncBlockPriority[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
@@ -645,12 +513,6 @@ void ActiveSerialTesterBase ::
     this->m_to_typedAsyncDropPriority[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
@@ -670,12 +532,6 @@ void ActiveSerialTesterBase ::
     this->m_to_typedGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
@@ -695,12 +551,6 @@ void ActiveSerialTesterBase ::
     this->m_to_typedReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
@@ -720,12 +570,6 @@ void ActiveSerialTesterBase ::
     this->m_to_typedReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
@@ -745,12 +589,6 @@ void ActiveSerialTesterBase ::
     this->m_to_typedSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",
@@ -770,12 +608,6 @@ void ActiveSerialTesterBase ::
     this->m_to_serialAsync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_serialAsync[%" PRI_PlatformIntType "]",
@@ -795,12 +627,6 @@ void ActiveSerialTesterBase ::
     this->m_to_serialAsyncAssert[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_serialAsyncAssert[%" PRI_PlatformIntType "]",
@@ -820,12 +646,6 @@ void ActiveSerialTesterBase ::
     this->m_to_serialAsyncBlockPriority[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_serialAsyncBlockPriority[%" PRI_PlatformIntType "]",
@@ -845,12 +665,6 @@ void ActiveSerialTesterBase ::
     this->m_to_serialAsyncDropPriority[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_serialAsyncDropPriority[%" PRI_PlatformIntType "]",
@@ -870,12 +684,6 @@ void ActiveSerialTesterBase ::
     this->m_to_serialGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_serialGuarded[%" PRI_PlatformIntType "]",
@@ -895,12 +703,6 @@ void ActiveSerialTesterBase ::
     this->m_to_serialSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_serialSync[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSerialTesterBase.ref.cpp
@@ -39,15 +39,13 @@ void ActiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_cmdRegOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_cmdRegOut[port].setObjName(portName);
+    this->m_from_cmdRegOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -71,15 +69,13 @@ void ActiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_cmdResponseOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_cmdResponseOut[port].setObjName(portName);
+    this->m_from_cmdResponseOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -103,15 +99,13 @@ void ActiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_eventOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_eventOut[port].setObjName(portName);
+    this->m_from_eventOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -135,15 +129,13 @@ void ActiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_prmGetOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_prmGetOut[port].setObjName(portName);
+    this->m_from_prmGetOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -167,15 +159,13 @@ void ActiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_prmSetOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_prmSetOut[port].setObjName(portName);
+    this->m_from_prmSetOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -200,15 +190,13 @@ void ActiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_textEventOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_textEventOut[port].setObjName(portName);
+    this->m_from_textEventOut[port].setObjName(portName.toChar());
 #endif
   }
 #endif
@@ -233,15 +221,13 @@ void ActiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_timeGetOut[port].setObjName(portName);
+    this->m_from_timeGetOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -265,15 +251,13 @@ void ActiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_tlmOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_tlmOut[port].setObjName(portName);
+    this->m_from_tlmOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -297,15 +281,13 @@ void ActiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsOut[port].setObjName(portName);
+    this->m_from_noArgsOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -329,15 +311,13 @@ void ActiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsReturnOut[port].setObjName(portName);
+    this->m_from_noArgsReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -361,15 +341,13 @@ void ActiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedOut[port].setObjName(portName);
+    this->m_from_typedOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -393,15 +371,13 @@ void ActiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedReturnOut[port].setObjName(portName);
+    this->m_from_typedReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -425,15 +401,13 @@ void ActiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_serialOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_serialOut[port].setObjName(portName);
+    this->m_from_serialOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -452,15 +426,13 @@ void ActiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_cmdIn[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_cmdIn[port].setObjName(portName);
+    this->m_to_cmdIn[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -479,15 +451,13 @@ void ActiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsAsync[port].setObjName(portName);
+    this->m_to_noArgsAsync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -506,15 +476,13 @@ void ActiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsGuarded[port].setObjName(portName);
+    this->m_to_noArgsGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -533,15 +501,13 @@ void ActiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnGuarded[port].setObjName(portName);
+    this->m_to_noArgsReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -560,15 +526,13 @@ void ActiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnSync[port].setObjName(portName);
+    this->m_to_noArgsReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -587,15 +551,13 @@ void ActiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsSync[port].setObjName(portName);
+    this->m_to_noArgsSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -614,15 +576,13 @@ void ActiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsync[port].setObjName(portName);
+    this->m_to_typedAsync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -641,15 +601,13 @@ void ActiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncAssert[port].setObjName(portName);
+    this->m_to_typedAsyncAssert[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -668,15 +626,13 @@ void ActiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncBlockPriority[port].setObjName(portName);
+    this->m_to_typedAsyncBlockPriority[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -695,15 +651,13 @@ void ActiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncDropPriority[port].setObjName(portName);
+    this->m_to_typedAsyncDropPriority[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -722,15 +676,13 @@ void ActiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedGuarded[port].setObjName(portName);
+    this->m_to_typedGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -749,15 +701,13 @@ void ActiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnGuarded[port].setObjName(portName);
+    this->m_to_typedReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -776,15 +726,13 @@ void ActiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnSync[port].setObjName(portName);
+    this->m_to_typedReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -803,15 +751,13 @@ void ActiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedSync[port].setObjName(portName);
+    this->m_to_typedSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -830,15 +776,13 @@ void ActiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_serialAsync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_serialAsync[port].setObjName(portName);
+    this->m_to_serialAsync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -857,15 +801,13 @@ void ActiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_serialAsyncAssert[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_serialAsyncAssert[port].setObjName(portName);
+    this->m_to_serialAsyncAssert[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -884,15 +826,13 @@ void ActiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_serialAsyncBlockPriority[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_serialAsyncBlockPriority[port].setObjName(portName);
+    this->m_to_serialAsyncBlockPriority[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -911,15 +851,13 @@ void ActiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_serialAsyncDropPriority[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_serialAsyncDropPriority[port].setObjName(portName);
+    this->m_to_serialAsyncDropPriority[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -938,15 +876,13 @@ void ActiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_serialGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_serialGuarded[port].setObjName(portName);
+    this->m_to_serialGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -965,15 +901,13 @@ void ActiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_serialSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_serialSync[port].setObjName(portName);
+    this->m_to_serialSync[port].setObjName(portName.toChar());
 #endif
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSyncProductsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSyncProductsTesterBase.ref.cpp
@@ -33,12 +33,6 @@ void ActiveSyncProductsTesterBase ::
     this->m_from_productRequestOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_productRequestOut[%" PRI_PlatformIntType "]",
@@ -63,12 +57,6 @@ void ActiveSyncProductsTesterBase ::
     this->m_from_productSendOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_productSendOut[%" PRI_PlatformIntType "]",
@@ -93,12 +81,6 @@ void ActiveSyncProductsTesterBase ::
     this->m_from_timeGetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
@@ -123,12 +105,6 @@ void ActiveSyncProductsTesterBase ::
     this->m_from_noArgsOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
@@ -153,12 +129,6 @@ void ActiveSyncProductsTesterBase ::
     this->m_from_noArgsReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
@@ -183,12 +153,6 @@ void ActiveSyncProductsTesterBase ::
     this->m_from_typedOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
@@ -213,12 +177,6 @@ void ActiveSyncProductsTesterBase ::
     this->m_from_typedReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
@@ -238,12 +196,6 @@ void ActiveSyncProductsTesterBase ::
     this->m_to_productRecvIn[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_productRecvIn[%" PRI_PlatformIntType "]",
@@ -263,12 +215,6 @@ void ActiveSyncProductsTesterBase ::
     this->m_to_noArgsAsync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
@@ -288,12 +234,6 @@ void ActiveSyncProductsTesterBase ::
     this->m_to_noArgsGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
@@ -313,12 +253,6 @@ void ActiveSyncProductsTesterBase ::
     this->m_to_noArgsReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
@@ -338,12 +272,6 @@ void ActiveSyncProductsTesterBase ::
     this->m_to_noArgsReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
@@ -363,12 +291,6 @@ void ActiveSyncProductsTesterBase ::
     this->m_to_noArgsSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
@@ -388,12 +310,6 @@ void ActiveSyncProductsTesterBase ::
     this->m_to_typedAsync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsync[%" PRI_PlatformIntType "]",
@@ -413,12 +329,6 @@ void ActiveSyncProductsTesterBase ::
     this->m_to_typedAsyncAssert[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
@@ -438,12 +348,6 @@ void ActiveSyncProductsTesterBase ::
     this->m_to_typedAsyncBlockPriority[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
@@ -463,12 +367,6 @@ void ActiveSyncProductsTesterBase ::
     this->m_to_typedAsyncDropPriority[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
@@ -488,12 +386,6 @@ void ActiveSyncProductsTesterBase ::
     this->m_to_typedGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
@@ -513,12 +405,6 @@ void ActiveSyncProductsTesterBase ::
     this->m_to_typedReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
@@ -538,12 +424,6 @@ void ActiveSyncProductsTesterBase ::
     this->m_to_typedReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
@@ -563,12 +443,6 @@ void ActiveSyncProductsTesterBase ::
     this->m_to_typedSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSyncProductsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveSyncProductsTesterBase.ref.cpp
@@ -39,15 +39,13 @@ void ActiveSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_productRequestOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_productRequestOut[port].setObjName(portName);
+    this->m_from_productRequestOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -71,15 +69,13 @@ void ActiveSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_productSendOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_productSendOut[port].setObjName(portName);
+    this->m_from_productSendOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -103,15 +99,13 @@ void ActiveSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_timeGetOut[port].setObjName(portName);
+    this->m_from_timeGetOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -135,15 +129,13 @@ void ActiveSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsOut[port].setObjName(portName);
+    this->m_from_noArgsOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -167,15 +159,13 @@ void ActiveSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsReturnOut[port].setObjName(portName);
+    this->m_from_noArgsReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -199,15 +189,13 @@ void ActiveSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedOut[port].setObjName(portName);
+    this->m_from_typedOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -231,15 +219,13 @@ void ActiveSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedReturnOut[port].setObjName(portName);
+    this->m_from_typedReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -258,15 +244,13 @@ void ActiveSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_productRecvIn[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_productRecvIn[port].setObjName(portName);
+    this->m_to_productRecvIn[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -285,15 +269,13 @@ void ActiveSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsAsync[port].setObjName(portName);
+    this->m_to_noArgsAsync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -312,15 +294,13 @@ void ActiveSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsGuarded[port].setObjName(portName);
+    this->m_to_noArgsGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -339,15 +319,13 @@ void ActiveSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnGuarded[port].setObjName(portName);
+    this->m_to_noArgsReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -366,15 +344,13 @@ void ActiveSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnSync[port].setObjName(portName);
+    this->m_to_noArgsReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -393,15 +369,13 @@ void ActiveSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsSync[port].setObjName(portName);
+    this->m_to_noArgsSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -420,15 +394,13 @@ void ActiveSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsync[port].setObjName(portName);
+    this->m_to_typedAsync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -447,15 +419,13 @@ void ActiveSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncAssert[port].setObjName(portName);
+    this->m_to_typedAsyncAssert[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -474,15 +444,13 @@ void ActiveSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncBlockPriority[port].setObjName(portName);
+    this->m_to_typedAsyncBlockPriority[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -501,15 +469,13 @@ void ActiveSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncDropPriority[port].setObjName(portName);
+    this->m_to_typedAsyncDropPriority[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -528,15 +494,13 @@ void ActiveSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedGuarded[port].setObjName(portName);
+    this->m_to_typedGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -555,15 +519,13 @@ void ActiveSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnGuarded[port].setObjName(portName);
+    this->m_to_typedReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -582,15 +544,13 @@ void ActiveSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnSync[port].setObjName(portName);
+    this->m_to_typedReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -609,15 +569,13 @@ void ActiveSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedSync[port].setObjName(portName);
+    this->m_to_typedSync[port].setObjName(portName.toChar());
 #endif
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTelemetryTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTelemetryTesterBase.ref.cpp
@@ -39,15 +39,13 @@ void ActiveTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_timeGetOut[port].setObjName(portName);
+    this->m_from_timeGetOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -71,15 +69,13 @@ void ActiveTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_tlmOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_tlmOut[port].setObjName(portName);
+    this->m_from_tlmOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -103,15 +99,13 @@ void ActiveTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsOut[port].setObjName(portName);
+    this->m_from_noArgsOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -135,15 +129,13 @@ void ActiveTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsReturnOut[port].setObjName(portName);
+    this->m_from_noArgsReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -167,15 +159,13 @@ void ActiveTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedOut[port].setObjName(portName);
+    this->m_from_typedOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -199,15 +189,13 @@ void ActiveTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedReturnOut[port].setObjName(portName);
+    this->m_from_typedReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -226,15 +214,13 @@ void ActiveTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsAsync[port].setObjName(portName);
+    this->m_to_noArgsAsync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -253,15 +239,13 @@ void ActiveTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsGuarded[port].setObjName(portName);
+    this->m_to_noArgsGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -280,15 +264,13 @@ void ActiveTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnGuarded[port].setObjName(portName);
+    this->m_to_noArgsReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -307,15 +289,13 @@ void ActiveTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnSync[port].setObjName(portName);
+    this->m_to_noArgsReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -334,15 +314,13 @@ void ActiveTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsSync[port].setObjName(portName);
+    this->m_to_noArgsSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -361,15 +339,13 @@ void ActiveTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsync[port].setObjName(portName);
+    this->m_to_typedAsync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -388,15 +364,13 @@ void ActiveTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncAssert[port].setObjName(portName);
+    this->m_to_typedAsyncAssert[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -415,15 +389,13 @@ void ActiveTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncBlockPriority[port].setObjName(portName);
+    this->m_to_typedAsyncBlockPriority[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -442,15 +414,13 @@ void ActiveTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncDropPriority[port].setObjName(portName);
+    this->m_to_typedAsyncDropPriority[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -469,15 +439,13 @@ void ActiveTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedGuarded[port].setObjName(portName);
+    this->m_to_typedGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -496,15 +464,13 @@ void ActiveTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnGuarded[port].setObjName(portName);
+    this->m_to_typedReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -523,15 +489,13 @@ void ActiveTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnSync[port].setObjName(portName);
+    this->m_to_typedReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -550,15 +514,13 @@ void ActiveTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedSync[port].setObjName(portName);
+    this->m_to_typedSync[port].setObjName(portName.toChar());
 #endif
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTelemetryTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTelemetryTesterBase.ref.cpp
@@ -33,12 +33,6 @@ void ActiveTelemetryTesterBase ::
     this->m_from_timeGetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
@@ -63,12 +57,6 @@ void ActiveTelemetryTesterBase ::
     this->m_from_tlmOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_tlmOut[%" PRI_PlatformIntType "]",
@@ -93,12 +81,6 @@ void ActiveTelemetryTesterBase ::
     this->m_from_noArgsOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
@@ -123,12 +105,6 @@ void ActiveTelemetryTesterBase ::
     this->m_from_noArgsReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
@@ -153,12 +129,6 @@ void ActiveTelemetryTesterBase ::
     this->m_from_typedOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
@@ -183,12 +153,6 @@ void ActiveTelemetryTesterBase ::
     this->m_from_typedReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
@@ -208,12 +172,6 @@ void ActiveTelemetryTesterBase ::
     this->m_to_noArgsAsync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
@@ -233,12 +191,6 @@ void ActiveTelemetryTesterBase ::
     this->m_to_noArgsGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
@@ -258,12 +210,6 @@ void ActiveTelemetryTesterBase ::
     this->m_to_noArgsReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
@@ -283,12 +229,6 @@ void ActiveTelemetryTesterBase ::
     this->m_to_noArgsReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
@@ -308,12 +248,6 @@ void ActiveTelemetryTesterBase ::
     this->m_to_noArgsSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
@@ -333,12 +267,6 @@ void ActiveTelemetryTesterBase ::
     this->m_to_typedAsync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsync[%" PRI_PlatformIntType "]",
@@ -358,12 +286,6 @@ void ActiveTelemetryTesterBase ::
     this->m_to_typedAsyncAssert[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
@@ -383,12 +305,6 @@ void ActiveTelemetryTesterBase ::
     this->m_to_typedAsyncBlockPriority[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
@@ -408,12 +324,6 @@ void ActiveTelemetryTesterBase ::
     this->m_to_typedAsyncDropPriority[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
@@ -433,12 +343,6 @@ void ActiveTelemetryTesterBase ::
     this->m_to_typedGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
@@ -458,12 +362,6 @@ void ActiveTelemetryTesterBase ::
     this->m_to_typedReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
@@ -483,12 +381,6 @@ void ActiveTelemetryTesterBase ::
     this->m_to_typedReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
@@ -508,12 +400,6 @@ void ActiveTelemetryTesterBase ::
     this->m_to_typedSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.cpp
@@ -41,15 +41,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_from_cmdRegOut[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_from_cmdRegOut[port].setObjName(portName);
+      this->m_from_cmdRegOut[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -73,15 +71,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_from_cmdResponseOut[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_from_cmdResponseOut[port].setObjName(portName);
+      this->m_from_cmdResponseOut[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -105,15 +101,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_from_eventOut[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_from_eventOut[port].setObjName(portName);
+      this->m_from_eventOut[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -137,15 +131,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_from_prmGetOut[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_from_prmGetOut[port].setObjName(portName);
+      this->m_from_prmGetOut[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -169,15 +161,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_from_prmSetOut[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_from_prmSetOut[port].setObjName(portName);
+      this->m_from_prmSetOut[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -201,15 +191,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_from_productRequestOut[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_from_productRequestOut[port].setObjName(portName);
+      this->m_from_productRequestOut[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -233,15 +221,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_from_productSendOut[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_from_productSendOut[port].setObjName(portName);
+      this->m_from_productSendOut[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -266,15 +252,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_from_textEventOut[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_from_textEventOut[port].setObjName(portName);
+      this->m_from_textEventOut[port].setObjName(portName.toChar());
 #endif
     }
 #endif
@@ -299,15 +283,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_from_timeGetOut[port].setObjName(portName);
+      this->m_from_timeGetOut[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -331,15 +313,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_from_tlmOut[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_from_tlmOut[port].setObjName(portName);
+      this->m_from_tlmOut[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -363,15 +343,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_from_noArgsOut[port].setObjName(portName);
+      this->m_from_noArgsOut[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -395,15 +373,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_from_noArgsReturnOut[port].setObjName(portName);
+      this->m_from_noArgsReturnOut[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -427,15 +403,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_from_typedOut[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_from_typedOut[port].setObjName(portName);
+      this->m_from_typedOut[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -459,15 +433,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_from_typedReturnOut[port].setObjName(portName);
+      this->m_from_typedReturnOut[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -486,15 +458,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_to_cmdIn[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_to_cmdIn[port].setObjName(portName);
+      this->m_to_cmdIn[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -513,15 +483,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_to_productRecvIn[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_to_productRecvIn[port].setObjName(portName);
+      this->m_to_productRecvIn[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -540,15 +508,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_to_noArgsAsync[port].setObjName(portName);
+      this->m_to_noArgsAsync[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -567,15 +533,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_to_noArgsGuarded[port].setObjName(portName);
+      this->m_to_noArgsGuarded[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -594,15 +558,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_to_noArgsReturnGuarded[port].setObjName(portName);
+      this->m_to_noArgsReturnGuarded[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -621,15 +583,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_to_noArgsReturnSync[port].setObjName(portName);
+      this->m_to_noArgsReturnSync[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -648,15 +608,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_to_noArgsSync[port].setObjName(portName);
+      this->m_to_noArgsSync[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -675,15 +633,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_to_typedAsync[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_to_typedAsync[port].setObjName(portName);
+      this->m_to_typedAsync[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -702,15 +658,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_to_typedAsyncAssert[port].setObjName(portName);
+      this->m_to_typedAsyncAssert[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -729,15 +683,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_to_typedAsyncBlockPriority[port].setObjName(portName);
+      this->m_to_typedAsyncBlockPriority[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -756,15 +708,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_to_typedAsyncDropPriority[port].setObjName(portName);
+      this->m_to_typedAsyncDropPriority[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -783,15 +733,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_to_typedGuarded[port].setObjName(portName);
+      this->m_to_typedGuarded[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -810,15 +758,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_to_typedReturnGuarded[port].setObjName(portName);
+      this->m_to_typedReturnGuarded[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -837,15 +783,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_to_typedReturnSync[port].setObjName(portName);
+      this->m_to_typedReturnSync[port].setObjName(portName.toChar());
 #endif
     }
 
@@ -864,15 +808,13 @@ namespace M {
       // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
       // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
       // bytes to cover the extra info.
-      char portName[2*FW_OBJ_NAME_MAX_SIZE];
-      (void) snprintf(
-        portName,
-        sizeof(portName),
+      Fw::ObjectName portName;
+      portName.format(
         "%s_to_typedSync[%" PRI_PlatformIntType "]",
-        this->m_objName,
+        this->m_objName.toChar(),
         port
       );
-      this->m_to_typedSync[port].setObjName(portName);
+      this->m_to_typedSync[port].setObjName(portName.toChar());
 #endif
     }
   }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/ActiveTestTesterBase.ref.cpp
@@ -35,12 +35,6 @@ namespace M {
       this->m_from_cmdRegOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_from_cmdRegOut[%" PRI_PlatformIntType "]",
@@ -65,12 +59,6 @@ namespace M {
       this->m_from_cmdResponseOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_from_cmdResponseOut[%" PRI_PlatformIntType "]",
@@ -95,12 +83,6 @@ namespace M {
       this->m_from_eventOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_from_eventOut[%" PRI_PlatformIntType "]",
@@ -125,12 +107,6 @@ namespace M {
       this->m_from_prmGetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_from_prmGetOut[%" PRI_PlatformIntType "]",
@@ -155,12 +131,6 @@ namespace M {
       this->m_from_prmSetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_from_prmSetOut[%" PRI_PlatformIntType "]",
@@ -185,12 +155,6 @@ namespace M {
       this->m_from_productRequestOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_from_productRequestOut[%" PRI_PlatformIntType "]",
@@ -215,12 +179,6 @@ namespace M {
       this->m_from_productSendOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_from_productSendOut[%" PRI_PlatformIntType "]",
@@ -246,12 +204,6 @@ namespace M {
       this->m_from_textEventOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_from_textEventOut[%" PRI_PlatformIntType "]",
@@ -277,12 +229,6 @@ namespace M {
       this->m_from_timeGetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
@@ -307,12 +253,6 @@ namespace M {
       this->m_from_tlmOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_from_tlmOut[%" PRI_PlatformIntType "]",
@@ -337,12 +277,6 @@ namespace M {
       this->m_from_noArgsOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
@@ -367,12 +301,6 @@ namespace M {
       this->m_from_noArgsReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
@@ -397,12 +325,6 @@ namespace M {
       this->m_from_typedOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_from_typedOut[%" PRI_PlatformIntType "]",
@@ -427,12 +349,6 @@ namespace M {
       this->m_from_typedReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
@@ -452,12 +368,6 @@ namespace M {
       this->m_to_cmdIn[port].init();
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_to_cmdIn[%" PRI_PlatformIntType "]",
@@ -477,12 +387,6 @@ namespace M {
       this->m_to_productRecvIn[port].init();
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_to_productRecvIn[%" PRI_PlatformIntType "]",
@@ -502,12 +406,6 @@ namespace M {
       this->m_to_noArgsAsync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
@@ -527,12 +425,6 @@ namespace M {
       this->m_to_noArgsGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
@@ -552,12 +444,6 @@ namespace M {
       this->m_to_noArgsReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
@@ -577,12 +463,6 @@ namespace M {
       this->m_to_noArgsReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
@@ -602,12 +482,6 @@ namespace M {
       this->m_to_noArgsSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
@@ -627,12 +501,6 @@ namespace M {
       this->m_to_typedAsync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_to_typedAsync[%" PRI_PlatformIntType "]",
@@ -652,12 +520,6 @@ namespace M {
       this->m_to_typedAsyncAssert[port].init();
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
@@ -677,12 +539,6 @@ namespace M {
       this->m_to_typedAsyncBlockPriority[port].init();
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
@@ -702,12 +558,6 @@ namespace M {
       this->m_to_typedAsyncDropPriority[port].init();
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
@@ -727,12 +577,6 @@ namespace M {
       this->m_to_typedGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
@@ -752,12 +596,6 @@ namespace M {
       this->m_to_typedReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
@@ -777,12 +615,6 @@ namespace M {
       this->m_to_typedReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
@@ -802,12 +634,6 @@ namespace M {
       this->m_to_typedSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-      // The port name consists of this->m_objName and some extra info.
-      // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-      // However, the compiler may assume that this->m_objName fills
-      // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-      // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-      // bytes to cover the extra info.
       Fw::ObjectName portName;
       portName.format(
         "%s_to_typedSync[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveCommandsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveCommandsTesterBase.ref.cpp
@@ -33,12 +33,6 @@ void PassiveCommandsTesterBase ::
     this->m_from_cmdRegOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_cmdRegOut[%" PRI_PlatformIntType "]",
@@ -63,12 +57,6 @@ void PassiveCommandsTesterBase ::
     this->m_from_cmdResponseOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_cmdResponseOut[%" PRI_PlatformIntType "]",
@@ -93,12 +81,6 @@ void PassiveCommandsTesterBase ::
     this->m_from_timeGetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
@@ -123,12 +105,6 @@ void PassiveCommandsTesterBase ::
     this->m_from_noArgsOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
@@ -153,12 +129,6 @@ void PassiveCommandsTesterBase ::
     this->m_from_noArgsReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
@@ -183,12 +153,6 @@ void PassiveCommandsTesterBase ::
     this->m_from_typedOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
@@ -213,12 +177,6 @@ void PassiveCommandsTesterBase ::
     this->m_from_typedReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
@@ -238,12 +196,6 @@ void PassiveCommandsTesterBase ::
     this->m_to_cmdIn[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_cmdIn[%" PRI_PlatformIntType "]",
@@ -263,12 +215,6 @@ void PassiveCommandsTesterBase ::
     this->m_to_noArgsGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
@@ -288,12 +234,6 @@ void PassiveCommandsTesterBase ::
     this->m_to_noArgsReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
@@ -313,12 +253,6 @@ void PassiveCommandsTesterBase ::
     this->m_to_noArgsReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
@@ -338,12 +272,6 @@ void PassiveCommandsTesterBase ::
     this->m_to_noArgsSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
@@ -363,12 +291,6 @@ void PassiveCommandsTesterBase ::
     this->m_to_typedGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
@@ -388,12 +310,6 @@ void PassiveCommandsTesterBase ::
     this->m_to_typedReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
@@ -413,12 +329,6 @@ void PassiveCommandsTesterBase ::
     this->m_to_typedReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
@@ -438,12 +348,6 @@ void PassiveCommandsTesterBase ::
     this->m_to_typedSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveCommandsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveCommandsTesterBase.ref.cpp
@@ -39,15 +39,13 @@ void PassiveCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_cmdRegOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_cmdRegOut[port].setObjName(portName);
+    this->m_from_cmdRegOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -71,15 +69,13 @@ void PassiveCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_cmdResponseOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_cmdResponseOut[port].setObjName(portName);
+    this->m_from_cmdResponseOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -103,15 +99,13 @@ void PassiveCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_timeGetOut[port].setObjName(portName);
+    this->m_from_timeGetOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -135,15 +129,13 @@ void PassiveCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsOut[port].setObjName(portName);
+    this->m_from_noArgsOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -167,15 +159,13 @@ void PassiveCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsReturnOut[port].setObjName(portName);
+    this->m_from_noArgsReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -199,15 +189,13 @@ void PassiveCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedOut[port].setObjName(portName);
+    this->m_from_typedOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -231,15 +219,13 @@ void PassiveCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedReturnOut[port].setObjName(portName);
+    this->m_from_typedReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -258,15 +244,13 @@ void PassiveCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_cmdIn[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_cmdIn[port].setObjName(portName);
+    this->m_to_cmdIn[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -285,15 +269,13 @@ void PassiveCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsGuarded[port].setObjName(portName);
+    this->m_to_noArgsGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -312,15 +294,13 @@ void PassiveCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnGuarded[port].setObjName(portName);
+    this->m_to_noArgsReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -339,15 +319,13 @@ void PassiveCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnSync[port].setObjName(portName);
+    this->m_to_noArgsReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -366,15 +344,13 @@ void PassiveCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsSync[port].setObjName(portName);
+    this->m_to_noArgsSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -393,15 +369,13 @@ void PassiveCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedGuarded[port].setObjName(portName);
+    this->m_to_typedGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -420,15 +394,13 @@ void PassiveCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnGuarded[port].setObjName(portName);
+    this->m_to_typedReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -447,15 +419,13 @@ void PassiveCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnSync[port].setObjName(portName);
+    this->m_to_typedReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -474,15 +444,13 @@ void PassiveCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedSync[port].setObjName(portName);
+    this->m_to_typedSync[port].setObjName(portName.toChar());
 #endif
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveEventsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveEventsTesterBase.ref.cpp
@@ -33,12 +33,6 @@ void PassiveEventsTesterBase ::
     this->m_from_eventOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_eventOut[%" PRI_PlatformIntType "]",
@@ -64,12 +58,6 @@ void PassiveEventsTesterBase ::
     this->m_from_textEventOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_textEventOut[%" PRI_PlatformIntType "]",
@@ -95,12 +83,6 @@ void PassiveEventsTesterBase ::
     this->m_from_timeGetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
@@ -125,12 +107,6 @@ void PassiveEventsTesterBase ::
     this->m_from_noArgsOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
@@ -155,12 +131,6 @@ void PassiveEventsTesterBase ::
     this->m_from_noArgsReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
@@ -185,12 +155,6 @@ void PassiveEventsTesterBase ::
     this->m_from_typedOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
@@ -215,12 +179,6 @@ void PassiveEventsTesterBase ::
     this->m_from_typedReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
@@ -240,12 +198,6 @@ void PassiveEventsTesterBase ::
     this->m_to_noArgsGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
@@ -265,12 +217,6 @@ void PassiveEventsTesterBase ::
     this->m_to_noArgsReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
@@ -290,12 +236,6 @@ void PassiveEventsTesterBase ::
     this->m_to_noArgsReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
@@ -315,12 +255,6 @@ void PassiveEventsTesterBase ::
     this->m_to_noArgsSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
@@ -340,12 +274,6 @@ void PassiveEventsTesterBase ::
     this->m_to_typedGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
@@ -365,12 +293,6 @@ void PassiveEventsTesterBase ::
     this->m_to_typedReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
@@ -390,12 +312,6 @@ void PassiveEventsTesterBase ::
     this->m_to_typedReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
@@ -415,12 +331,6 @@ void PassiveEventsTesterBase ::
     this->m_to_typedSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveEventsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveEventsTesterBase.ref.cpp
@@ -39,15 +39,13 @@ void PassiveEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_eventOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_eventOut[port].setObjName(portName);
+    this->m_from_eventOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -72,15 +70,13 @@ void PassiveEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_textEventOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_textEventOut[port].setObjName(portName);
+    this->m_from_textEventOut[port].setObjName(portName.toChar());
 #endif
   }
 #endif
@@ -105,15 +101,13 @@ void PassiveEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_timeGetOut[port].setObjName(portName);
+    this->m_from_timeGetOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -137,15 +131,13 @@ void PassiveEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsOut[port].setObjName(portName);
+    this->m_from_noArgsOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -169,15 +161,13 @@ void PassiveEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsReturnOut[port].setObjName(portName);
+    this->m_from_noArgsReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -201,15 +191,13 @@ void PassiveEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedOut[port].setObjName(portName);
+    this->m_from_typedOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -233,15 +221,13 @@ void PassiveEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedReturnOut[port].setObjName(portName);
+    this->m_from_typedReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -260,15 +246,13 @@ void PassiveEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsGuarded[port].setObjName(portName);
+    this->m_to_noArgsGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -287,15 +271,13 @@ void PassiveEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnGuarded[port].setObjName(portName);
+    this->m_to_noArgsReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -314,15 +296,13 @@ void PassiveEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnSync[port].setObjName(portName);
+    this->m_to_noArgsReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -341,15 +321,13 @@ void PassiveEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsSync[port].setObjName(portName);
+    this->m_to_noArgsSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -368,15 +346,13 @@ void PassiveEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedGuarded[port].setObjName(portName);
+    this->m_to_typedGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -395,15 +371,13 @@ void PassiveEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnGuarded[port].setObjName(portName);
+    this->m_to_typedReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -422,15 +396,13 @@ void PassiveEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnSync[port].setObjName(portName);
+    this->m_to_typedReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -449,15 +421,13 @@ void PassiveEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedSync[port].setObjName(portName);
+    this->m_to_typedSync[port].setObjName(portName.toChar());
 #endif
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveGetProductsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveGetProductsTesterBase.ref.cpp
@@ -33,12 +33,6 @@ void PassiveGetProductsTesterBase ::
     this->m_from_productGetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_productGetOut[%" PRI_PlatformIntType "]",
@@ -63,12 +57,6 @@ void PassiveGetProductsTesterBase ::
     this->m_from_productSendOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_productSendOut[%" PRI_PlatformIntType "]",
@@ -93,12 +81,6 @@ void PassiveGetProductsTesterBase ::
     this->m_from_timeGetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
@@ -123,12 +105,6 @@ void PassiveGetProductsTesterBase ::
     this->m_from_noArgsOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
@@ -153,12 +129,6 @@ void PassiveGetProductsTesterBase ::
     this->m_from_noArgsReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
@@ -183,12 +153,6 @@ void PassiveGetProductsTesterBase ::
     this->m_from_typedOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
@@ -213,12 +177,6 @@ void PassiveGetProductsTesterBase ::
     this->m_from_typedReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
@@ -238,12 +196,6 @@ void PassiveGetProductsTesterBase ::
     this->m_to_noArgsGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
@@ -263,12 +215,6 @@ void PassiveGetProductsTesterBase ::
     this->m_to_noArgsReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
@@ -288,12 +234,6 @@ void PassiveGetProductsTesterBase ::
     this->m_to_noArgsReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
@@ -313,12 +253,6 @@ void PassiveGetProductsTesterBase ::
     this->m_to_noArgsSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
@@ -338,12 +272,6 @@ void PassiveGetProductsTesterBase ::
     this->m_to_typedGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
@@ -363,12 +291,6 @@ void PassiveGetProductsTesterBase ::
     this->m_to_typedReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
@@ -388,12 +310,6 @@ void PassiveGetProductsTesterBase ::
     this->m_to_typedReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
@@ -413,12 +329,6 @@ void PassiveGetProductsTesterBase ::
     this->m_to_typedSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveGetProductsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveGetProductsTesterBase.ref.cpp
@@ -39,15 +39,13 @@ void PassiveGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_productGetOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_productGetOut[port].setObjName(portName);
+    this->m_from_productGetOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -71,15 +69,13 @@ void PassiveGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_productSendOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_productSendOut[port].setObjName(portName);
+    this->m_from_productSendOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -103,15 +99,13 @@ void PassiveGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_timeGetOut[port].setObjName(portName);
+    this->m_from_timeGetOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -135,15 +129,13 @@ void PassiveGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsOut[port].setObjName(portName);
+    this->m_from_noArgsOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -167,15 +159,13 @@ void PassiveGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsReturnOut[port].setObjName(portName);
+    this->m_from_noArgsReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -199,15 +189,13 @@ void PassiveGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedOut[port].setObjName(portName);
+    this->m_from_typedOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -231,15 +219,13 @@ void PassiveGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedReturnOut[port].setObjName(portName);
+    this->m_from_typedReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -258,15 +244,13 @@ void PassiveGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsGuarded[port].setObjName(portName);
+    this->m_to_noArgsGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -285,15 +269,13 @@ void PassiveGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnGuarded[port].setObjName(portName);
+    this->m_to_noArgsReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -312,15 +294,13 @@ void PassiveGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnSync[port].setObjName(portName);
+    this->m_to_noArgsReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -339,15 +319,13 @@ void PassiveGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsSync[port].setObjName(portName);
+    this->m_to_noArgsSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -366,15 +344,13 @@ void PassiveGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedGuarded[port].setObjName(portName);
+    this->m_to_typedGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -393,15 +369,13 @@ void PassiveGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnGuarded[port].setObjName(portName);
+    this->m_to_typedReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -420,15 +394,13 @@ void PassiveGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnSync[port].setObjName(portName);
+    this->m_to_typedReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -447,15 +419,13 @@ void PassiveGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedSync[port].setObjName(portName);
+    this->m_to_typedSync[port].setObjName(portName.toChar());
 #endif
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveGuardedProductsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveGuardedProductsTesterBase.ref.cpp
@@ -39,15 +39,13 @@ void PassiveGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_productRequestOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_productRequestOut[port].setObjName(portName);
+    this->m_from_productRequestOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -71,15 +69,13 @@ void PassiveGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_productSendOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_productSendOut[port].setObjName(portName);
+    this->m_from_productSendOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -103,15 +99,13 @@ void PassiveGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_timeGetOut[port].setObjName(portName);
+    this->m_from_timeGetOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -135,15 +129,13 @@ void PassiveGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsOut[port].setObjName(portName);
+    this->m_from_noArgsOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -167,15 +159,13 @@ void PassiveGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsReturnOut[port].setObjName(portName);
+    this->m_from_noArgsReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -199,15 +189,13 @@ void PassiveGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedOut[port].setObjName(portName);
+    this->m_from_typedOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -231,15 +219,13 @@ void PassiveGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedReturnOut[port].setObjName(portName);
+    this->m_from_typedReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -258,15 +244,13 @@ void PassiveGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_productRecvIn[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_productRecvIn[port].setObjName(portName);
+    this->m_to_productRecvIn[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -285,15 +269,13 @@ void PassiveGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsGuarded[port].setObjName(portName);
+    this->m_to_noArgsGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -312,15 +294,13 @@ void PassiveGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnGuarded[port].setObjName(portName);
+    this->m_to_noArgsReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -339,15 +319,13 @@ void PassiveGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnSync[port].setObjName(portName);
+    this->m_to_noArgsReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -366,15 +344,13 @@ void PassiveGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsSync[port].setObjName(portName);
+    this->m_to_noArgsSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -393,15 +369,13 @@ void PassiveGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedGuarded[port].setObjName(portName);
+    this->m_to_typedGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -420,15 +394,13 @@ void PassiveGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnGuarded[port].setObjName(portName);
+    this->m_to_typedReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -447,15 +419,13 @@ void PassiveGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnSync[port].setObjName(portName);
+    this->m_to_typedReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -474,15 +444,13 @@ void PassiveGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedSync[port].setObjName(portName);
+    this->m_to_typedSync[port].setObjName(portName.toChar());
 #endif
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveGuardedProductsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveGuardedProductsTesterBase.ref.cpp
@@ -33,12 +33,6 @@ void PassiveGuardedProductsTesterBase ::
     this->m_from_productRequestOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_productRequestOut[%" PRI_PlatformIntType "]",
@@ -63,12 +57,6 @@ void PassiveGuardedProductsTesterBase ::
     this->m_from_productSendOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_productSendOut[%" PRI_PlatformIntType "]",
@@ -93,12 +81,6 @@ void PassiveGuardedProductsTesterBase ::
     this->m_from_timeGetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
@@ -123,12 +105,6 @@ void PassiveGuardedProductsTesterBase ::
     this->m_from_noArgsOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
@@ -153,12 +129,6 @@ void PassiveGuardedProductsTesterBase ::
     this->m_from_noArgsReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
@@ -183,12 +153,6 @@ void PassiveGuardedProductsTesterBase ::
     this->m_from_typedOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
@@ -213,12 +177,6 @@ void PassiveGuardedProductsTesterBase ::
     this->m_from_typedReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
@@ -238,12 +196,6 @@ void PassiveGuardedProductsTesterBase ::
     this->m_to_productRecvIn[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_productRecvIn[%" PRI_PlatformIntType "]",
@@ -263,12 +215,6 @@ void PassiveGuardedProductsTesterBase ::
     this->m_to_noArgsGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
@@ -288,12 +234,6 @@ void PassiveGuardedProductsTesterBase ::
     this->m_to_noArgsReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
@@ -313,12 +253,6 @@ void PassiveGuardedProductsTesterBase ::
     this->m_to_noArgsReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
@@ -338,12 +272,6 @@ void PassiveGuardedProductsTesterBase ::
     this->m_to_noArgsSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
@@ -363,12 +291,6 @@ void PassiveGuardedProductsTesterBase ::
     this->m_to_typedGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
@@ -388,12 +310,6 @@ void PassiveGuardedProductsTesterBase ::
     this->m_to_typedReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
@@ -413,12 +329,6 @@ void PassiveGuardedProductsTesterBase ::
     this->m_to_typedReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
@@ -438,12 +348,6 @@ void PassiveGuardedProductsTesterBase ::
     this->m_to_typedSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveParamsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveParamsTesterBase.ref.cpp
@@ -39,15 +39,13 @@ void PassiveParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_cmdRegOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_cmdRegOut[port].setObjName(portName);
+    this->m_from_cmdRegOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -71,15 +69,13 @@ void PassiveParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_cmdResponseOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_cmdResponseOut[port].setObjName(portName);
+    this->m_from_cmdResponseOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -103,15 +99,13 @@ void PassiveParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_prmGetOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_prmGetOut[port].setObjName(portName);
+    this->m_from_prmGetOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -135,15 +129,13 @@ void PassiveParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_prmSetOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_prmSetOut[port].setObjName(portName);
+    this->m_from_prmSetOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -167,15 +159,13 @@ void PassiveParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_timeGetOut[port].setObjName(portName);
+    this->m_from_timeGetOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -199,15 +189,13 @@ void PassiveParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsOut[port].setObjName(portName);
+    this->m_from_noArgsOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -231,15 +219,13 @@ void PassiveParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsReturnOut[port].setObjName(portName);
+    this->m_from_noArgsReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -263,15 +249,13 @@ void PassiveParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedOut[port].setObjName(portName);
+    this->m_from_typedOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -295,15 +279,13 @@ void PassiveParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedReturnOut[port].setObjName(portName);
+    this->m_from_typedReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -322,15 +304,13 @@ void PassiveParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_cmdIn[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_cmdIn[port].setObjName(portName);
+    this->m_to_cmdIn[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -349,15 +329,13 @@ void PassiveParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsGuarded[port].setObjName(portName);
+    this->m_to_noArgsGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -376,15 +354,13 @@ void PassiveParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnGuarded[port].setObjName(portName);
+    this->m_to_noArgsReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -403,15 +379,13 @@ void PassiveParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnSync[port].setObjName(portName);
+    this->m_to_noArgsReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -430,15 +404,13 @@ void PassiveParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsSync[port].setObjName(portName);
+    this->m_to_noArgsSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -457,15 +429,13 @@ void PassiveParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedGuarded[port].setObjName(portName);
+    this->m_to_typedGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -484,15 +454,13 @@ void PassiveParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnGuarded[port].setObjName(portName);
+    this->m_to_typedReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -511,15 +479,13 @@ void PassiveParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnSync[port].setObjName(portName);
+    this->m_to_typedReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -538,15 +504,13 @@ void PassiveParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedSync[port].setObjName(portName);
+    this->m_to_typedSync[port].setObjName(portName.toChar());
 #endif
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveParamsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveParamsTesterBase.ref.cpp
@@ -33,12 +33,6 @@ void PassiveParamsTesterBase ::
     this->m_from_cmdRegOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_cmdRegOut[%" PRI_PlatformIntType "]",
@@ -63,12 +57,6 @@ void PassiveParamsTesterBase ::
     this->m_from_cmdResponseOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_cmdResponseOut[%" PRI_PlatformIntType "]",
@@ -93,12 +81,6 @@ void PassiveParamsTesterBase ::
     this->m_from_prmGetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_prmGetOut[%" PRI_PlatformIntType "]",
@@ -123,12 +105,6 @@ void PassiveParamsTesterBase ::
     this->m_from_prmSetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_prmSetOut[%" PRI_PlatformIntType "]",
@@ -153,12 +129,6 @@ void PassiveParamsTesterBase ::
     this->m_from_timeGetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
@@ -183,12 +153,6 @@ void PassiveParamsTesterBase ::
     this->m_from_noArgsOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
@@ -213,12 +177,6 @@ void PassiveParamsTesterBase ::
     this->m_from_noArgsReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
@@ -243,12 +201,6 @@ void PassiveParamsTesterBase ::
     this->m_from_typedOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
@@ -273,12 +225,6 @@ void PassiveParamsTesterBase ::
     this->m_from_typedReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
@@ -298,12 +244,6 @@ void PassiveParamsTesterBase ::
     this->m_to_cmdIn[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_cmdIn[%" PRI_PlatformIntType "]",
@@ -323,12 +263,6 @@ void PassiveParamsTesterBase ::
     this->m_to_noArgsGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
@@ -348,12 +282,6 @@ void PassiveParamsTesterBase ::
     this->m_to_noArgsReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
@@ -373,12 +301,6 @@ void PassiveParamsTesterBase ::
     this->m_to_noArgsReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
@@ -398,12 +320,6 @@ void PassiveParamsTesterBase ::
     this->m_to_noArgsSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
@@ -423,12 +339,6 @@ void PassiveParamsTesterBase ::
     this->m_to_typedGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
@@ -448,12 +358,6 @@ void PassiveParamsTesterBase ::
     this->m_to_typedReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
@@ -473,12 +377,6 @@ void PassiveParamsTesterBase ::
     this->m_to_typedReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
@@ -498,12 +396,6 @@ void PassiveParamsTesterBase ::
     this->m_to_typedSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.cpp
@@ -39,15 +39,13 @@ void PassiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_cmdRegOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_cmdRegOut[port].setObjName(portName);
+    this->m_from_cmdRegOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -71,15 +69,13 @@ void PassiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_cmdResponseOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_cmdResponseOut[port].setObjName(portName);
+    this->m_from_cmdResponseOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -103,15 +99,13 @@ void PassiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_eventOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_eventOut[port].setObjName(portName);
+    this->m_from_eventOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -135,15 +129,13 @@ void PassiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_prmGetOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_prmGetOut[port].setObjName(portName);
+    this->m_from_prmGetOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -167,15 +159,13 @@ void PassiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_prmSetOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_prmSetOut[port].setObjName(portName);
+    this->m_from_prmSetOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -200,15 +190,13 @@ void PassiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_textEventOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_textEventOut[port].setObjName(portName);
+    this->m_from_textEventOut[port].setObjName(portName.toChar());
 #endif
   }
 #endif
@@ -233,15 +221,13 @@ void PassiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_timeGetOut[port].setObjName(portName);
+    this->m_from_timeGetOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -265,15 +251,13 @@ void PassiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_tlmOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_tlmOut[port].setObjName(portName);
+    this->m_from_tlmOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -297,15 +281,13 @@ void PassiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsOut[port].setObjName(portName);
+    this->m_from_noArgsOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -329,15 +311,13 @@ void PassiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsReturnOut[port].setObjName(portName);
+    this->m_from_noArgsReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -361,15 +341,13 @@ void PassiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedOut[port].setObjName(portName);
+    this->m_from_typedOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -393,15 +371,13 @@ void PassiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedReturnOut[port].setObjName(portName);
+    this->m_from_typedReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -425,15 +401,13 @@ void PassiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_serialOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_serialOut[port].setObjName(portName);
+    this->m_from_serialOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -452,15 +426,13 @@ void PassiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_cmdIn[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_cmdIn[port].setObjName(portName);
+    this->m_to_cmdIn[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -479,15 +451,13 @@ void PassiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsGuarded[port].setObjName(portName);
+    this->m_to_noArgsGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -506,15 +476,13 @@ void PassiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnGuarded[port].setObjName(portName);
+    this->m_to_noArgsReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -533,15 +501,13 @@ void PassiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnSync[port].setObjName(portName);
+    this->m_to_noArgsReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -560,15 +526,13 @@ void PassiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsSync[port].setObjName(portName);
+    this->m_to_noArgsSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -587,15 +551,13 @@ void PassiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedGuarded[port].setObjName(portName);
+    this->m_to_typedGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -614,15 +576,13 @@ void PassiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnGuarded[port].setObjName(portName);
+    this->m_to_typedReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -641,15 +601,13 @@ void PassiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnSync[port].setObjName(portName);
+    this->m_to_typedReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -668,15 +626,13 @@ void PassiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedSync[port].setObjName(portName);
+    this->m_to_typedSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -695,15 +651,13 @@ void PassiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_serialGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_serialGuarded[port].setObjName(portName);
+    this->m_to_serialGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -722,15 +676,13 @@ void PassiveSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_serialSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_serialSync[port].setObjName(portName);
+    this->m_to_serialSync[port].setObjName(portName.toChar());
 #endif
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSerialTesterBase.ref.cpp
@@ -33,12 +33,6 @@ void PassiveSerialTesterBase ::
     this->m_from_cmdRegOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_cmdRegOut[%" PRI_PlatformIntType "]",
@@ -63,12 +57,6 @@ void PassiveSerialTesterBase ::
     this->m_from_cmdResponseOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_cmdResponseOut[%" PRI_PlatformIntType "]",
@@ -93,12 +81,6 @@ void PassiveSerialTesterBase ::
     this->m_from_eventOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_eventOut[%" PRI_PlatformIntType "]",
@@ -123,12 +105,6 @@ void PassiveSerialTesterBase ::
     this->m_from_prmGetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_prmGetOut[%" PRI_PlatformIntType "]",
@@ -153,12 +129,6 @@ void PassiveSerialTesterBase ::
     this->m_from_prmSetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_prmSetOut[%" PRI_PlatformIntType "]",
@@ -184,12 +154,6 @@ void PassiveSerialTesterBase ::
     this->m_from_textEventOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_textEventOut[%" PRI_PlatformIntType "]",
@@ -215,12 +179,6 @@ void PassiveSerialTesterBase ::
     this->m_from_timeGetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
@@ -245,12 +203,6 @@ void PassiveSerialTesterBase ::
     this->m_from_tlmOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_tlmOut[%" PRI_PlatformIntType "]",
@@ -275,12 +227,6 @@ void PassiveSerialTesterBase ::
     this->m_from_noArgsOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
@@ -305,12 +251,6 @@ void PassiveSerialTesterBase ::
     this->m_from_noArgsReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
@@ -335,12 +275,6 @@ void PassiveSerialTesterBase ::
     this->m_from_typedOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
@@ -365,12 +299,6 @@ void PassiveSerialTesterBase ::
     this->m_from_typedReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
@@ -395,12 +323,6 @@ void PassiveSerialTesterBase ::
     this->m_from_serialOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_serialOut[%" PRI_PlatformIntType "]",
@@ -420,12 +342,6 @@ void PassiveSerialTesterBase ::
     this->m_to_cmdIn[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_cmdIn[%" PRI_PlatformIntType "]",
@@ -445,12 +361,6 @@ void PassiveSerialTesterBase ::
     this->m_to_noArgsGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
@@ -470,12 +380,6 @@ void PassiveSerialTesterBase ::
     this->m_to_noArgsReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
@@ -495,12 +399,6 @@ void PassiveSerialTesterBase ::
     this->m_to_noArgsReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
@@ -520,12 +418,6 @@ void PassiveSerialTesterBase ::
     this->m_to_noArgsSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
@@ -545,12 +437,6 @@ void PassiveSerialTesterBase ::
     this->m_to_typedGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
@@ -570,12 +456,6 @@ void PassiveSerialTesterBase ::
     this->m_to_typedReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
@@ -595,12 +475,6 @@ void PassiveSerialTesterBase ::
     this->m_to_typedReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
@@ -620,12 +494,6 @@ void PassiveSerialTesterBase ::
     this->m_to_typedSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",
@@ -645,12 +513,6 @@ void PassiveSerialTesterBase ::
     this->m_to_serialGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_serialGuarded[%" PRI_PlatformIntType "]",
@@ -670,12 +532,6 @@ void PassiveSerialTesterBase ::
     this->m_to_serialSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_serialSync[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSyncProductsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSyncProductsTesterBase.ref.cpp
@@ -33,12 +33,6 @@ void PassiveSyncProductsTesterBase ::
     this->m_from_productRequestOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_productRequestOut[%" PRI_PlatformIntType "]",
@@ -63,12 +57,6 @@ void PassiveSyncProductsTesterBase ::
     this->m_from_productSendOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_productSendOut[%" PRI_PlatformIntType "]",
@@ -93,12 +81,6 @@ void PassiveSyncProductsTesterBase ::
     this->m_from_timeGetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
@@ -123,12 +105,6 @@ void PassiveSyncProductsTesterBase ::
     this->m_from_noArgsOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
@@ -153,12 +129,6 @@ void PassiveSyncProductsTesterBase ::
     this->m_from_noArgsReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
@@ -183,12 +153,6 @@ void PassiveSyncProductsTesterBase ::
     this->m_from_typedOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
@@ -213,12 +177,6 @@ void PassiveSyncProductsTesterBase ::
     this->m_from_typedReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
@@ -238,12 +196,6 @@ void PassiveSyncProductsTesterBase ::
     this->m_to_productRecvIn[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_productRecvIn[%" PRI_PlatformIntType "]",
@@ -263,12 +215,6 @@ void PassiveSyncProductsTesterBase ::
     this->m_to_noArgsGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
@@ -288,12 +234,6 @@ void PassiveSyncProductsTesterBase ::
     this->m_to_noArgsReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
@@ -313,12 +253,6 @@ void PassiveSyncProductsTesterBase ::
     this->m_to_noArgsReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
@@ -338,12 +272,6 @@ void PassiveSyncProductsTesterBase ::
     this->m_to_noArgsSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
@@ -363,12 +291,6 @@ void PassiveSyncProductsTesterBase ::
     this->m_to_typedGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
@@ -388,12 +310,6 @@ void PassiveSyncProductsTesterBase ::
     this->m_to_typedReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
@@ -413,12 +329,6 @@ void PassiveSyncProductsTesterBase ::
     this->m_to_typedReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
@@ -438,12 +348,6 @@ void PassiveSyncProductsTesterBase ::
     this->m_to_typedSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSyncProductsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveSyncProductsTesterBase.ref.cpp
@@ -39,15 +39,13 @@ void PassiveSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_productRequestOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_productRequestOut[port].setObjName(portName);
+    this->m_from_productRequestOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -71,15 +69,13 @@ void PassiveSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_productSendOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_productSendOut[port].setObjName(portName);
+    this->m_from_productSendOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -103,15 +99,13 @@ void PassiveSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_timeGetOut[port].setObjName(portName);
+    this->m_from_timeGetOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -135,15 +129,13 @@ void PassiveSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsOut[port].setObjName(portName);
+    this->m_from_noArgsOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -167,15 +159,13 @@ void PassiveSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsReturnOut[port].setObjName(portName);
+    this->m_from_noArgsReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -199,15 +189,13 @@ void PassiveSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedOut[port].setObjName(portName);
+    this->m_from_typedOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -231,15 +219,13 @@ void PassiveSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedReturnOut[port].setObjName(portName);
+    this->m_from_typedReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -258,15 +244,13 @@ void PassiveSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_productRecvIn[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_productRecvIn[port].setObjName(portName);
+    this->m_to_productRecvIn[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -285,15 +269,13 @@ void PassiveSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsGuarded[port].setObjName(portName);
+    this->m_to_noArgsGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -312,15 +294,13 @@ void PassiveSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnGuarded[port].setObjName(portName);
+    this->m_to_noArgsReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -339,15 +319,13 @@ void PassiveSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnSync[port].setObjName(portName);
+    this->m_to_noArgsReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -366,15 +344,13 @@ void PassiveSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsSync[port].setObjName(portName);
+    this->m_to_noArgsSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -393,15 +369,13 @@ void PassiveSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedGuarded[port].setObjName(portName);
+    this->m_to_typedGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -420,15 +394,13 @@ void PassiveSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnGuarded[port].setObjName(portName);
+    this->m_to_typedReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -447,15 +419,13 @@ void PassiveSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnSync[port].setObjName(portName);
+    this->m_to_typedReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -474,15 +444,13 @@ void PassiveSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedSync[port].setObjName(portName);
+    this->m_to_typedSync[port].setObjName(portName.toChar());
 #endif
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTelemetryTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTelemetryTesterBase.ref.cpp
@@ -33,12 +33,6 @@ void PassiveTelemetryTesterBase ::
     this->m_from_timeGetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
@@ -63,12 +57,6 @@ void PassiveTelemetryTesterBase ::
     this->m_from_tlmOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_tlmOut[%" PRI_PlatformIntType "]",
@@ -93,12 +81,6 @@ void PassiveTelemetryTesterBase ::
     this->m_from_noArgsOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
@@ -123,12 +105,6 @@ void PassiveTelemetryTesterBase ::
     this->m_from_noArgsReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
@@ -153,12 +129,6 @@ void PassiveTelemetryTesterBase ::
     this->m_from_typedOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
@@ -183,12 +153,6 @@ void PassiveTelemetryTesterBase ::
     this->m_from_typedReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
@@ -208,12 +172,6 @@ void PassiveTelemetryTesterBase ::
     this->m_to_noArgsGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
@@ -233,12 +191,6 @@ void PassiveTelemetryTesterBase ::
     this->m_to_noArgsReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
@@ -258,12 +210,6 @@ void PassiveTelemetryTesterBase ::
     this->m_to_noArgsReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
@@ -283,12 +229,6 @@ void PassiveTelemetryTesterBase ::
     this->m_to_noArgsSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
@@ -308,12 +248,6 @@ void PassiveTelemetryTesterBase ::
     this->m_to_typedGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
@@ -333,12 +267,6 @@ void PassiveTelemetryTesterBase ::
     this->m_to_typedReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
@@ -358,12 +286,6 @@ void PassiveTelemetryTesterBase ::
     this->m_to_typedReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
@@ -383,12 +305,6 @@ void PassiveTelemetryTesterBase ::
     this->m_to_typedSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTelemetryTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTelemetryTesterBase.ref.cpp
@@ -39,15 +39,13 @@ void PassiveTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_timeGetOut[port].setObjName(portName);
+    this->m_from_timeGetOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -71,15 +69,13 @@ void PassiveTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_tlmOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_tlmOut[port].setObjName(portName);
+    this->m_from_tlmOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -103,15 +99,13 @@ void PassiveTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsOut[port].setObjName(portName);
+    this->m_from_noArgsOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -135,15 +129,13 @@ void PassiveTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsReturnOut[port].setObjName(portName);
+    this->m_from_noArgsReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -167,15 +159,13 @@ void PassiveTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedOut[port].setObjName(portName);
+    this->m_from_typedOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -199,15 +189,13 @@ void PassiveTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedReturnOut[port].setObjName(portName);
+    this->m_from_typedReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -226,15 +214,13 @@ void PassiveTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsGuarded[port].setObjName(portName);
+    this->m_to_noArgsGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -253,15 +239,13 @@ void PassiveTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnGuarded[port].setObjName(portName);
+    this->m_to_noArgsReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -280,15 +264,13 @@ void PassiveTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnSync[port].setObjName(portName);
+    this->m_to_noArgsReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -307,15 +289,13 @@ void PassiveTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsSync[port].setObjName(portName);
+    this->m_to_noArgsSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -334,15 +314,13 @@ void PassiveTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedGuarded[port].setObjName(portName);
+    this->m_to_typedGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -361,15 +339,13 @@ void PassiveTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnGuarded[port].setObjName(portName);
+    this->m_to_typedReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -388,15 +364,13 @@ void PassiveTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnSync[port].setObjName(portName);
+    this->m_to_typedReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -415,15 +389,13 @@ void PassiveTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedSync[port].setObjName(portName);
+    this->m_to_typedSync[port].setObjName(portName.toChar());
 #endif
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.cpp
@@ -33,12 +33,6 @@ void PassiveTestTesterBase ::
     this->m_from_cmdRegOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_cmdRegOut[%" PRI_PlatformIntType "]",
@@ -63,12 +57,6 @@ void PassiveTestTesterBase ::
     this->m_from_cmdResponseOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_cmdResponseOut[%" PRI_PlatformIntType "]",
@@ -93,12 +81,6 @@ void PassiveTestTesterBase ::
     this->m_from_eventOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_eventOut[%" PRI_PlatformIntType "]",
@@ -123,12 +105,6 @@ void PassiveTestTesterBase ::
     this->m_from_prmGetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_prmGetOut[%" PRI_PlatformIntType "]",
@@ -153,12 +129,6 @@ void PassiveTestTesterBase ::
     this->m_from_prmSetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_prmSetOut[%" PRI_PlatformIntType "]",
@@ -183,12 +153,6 @@ void PassiveTestTesterBase ::
     this->m_from_productRequestOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_productRequestOut[%" PRI_PlatformIntType "]",
@@ -213,12 +177,6 @@ void PassiveTestTesterBase ::
     this->m_from_productSendOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_productSendOut[%" PRI_PlatformIntType "]",
@@ -244,12 +202,6 @@ void PassiveTestTesterBase ::
     this->m_from_textEventOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_textEventOut[%" PRI_PlatformIntType "]",
@@ -275,12 +227,6 @@ void PassiveTestTesterBase ::
     this->m_from_timeGetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
@@ -305,12 +251,6 @@ void PassiveTestTesterBase ::
     this->m_from_tlmOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_tlmOut[%" PRI_PlatformIntType "]",
@@ -335,12 +275,6 @@ void PassiveTestTesterBase ::
     this->m_from_noArgsOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
@@ -365,12 +299,6 @@ void PassiveTestTesterBase ::
     this->m_from_noArgsReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
@@ -395,12 +323,6 @@ void PassiveTestTesterBase ::
     this->m_from_typedOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
@@ -425,12 +347,6 @@ void PassiveTestTesterBase ::
     this->m_from_typedReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
@@ -450,12 +366,6 @@ void PassiveTestTesterBase ::
     this->m_to_cmdIn[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_cmdIn[%" PRI_PlatformIntType "]",
@@ -475,12 +385,6 @@ void PassiveTestTesterBase ::
     this->m_to_productRecvIn[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_productRecvIn[%" PRI_PlatformIntType "]",
@@ -500,12 +404,6 @@ void PassiveTestTesterBase ::
     this->m_to_noArgsGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
@@ -525,12 +423,6 @@ void PassiveTestTesterBase ::
     this->m_to_noArgsReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
@@ -550,12 +442,6 @@ void PassiveTestTesterBase ::
     this->m_to_noArgsReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
@@ -575,12 +461,6 @@ void PassiveTestTesterBase ::
     this->m_to_noArgsSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
@@ -600,12 +480,6 @@ void PassiveTestTesterBase ::
     this->m_to_typedGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
@@ -625,12 +499,6 @@ void PassiveTestTesterBase ::
     this->m_to_typedReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
@@ -650,12 +518,6 @@ void PassiveTestTesterBase ::
     this->m_to_typedReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
@@ -675,12 +537,6 @@ void PassiveTestTesterBase ::
     this->m_to_typedSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/PassiveTestTesterBase.ref.cpp
@@ -39,15 +39,13 @@ void PassiveTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_cmdRegOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_cmdRegOut[port].setObjName(portName);
+    this->m_from_cmdRegOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -71,15 +69,13 @@ void PassiveTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_cmdResponseOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_cmdResponseOut[port].setObjName(portName);
+    this->m_from_cmdResponseOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -103,15 +99,13 @@ void PassiveTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_eventOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_eventOut[port].setObjName(portName);
+    this->m_from_eventOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -135,15 +129,13 @@ void PassiveTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_prmGetOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_prmGetOut[port].setObjName(portName);
+    this->m_from_prmGetOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -167,15 +159,13 @@ void PassiveTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_prmSetOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_prmSetOut[port].setObjName(portName);
+    this->m_from_prmSetOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -199,15 +189,13 @@ void PassiveTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_productRequestOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_productRequestOut[port].setObjName(portName);
+    this->m_from_productRequestOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -231,15 +219,13 @@ void PassiveTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_productSendOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_productSendOut[port].setObjName(portName);
+    this->m_from_productSendOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -264,15 +250,13 @@ void PassiveTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_textEventOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_textEventOut[port].setObjName(portName);
+    this->m_from_textEventOut[port].setObjName(portName.toChar());
 #endif
   }
 #endif
@@ -297,15 +281,13 @@ void PassiveTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_timeGetOut[port].setObjName(portName);
+    this->m_from_timeGetOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -329,15 +311,13 @@ void PassiveTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_tlmOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_tlmOut[port].setObjName(portName);
+    this->m_from_tlmOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -361,15 +341,13 @@ void PassiveTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsOut[port].setObjName(portName);
+    this->m_from_noArgsOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -393,15 +371,13 @@ void PassiveTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsReturnOut[port].setObjName(portName);
+    this->m_from_noArgsReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -425,15 +401,13 @@ void PassiveTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedOut[port].setObjName(portName);
+    this->m_from_typedOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -457,15 +431,13 @@ void PassiveTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedReturnOut[port].setObjName(portName);
+    this->m_from_typedReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -484,15 +456,13 @@ void PassiveTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_cmdIn[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_cmdIn[port].setObjName(portName);
+    this->m_to_cmdIn[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -511,15 +481,13 @@ void PassiveTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_productRecvIn[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_productRecvIn[port].setObjName(portName);
+    this->m_to_productRecvIn[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -538,15 +506,13 @@ void PassiveTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsGuarded[port].setObjName(portName);
+    this->m_to_noArgsGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -565,15 +531,13 @@ void PassiveTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnGuarded[port].setObjName(portName);
+    this->m_to_noArgsReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -592,15 +556,13 @@ void PassiveTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnSync[port].setObjName(portName);
+    this->m_to_noArgsReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -619,15 +581,13 @@ void PassiveTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsSync[port].setObjName(portName);
+    this->m_to_noArgsSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -646,15 +606,13 @@ void PassiveTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedGuarded[port].setObjName(portName);
+    this->m_to_typedGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -673,15 +631,13 @@ void PassiveTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnGuarded[port].setObjName(portName);
+    this->m_to_typedReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -700,15 +656,13 @@ void PassiveTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnSync[port].setObjName(portName);
+    this->m_to_typedReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -727,15 +681,13 @@ void PassiveTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedSync[port].setObjName(portName);
+    this->m_to_typedSync[port].setObjName(portName.toChar());
 #endif
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedAsyncProductsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedAsyncProductsTesterBase.ref.cpp
@@ -39,15 +39,13 @@ void QueuedAsyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_productRequestOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_productRequestOut[port].setObjName(portName);
+    this->m_from_productRequestOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -71,15 +69,13 @@ void QueuedAsyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_productSendOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_productSendOut[port].setObjName(portName);
+    this->m_from_productSendOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -103,15 +99,13 @@ void QueuedAsyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_timeGetOut[port].setObjName(portName);
+    this->m_from_timeGetOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -135,15 +129,13 @@ void QueuedAsyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsOut[port].setObjName(portName);
+    this->m_from_noArgsOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -167,15 +159,13 @@ void QueuedAsyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsReturnOut[port].setObjName(portName);
+    this->m_from_noArgsReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -199,15 +189,13 @@ void QueuedAsyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedOut[port].setObjName(portName);
+    this->m_from_typedOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -231,15 +219,13 @@ void QueuedAsyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedReturnOut[port].setObjName(portName);
+    this->m_from_typedReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -258,15 +244,13 @@ void QueuedAsyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_productRecvIn[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_productRecvIn[port].setObjName(portName);
+    this->m_to_productRecvIn[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -285,15 +269,13 @@ void QueuedAsyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsAsync[port].setObjName(portName);
+    this->m_to_noArgsAsync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -312,15 +294,13 @@ void QueuedAsyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsGuarded[port].setObjName(portName);
+    this->m_to_noArgsGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -339,15 +319,13 @@ void QueuedAsyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnGuarded[port].setObjName(portName);
+    this->m_to_noArgsReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -366,15 +344,13 @@ void QueuedAsyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnSync[port].setObjName(portName);
+    this->m_to_noArgsReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -393,15 +369,13 @@ void QueuedAsyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsSync[port].setObjName(portName);
+    this->m_to_noArgsSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -420,15 +394,13 @@ void QueuedAsyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsync[port].setObjName(portName);
+    this->m_to_typedAsync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -447,15 +419,13 @@ void QueuedAsyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncAssert[port].setObjName(portName);
+    this->m_to_typedAsyncAssert[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -474,15 +444,13 @@ void QueuedAsyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncBlockPriority[port].setObjName(portName);
+    this->m_to_typedAsyncBlockPriority[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -501,15 +469,13 @@ void QueuedAsyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncDropPriority[port].setObjName(portName);
+    this->m_to_typedAsyncDropPriority[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -528,15 +494,13 @@ void QueuedAsyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedGuarded[port].setObjName(portName);
+    this->m_to_typedGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -555,15 +519,13 @@ void QueuedAsyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnGuarded[port].setObjName(portName);
+    this->m_to_typedReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -582,15 +544,13 @@ void QueuedAsyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnSync[port].setObjName(portName);
+    this->m_to_typedReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -609,15 +569,13 @@ void QueuedAsyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedSync[port].setObjName(portName);
+    this->m_to_typedSync[port].setObjName(portName.toChar());
 #endif
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedAsyncProductsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedAsyncProductsTesterBase.ref.cpp
@@ -33,12 +33,6 @@ void QueuedAsyncProductsTesterBase ::
     this->m_from_productRequestOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_productRequestOut[%" PRI_PlatformIntType "]",
@@ -63,12 +57,6 @@ void QueuedAsyncProductsTesterBase ::
     this->m_from_productSendOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_productSendOut[%" PRI_PlatformIntType "]",
@@ -93,12 +81,6 @@ void QueuedAsyncProductsTesterBase ::
     this->m_from_timeGetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
@@ -123,12 +105,6 @@ void QueuedAsyncProductsTesterBase ::
     this->m_from_noArgsOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
@@ -153,12 +129,6 @@ void QueuedAsyncProductsTesterBase ::
     this->m_from_noArgsReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
@@ -183,12 +153,6 @@ void QueuedAsyncProductsTesterBase ::
     this->m_from_typedOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
@@ -213,12 +177,6 @@ void QueuedAsyncProductsTesterBase ::
     this->m_from_typedReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
@@ -238,12 +196,6 @@ void QueuedAsyncProductsTesterBase ::
     this->m_to_productRecvIn[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_productRecvIn[%" PRI_PlatformIntType "]",
@@ -263,12 +215,6 @@ void QueuedAsyncProductsTesterBase ::
     this->m_to_noArgsAsync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
@@ -288,12 +234,6 @@ void QueuedAsyncProductsTesterBase ::
     this->m_to_noArgsGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
@@ -313,12 +253,6 @@ void QueuedAsyncProductsTesterBase ::
     this->m_to_noArgsReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
@@ -338,12 +272,6 @@ void QueuedAsyncProductsTesterBase ::
     this->m_to_noArgsReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
@@ -363,12 +291,6 @@ void QueuedAsyncProductsTesterBase ::
     this->m_to_noArgsSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
@@ -388,12 +310,6 @@ void QueuedAsyncProductsTesterBase ::
     this->m_to_typedAsync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsync[%" PRI_PlatformIntType "]",
@@ -413,12 +329,6 @@ void QueuedAsyncProductsTesterBase ::
     this->m_to_typedAsyncAssert[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
@@ -438,12 +348,6 @@ void QueuedAsyncProductsTesterBase ::
     this->m_to_typedAsyncBlockPriority[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
@@ -463,12 +367,6 @@ void QueuedAsyncProductsTesterBase ::
     this->m_to_typedAsyncDropPriority[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
@@ -488,12 +386,6 @@ void QueuedAsyncProductsTesterBase ::
     this->m_to_typedGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
@@ -513,12 +405,6 @@ void QueuedAsyncProductsTesterBase ::
     this->m_to_typedReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
@@ -538,12 +424,6 @@ void QueuedAsyncProductsTesterBase ::
     this->m_to_typedReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
@@ -563,12 +443,6 @@ void QueuedAsyncProductsTesterBase ::
     this->m_to_typedSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedCommandsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedCommandsTesterBase.ref.cpp
@@ -39,15 +39,13 @@ void QueuedCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_cmdRegOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_cmdRegOut[port].setObjName(portName);
+    this->m_from_cmdRegOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -71,15 +69,13 @@ void QueuedCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_cmdResponseOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_cmdResponseOut[port].setObjName(portName);
+    this->m_from_cmdResponseOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -103,15 +99,13 @@ void QueuedCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_timeGetOut[port].setObjName(portName);
+    this->m_from_timeGetOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -135,15 +129,13 @@ void QueuedCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsOut[port].setObjName(portName);
+    this->m_from_noArgsOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -167,15 +159,13 @@ void QueuedCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsReturnOut[port].setObjName(portName);
+    this->m_from_noArgsReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -199,15 +189,13 @@ void QueuedCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedOut[port].setObjName(portName);
+    this->m_from_typedOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -231,15 +219,13 @@ void QueuedCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedReturnOut[port].setObjName(portName);
+    this->m_from_typedReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -258,15 +244,13 @@ void QueuedCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_cmdIn[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_cmdIn[port].setObjName(portName);
+    this->m_to_cmdIn[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -285,15 +269,13 @@ void QueuedCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsAsync[port].setObjName(portName);
+    this->m_to_noArgsAsync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -312,15 +294,13 @@ void QueuedCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsGuarded[port].setObjName(portName);
+    this->m_to_noArgsGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -339,15 +319,13 @@ void QueuedCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnGuarded[port].setObjName(portName);
+    this->m_to_noArgsReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -366,15 +344,13 @@ void QueuedCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnSync[port].setObjName(portName);
+    this->m_to_noArgsReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -393,15 +369,13 @@ void QueuedCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsSync[port].setObjName(portName);
+    this->m_to_noArgsSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -420,15 +394,13 @@ void QueuedCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsync[port].setObjName(portName);
+    this->m_to_typedAsync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -447,15 +419,13 @@ void QueuedCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncAssert[port].setObjName(portName);
+    this->m_to_typedAsyncAssert[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -474,15 +444,13 @@ void QueuedCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncBlockPriority[port].setObjName(portName);
+    this->m_to_typedAsyncBlockPriority[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -501,15 +469,13 @@ void QueuedCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncDropPriority[port].setObjName(portName);
+    this->m_to_typedAsyncDropPriority[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -528,15 +494,13 @@ void QueuedCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedGuarded[port].setObjName(portName);
+    this->m_to_typedGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -555,15 +519,13 @@ void QueuedCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnGuarded[port].setObjName(portName);
+    this->m_to_typedReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -582,15 +544,13 @@ void QueuedCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnSync[port].setObjName(portName);
+    this->m_to_typedReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -609,15 +569,13 @@ void QueuedCommandsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedSync[port].setObjName(portName);
+    this->m_to_typedSync[port].setObjName(portName.toChar());
 #endif
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedCommandsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedCommandsTesterBase.ref.cpp
@@ -33,12 +33,6 @@ void QueuedCommandsTesterBase ::
     this->m_from_cmdRegOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_cmdRegOut[%" PRI_PlatformIntType "]",
@@ -63,12 +57,6 @@ void QueuedCommandsTesterBase ::
     this->m_from_cmdResponseOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_cmdResponseOut[%" PRI_PlatformIntType "]",
@@ -93,12 +81,6 @@ void QueuedCommandsTesterBase ::
     this->m_from_timeGetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
@@ -123,12 +105,6 @@ void QueuedCommandsTesterBase ::
     this->m_from_noArgsOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
@@ -153,12 +129,6 @@ void QueuedCommandsTesterBase ::
     this->m_from_noArgsReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
@@ -183,12 +153,6 @@ void QueuedCommandsTesterBase ::
     this->m_from_typedOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
@@ -213,12 +177,6 @@ void QueuedCommandsTesterBase ::
     this->m_from_typedReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
@@ -238,12 +196,6 @@ void QueuedCommandsTesterBase ::
     this->m_to_cmdIn[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_cmdIn[%" PRI_PlatformIntType "]",
@@ -263,12 +215,6 @@ void QueuedCommandsTesterBase ::
     this->m_to_noArgsAsync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
@@ -288,12 +234,6 @@ void QueuedCommandsTesterBase ::
     this->m_to_noArgsGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
@@ -313,12 +253,6 @@ void QueuedCommandsTesterBase ::
     this->m_to_noArgsReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
@@ -338,12 +272,6 @@ void QueuedCommandsTesterBase ::
     this->m_to_noArgsReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
@@ -363,12 +291,6 @@ void QueuedCommandsTesterBase ::
     this->m_to_noArgsSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
@@ -388,12 +310,6 @@ void QueuedCommandsTesterBase ::
     this->m_to_typedAsync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsync[%" PRI_PlatformIntType "]",
@@ -413,12 +329,6 @@ void QueuedCommandsTesterBase ::
     this->m_to_typedAsyncAssert[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
@@ -438,12 +348,6 @@ void QueuedCommandsTesterBase ::
     this->m_to_typedAsyncBlockPriority[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
@@ -463,12 +367,6 @@ void QueuedCommandsTesterBase ::
     this->m_to_typedAsyncDropPriority[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
@@ -488,12 +386,6 @@ void QueuedCommandsTesterBase ::
     this->m_to_typedGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
@@ -513,12 +405,6 @@ void QueuedCommandsTesterBase ::
     this->m_to_typedReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
@@ -538,12 +424,6 @@ void QueuedCommandsTesterBase ::
     this->m_to_typedReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
@@ -563,12 +443,6 @@ void QueuedCommandsTesterBase ::
     this->m_to_typedSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedEventsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedEventsTesterBase.ref.cpp
@@ -39,15 +39,13 @@ void QueuedEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_eventOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_eventOut[port].setObjName(portName);
+    this->m_from_eventOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -72,15 +70,13 @@ void QueuedEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_textEventOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_textEventOut[port].setObjName(portName);
+    this->m_from_textEventOut[port].setObjName(portName.toChar());
 #endif
   }
 #endif
@@ -105,15 +101,13 @@ void QueuedEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_timeGetOut[port].setObjName(portName);
+    this->m_from_timeGetOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -137,15 +131,13 @@ void QueuedEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsOut[port].setObjName(portName);
+    this->m_from_noArgsOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -169,15 +161,13 @@ void QueuedEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsReturnOut[port].setObjName(portName);
+    this->m_from_noArgsReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -201,15 +191,13 @@ void QueuedEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedOut[port].setObjName(portName);
+    this->m_from_typedOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -233,15 +221,13 @@ void QueuedEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedReturnOut[port].setObjName(portName);
+    this->m_from_typedReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -260,15 +246,13 @@ void QueuedEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsAsync[port].setObjName(portName);
+    this->m_to_noArgsAsync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -287,15 +271,13 @@ void QueuedEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsGuarded[port].setObjName(portName);
+    this->m_to_noArgsGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -314,15 +296,13 @@ void QueuedEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnGuarded[port].setObjName(portName);
+    this->m_to_noArgsReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -341,15 +321,13 @@ void QueuedEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnSync[port].setObjName(portName);
+    this->m_to_noArgsReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -368,15 +346,13 @@ void QueuedEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsSync[port].setObjName(portName);
+    this->m_to_noArgsSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -395,15 +371,13 @@ void QueuedEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsync[port].setObjName(portName);
+    this->m_to_typedAsync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -422,15 +396,13 @@ void QueuedEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncAssert[port].setObjName(portName);
+    this->m_to_typedAsyncAssert[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -449,15 +421,13 @@ void QueuedEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncBlockPriority[port].setObjName(portName);
+    this->m_to_typedAsyncBlockPriority[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -476,15 +446,13 @@ void QueuedEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncDropPriority[port].setObjName(portName);
+    this->m_to_typedAsyncDropPriority[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -503,15 +471,13 @@ void QueuedEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedGuarded[port].setObjName(portName);
+    this->m_to_typedGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -530,15 +496,13 @@ void QueuedEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnGuarded[port].setObjName(portName);
+    this->m_to_typedReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -557,15 +521,13 @@ void QueuedEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnSync[port].setObjName(portName);
+    this->m_to_typedReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -584,15 +546,13 @@ void QueuedEventsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedSync[port].setObjName(portName);
+    this->m_to_typedSync[port].setObjName(portName.toChar());
 #endif
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedEventsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedEventsTesterBase.ref.cpp
@@ -33,12 +33,6 @@ void QueuedEventsTesterBase ::
     this->m_from_eventOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_eventOut[%" PRI_PlatformIntType "]",
@@ -64,12 +58,6 @@ void QueuedEventsTesterBase ::
     this->m_from_textEventOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_textEventOut[%" PRI_PlatformIntType "]",
@@ -95,12 +83,6 @@ void QueuedEventsTesterBase ::
     this->m_from_timeGetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
@@ -125,12 +107,6 @@ void QueuedEventsTesterBase ::
     this->m_from_noArgsOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
@@ -155,12 +131,6 @@ void QueuedEventsTesterBase ::
     this->m_from_noArgsReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
@@ -185,12 +155,6 @@ void QueuedEventsTesterBase ::
     this->m_from_typedOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
@@ -215,12 +179,6 @@ void QueuedEventsTesterBase ::
     this->m_from_typedReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
@@ -240,12 +198,6 @@ void QueuedEventsTesterBase ::
     this->m_to_noArgsAsync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
@@ -265,12 +217,6 @@ void QueuedEventsTesterBase ::
     this->m_to_noArgsGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
@@ -290,12 +236,6 @@ void QueuedEventsTesterBase ::
     this->m_to_noArgsReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
@@ -315,12 +255,6 @@ void QueuedEventsTesterBase ::
     this->m_to_noArgsReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
@@ -340,12 +274,6 @@ void QueuedEventsTesterBase ::
     this->m_to_noArgsSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
@@ -365,12 +293,6 @@ void QueuedEventsTesterBase ::
     this->m_to_typedAsync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsync[%" PRI_PlatformIntType "]",
@@ -390,12 +312,6 @@ void QueuedEventsTesterBase ::
     this->m_to_typedAsyncAssert[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
@@ -415,12 +331,6 @@ void QueuedEventsTesterBase ::
     this->m_to_typedAsyncBlockPriority[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
@@ -440,12 +350,6 @@ void QueuedEventsTesterBase ::
     this->m_to_typedAsyncDropPriority[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
@@ -465,12 +369,6 @@ void QueuedEventsTesterBase ::
     this->m_to_typedGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
@@ -490,12 +388,6 @@ void QueuedEventsTesterBase ::
     this->m_to_typedReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
@@ -515,12 +407,6 @@ void QueuedEventsTesterBase ::
     this->m_to_typedReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
@@ -540,12 +426,6 @@ void QueuedEventsTesterBase ::
     this->m_to_typedSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedGetProductsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedGetProductsTesterBase.ref.cpp
@@ -33,12 +33,6 @@ void QueuedGetProductsTesterBase ::
     this->m_from_productGetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_productGetOut[%" PRI_PlatformIntType "]",
@@ -63,12 +57,6 @@ void QueuedGetProductsTesterBase ::
     this->m_from_productSendOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_productSendOut[%" PRI_PlatformIntType "]",
@@ -93,12 +81,6 @@ void QueuedGetProductsTesterBase ::
     this->m_from_timeGetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
@@ -123,12 +105,6 @@ void QueuedGetProductsTesterBase ::
     this->m_from_noArgsOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
@@ -153,12 +129,6 @@ void QueuedGetProductsTesterBase ::
     this->m_from_noArgsReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
@@ -183,12 +153,6 @@ void QueuedGetProductsTesterBase ::
     this->m_from_typedOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
@@ -213,12 +177,6 @@ void QueuedGetProductsTesterBase ::
     this->m_from_typedReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
@@ -238,12 +196,6 @@ void QueuedGetProductsTesterBase ::
     this->m_to_noArgsAsync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
@@ -263,12 +215,6 @@ void QueuedGetProductsTesterBase ::
     this->m_to_noArgsGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
@@ -288,12 +234,6 @@ void QueuedGetProductsTesterBase ::
     this->m_to_noArgsReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
@@ -313,12 +253,6 @@ void QueuedGetProductsTesterBase ::
     this->m_to_noArgsReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
@@ -338,12 +272,6 @@ void QueuedGetProductsTesterBase ::
     this->m_to_noArgsSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
@@ -363,12 +291,6 @@ void QueuedGetProductsTesterBase ::
     this->m_to_typedAsync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsync[%" PRI_PlatformIntType "]",
@@ -388,12 +310,6 @@ void QueuedGetProductsTesterBase ::
     this->m_to_typedAsyncAssert[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
@@ -413,12 +329,6 @@ void QueuedGetProductsTesterBase ::
     this->m_to_typedAsyncBlockPriority[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
@@ -438,12 +348,6 @@ void QueuedGetProductsTesterBase ::
     this->m_to_typedAsyncDropPriority[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
@@ -463,12 +367,6 @@ void QueuedGetProductsTesterBase ::
     this->m_to_typedGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
@@ -488,12 +386,6 @@ void QueuedGetProductsTesterBase ::
     this->m_to_typedReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
@@ -513,12 +405,6 @@ void QueuedGetProductsTesterBase ::
     this->m_to_typedReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
@@ -538,12 +424,6 @@ void QueuedGetProductsTesterBase ::
     this->m_to_typedSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedGetProductsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedGetProductsTesterBase.ref.cpp
@@ -39,15 +39,13 @@ void QueuedGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_productGetOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_productGetOut[port].setObjName(portName);
+    this->m_from_productGetOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -71,15 +69,13 @@ void QueuedGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_productSendOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_productSendOut[port].setObjName(portName);
+    this->m_from_productSendOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -103,15 +99,13 @@ void QueuedGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_timeGetOut[port].setObjName(portName);
+    this->m_from_timeGetOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -135,15 +129,13 @@ void QueuedGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsOut[port].setObjName(portName);
+    this->m_from_noArgsOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -167,15 +159,13 @@ void QueuedGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsReturnOut[port].setObjName(portName);
+    this->m_from_noArgsReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -199,15 +189,13 @@ void QueuedGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedOut[port].setObjName(portName);
+    this->m_from_typedOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -231,15 +219,13 @@ void QueuedGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedReturnOut[port].setObjName(portName);
+    this->m_from_typedReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -258,15 +244,13 @@ void QueuedGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsAsync[port].setObjName(portName);
+    this->m_to_noArgsAsync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -285,15 +269,13 @@ void QueuedGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsGuarded[port].setObjName(portName);
+    this->m_to_noArgsGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -312,15 +294,13 @@ void QueuedGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnGuarded[port].setObjName(portName);
+    this->m_to_noArgsReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -339,15 +319,13 @@ void QueuedGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnSync[port].setObjName(portName);
+    this->m_to_noArgsReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -366,15 +344,13 @@ void QueuedGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsSync[port].setObjName(portName);
+    this->m_to_noArgsSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -393,15 +369,13 @@ void QueuedGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsync[port].setObjName(portName);
+    this->m_to_typedAsync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -420,15 +394,13 @@ void QueuedGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncAssert[port].setObjName(portName);
+    this->m_to_typedAsyncAssert[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -447,15 +419,13 @@ void QueuedGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncBlockPriority[port].setObjName(portName);
+    this->m_to_typedAsyncBlockPriority[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -474,15 +444,13 @@ void QueuedGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncDropPriority[port].setObjName(portName);
+    this->m_to_typedAsyncDropPriority[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -501,15 +469,13 @@ void QueuedGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedGuarded[port].setObjName(portName);
+    this->m_to_typedGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -528,15 +494,13 @@ void QueuedGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnGuarded[port].setObjName(portName);
+    this->m_to_typedReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -555,15 +519,13 @@ void QueuedGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnSync[port].setObjName(portName);
+    this->m_to_typedReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -582,15 +544,13 @@ void QueuedGetProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedSync[port].setObjName(portName);
+    this->m_to_typedSync[port].setObjName(portName.toChar());
 #endif
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedGuardedProductsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedGuardedProductsTesterBase.ref.cpp
@@ -39,15 +39,13 @@ void QueuedGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_productRequestOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_productRequestOut[port].setObjName(portName);
+    this->m_from_productRequestOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -71,15 +69,13 @@ void QueuedGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_productSendOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_productSendOut[port].setObjName(portName);
+    this->m_from_productSendOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -103,15 +99,13 @@ void QueuedGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_timeGetOut[port].setObjName(portName);
+    this->m_from_timeGetOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -135,15 +129,13 @@ void QueuedGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsOut[port].setObjName(portName);
+    this->m_from_noArgsOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -167,15 +159,13 @@ void QueuedGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsReturnOut[port].setObjName(portName);
+    this->m_from_noArgsReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -199,15 +189,13 @@ void QueuedGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedOut[port].setObjName(portName);
+    this->m_from_typedOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -231,15 +219,13 @@ void QueuedGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedReturnOut[port].setObjName(portName);
+    this->m_from_typedReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -258,15 +244,13 @@ void QueuedGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_productRecvIn[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_productRecvIn[port].setObjName(portName);
+    this->m_to_productRecvIn[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -285,15 +269,13 @@ void QueuedGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsAsync[port].setObjName(portName);
+    this->m_to_noArgsAsync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -312,15 +294,13 @@ void QueuedGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsGuarded[port].setObjName(portName);
+    this->m_to_noArgsGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -339,15 +319,13 @@ void QueuedGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnGuarded[port].setObjName(portName);
+    this->m_to_noArgsReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -366,15 +344,13 @@ void QueuedGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnSync[port].setObjName(portName);
+    this->m_to_noArgsReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -393,15 +369,13 @@ void QueuedGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsSync[port].setObjName(portName);
+    this->m_to_noArgsSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -420,15 +394,13 @@ void QueuedGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsync[port].setObjName(portName);
+    this->m_to_typedAsync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -447,15 +419,13 @@ void QueuedGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncAssert[port].setObjName(portName);
+    this->m_to_typedAsyncAssert[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -474,15 +444,13 @@ void QueuedGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncBlockPriority[port].setObjName(portName);
+    this->m_to_typedAsyncBlockPriority[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -501,15 +469,13 @@ void QueuedGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncDropPriority[port].setObjName(portName);
+    this->m_to_typedAsyncDropPriority[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -528,15 +494,13 @@ void QueuedGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedGuarded[port].setObjName(portName);
+    this->m_to_typedGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -555,15 +519,13 @@ void QueuedGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnGuarded[port].setObjName(portName);
+    this->m_to_typedReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -582,15 +544,13 @@ void QueuedGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnSync[port].setObjName(portName);
+    this->m_to_typedReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -609,15 +569,13 @@ void QueuedGuardedProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedSync[port].setObjName(portName);
+    this->m_to_typedSync[port].setObjName(portName.toChar());
 #endif
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedGuardedProductsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedGuardedProductsTesterBase.ref.cpp
@@ -33,12 +33,6 @@ void QueuedGuardedProductsTesterBase ::
     this->m_from_productRequestOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_productRequestOut[%" PRI_PlatformIntType "]",
@@ -63,12 +57,6 @@ void QueuedGuardedProductsTesterBase ::
     this->m_from_productSendOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_productSendOut[%" PRI_PlatformIntType "]",
@@ -93,12 +81,6 @@ void QueuedGuardedProductsTesterBase ::
     this->m_from_timeGetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
@@ -123,12 +105,6 @@ void QueuedGuardedProductsTesterBase ::
     this->m_from_noArgsOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
@@ -153,12 +129,6 @@ void QueuedGuardedProductsTesterBase ::
     this->m_from_noArgsReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
@@ -183,12 +153,6 @@ void QueuedGuardedProductsTesterBase ::
     this->m_from_typedOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
@@ -213,12 +177,6 @@ void QueuedGuardedProductsTesterBase ::
     this->m_from_typedReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
@@ -238,12 +196,6 @@ void QueuedGuardedProductsTesterBase ::
     this->m_to_productRecvIn[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_productRecvIn[%" PRI_PlatformIntType "]",
@@ -263,12 +215,6 @@ void QueuedGuardedProductsTesterBase ::
     this->m_to_noArgsAsync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
@@ -288,12 +234,6 @@ void QueuedGuardedProductsTesterBase ::
     this->m_to_noArgsGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
@@ -313,12 +253,6 @@ void QueuedGuardedProductsTesterBase ::
     this->m_to_noArgsReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
@@ -338,12 +272,6 @@ void QueuedGuardedProductsTesterBase ::
     this->m_to_noArgsReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
@@ -363,12 +291,6 @@ void QueuedGuardedProductsTesterBase ::
     this->m_to_noArgsSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
@@ -388,12 +310,6 @@ void QueuedGuardedProductsTesterBase ::
     this->m_to_typedAsync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsync[%" PRI_PlatformIntType "]",
@@ -413,12 +329,6 @@ void QueuedGuardedProductsTesterBase ::
     this->m_to_typedAsyncAssert[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
@@ -438,12 +348,6 @@ void QueuedGuardedProductsTesterBase ::
     this->m_to_typedAsyncBlockPriority[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
@@ -463,12 +367,6 @@ void QueuedGuardedProductsTesterBase ::
     this->m_to_typedAsyncDropPriority[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
@@ -488,12 +386,6 @@ void QueuedGuardedProductsTesterBase ::
     this->m_to_typedGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
@@ -513,12 +405,6 @@ void QueuedGuardedProductsTesterBase ::
     this->m_to_typedReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
@@ -538,12 +424,6 @@ void QueuedGuardedProductsTesterBase ::
     this->m_to_typedReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
@@ -563,12 +443,6 @@ void QueuedGuardedProductsTesterBase ::
     this->m_to_typedSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedNoArgsPortsOnlyTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedNoArgsPortsOnlyTesterBase.ref.cpp
@@ -39,15 +39,13 @@ void QueuedNoArgsPortsOnlyTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsOut[port].setObjName(portName);
+    this->m_from_noArgsOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -71,15 +69,13 @@ void QueuedNoArgsPortsOnlyTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsReturnOut[port].setObjName(portName);
+    this->m_from_noArgsReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -98,15 +94,13 @@ void QueuedNoArgsPortsOnlyTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsAsync[port].setObjName(portName);
+    this->m_to_noArgsAsync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -125,15 +119,13 @@ void QueuedNoArgsPortsOnlyTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsGuarded[port].setObjName(portName);
+    this->m_to_noArgsGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -152,15 +144,13 @@ void QueuedNoArgsPortsOnlyTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnGuarded[port].setObjName(portName);
+    this->m_to_noArgsReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -179,15 +169,13 @@ void QueuedNoArgsPortsOnlyTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnSync[port].setObjName(portName);
+    this->m_to_noArgsReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedNoArgsPortsOnlyTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedNoArgsPortsOnlyTesterBase.ref.cpp
@@ -33,12 +33,6 @@ void QueuedNoArgsPortsOnlyTesterBase ::
     this->m_from_noArgsOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
@@ -63,12 +57,6 @@ void QueuedNoArgsPortsOnlyTesterBase ::
     this->m_from_noArgsReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
@@ -88,12 +76,6 @@ void QueuedNoArgsPortsOnlyTesterBase ::
     this->m_to_noArgsAsync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
@@ -113,12 +95,6 @@ void QueuedNoArgsPortsOnlyTesterBase ::
     this->m_to_noArgsGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
@@ -138,12 +114,6 @@ void QueuedNoArgsPortsOnlyTesterBase ::
     this->m_to_noArgsReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
@@ -163,12 +133,6 @@ void QueuedNoArgsPortsOnlyTesterBase ::
     this->m_to_noArgsReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedParamsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedParamsTesterBase.ref.cpp
@@ -33,12 +33,6 @@ void QueuedParamsTesterBase ::
     this->m_from_cmdRegOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_cmdRegOut[%" PRI_PlatformIntType "]",
@@ -63,12 +57,6 @@ void QueuedParamsTesterBase ::
     this->m_from_cmdResponseOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_cmdResponseOut[%" PRI_PlatformIntType "]",
@@ -93,12 +81,6 @@ void QueuedParamsTesterBase ::
     this->m_from_prmGetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_prmGetOut[%" PRI_PlatformIntType "]",
@@ -123,12 +105,6 @@ void QueuedParamsTesterBase ::
     this->m_from_prmSetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_prmSetOut[%" PRI_PlatformIntType "]",
@@ -153,12 +129,6 @@ void QueuedParamsTesterBase ::
     this->m_from_timeGetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
@@ -183,12 +153,6 @@ void QueuedParamsTesterBase ::
     this->m_from_noArgsOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
@@ -213,12 +177,6 @@ void QueuedParamsTesterBase ::
     this->m_from_noArgsReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
@@ -243,12 +201,6 @@ void QueuedParamsTesterBase ::
     this->m_from_typedOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
@@ -273,12 +225,6 @@ void QueuedParamsTesterBase ::
     this->m_from_typedReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
@@ -298,12 +244,6 @@ void QueuedParamsTesterBase ::
     this->m_to_cmdIn[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_cmdIn[%" PRI_PlatformIntType "]",
@@ -323,12 +263,6 @@ void QueuedParamsTesterBase ::
     this->m_to_noArgsAsync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
@@ -348,12 +282,6 @@ void QueuedParamsTesterBase ::
     this->m_to_noArgsGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
@@ -373,12 +301,6 @@ void QueuedParamsTesterBase ::
     this->m_to_noArgsReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
@@ -398,12 +320,6 @@ void QueuedParamsTesterBase ::
     this->m_to_noArgsReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
@@ -423,12 +339,6 @@ void QueuedParamsTesterBase ::
     this->m_to_noArgsSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
@@ -448,12 +358,6 @@ void QueuedParamsTesterBase ::
     this->m_to_typedAsync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsync[%" PRI_PlatformIntType "]",
@@ -473,12 +377,6 @@ void QueuedParamsTesterBase ::
     this->m_to_typedAsyncAssert[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
@@ -498,12 +396,6 @@ void QueuedParamsTesterBase ::
     this->m_to_typedAsyncBlockPriority[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
@@ -523,12 +415,6 @@ void QueuedParamsTesterBase ::
     this->m_to_typedAsyncDropPriority[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
@@ -548,12 +434,6 @@ void QueuedParamsTesterBase ::
     this->m_to_typedGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
@@ -573,12 +453,6 @@ void QueuedParamsTesterBase ::
     this->m_to_typedReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
@@ -598,12 +472,6 @@ void QueuedParamsTesterBase ::
     this->m_to_typedReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
@@ -623,12 +491,6 @@ void QueuedParamsTesterBase ::
     this->m_to_typedSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedParamsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedParamsTesterBase.ref.cpp
@@ -39,15 +39,13 @@ void QueuedParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_cmdRegOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_cmdRegOut[port].setObjName(portName);
+    this->m_from_cmdRegOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -71,15 +69,13 @@ void QueuedParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_cmdResponseOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_cmdResponseOut[port].setObjName(portName);
+    this->m_from_cmdResponseOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -103,15 +99,13 @@ void QueuedParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_prmGetOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_prmGetOut[port].setObjName(portName);
+    this->m_from_prmGetOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -135,15 +129,13 @@ void QueuedParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_prmSetOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_prmSetOut[port].setObjName(portName);
+    this->m_from_prmSetOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -167,15 +159,13 @@ void QueuedParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_timeGetOut[port].setObjName(portName);
+    this->m_from_timeGetOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -199,15 +189,13 @@ void QueuedParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsOut[port].setObjName(portName);
+    this->m_from_noArgsOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -231,15 +219,13 @@ void QueuedParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsReturnOut[port].setObjName(portName);
+    this->m_from_noArgsReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -263,15 +249,13 @@ void QueuedParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedOut[port].setObjName(portName);
+    this->m_from_typedOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -295,15 +279,13 @@ void QueuedParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedReturnOut[port].setObjName(portName);
+    this->m_from_typedReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -322,15 +304,13 @@ void QueuedParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_cmdIn[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_cmdIn[port].setObjName(portName);
+    this->m_to_cmdIn[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -349,15 +329,13 @@ void QueuedParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsAsync[port].setObjName(portName);
+    this->m_to_noArgsAsync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -376,15 +354,13 @@ void QueuedParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsGuarded[port].setObjName(portName);
+    this->m_to_noArgsGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -403,15 +379,13 @@ void QueuedParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnGuarded[port].setObjName(portName);
+    this->m_to_noArgsReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -430,15 +404,13 @@ void QueuedParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnSync[port].setObjName(portName);
+    this->m_to_noArgsReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -457,15 +429,13 @@ void QueuedParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsSync[port].setObjName(portName);
+    this->m_to_noArgsSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -484,15 +454,13 @@ void QueuedParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsync[port].setObjName(portName);
+    this->m_to_typedAsync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -511,15 +479,13 @@ void QueuedParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncAssert[port].setObjName(portName);
+    this->m_to_typedAsyncAssert[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -538,15 +504,13 @@ void QueuedParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncBlockPriority[port].setObjName(portName);
+    this->m_to_typedAsyncBlockPriority[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -565,15 +529,13 @@ void QueuedParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncDropPriority[port].setObjName(portName);
+    this->m_to_typedAsyncDropPriority[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -592,15 +554,13 @@ void QueuedParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedGuarded[port].setObjName(portName);
+    this->m_to_typedGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -619,15 +579,13 @@ void QueuedParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnGuarded[port].setObjName(portName);
+    this->m_to_typedReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -646,15 +604,13 @@ void QueuedParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnSync[port].setObjName(portName);
+    this->m_to_typedReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -673,15 +629,13 @@ void QueuedParamsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedSync[port].setObjName(portName);
+    this->m_to_typedSync[port].setObjName(portName.toChar());
 #endif
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.cpp
@@ -39,15 +39,13 @@ void QueuedSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_cmdRegOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_cmdRegOut[port].setObjName(portName);
+    this->m_from_cmdRegOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -71,15 +69,13 @@ void QueuedSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_cmdResponseOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_cmdResponseOut[port].setObjName(portName);
+    this->m_from_cmdResponseOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -103,15 +99,13 @@ void QueuedSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_eventOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_eventOut[port].setObjName(portName);
+    this->m_from_eventOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -135,15 +129,13 @@ void QueuedSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_prmGetOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_prmGetOut[port].setObjName(portName);
+    this->m_from_prmGetOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -167,15 +159,13 @@ void QueuedSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_prmSetOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_prmSetOut[port].setObjName(portName);
+    this->m_from_prmSetOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -200,15 +190,13 @@ void QueuedSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_textEventOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_textEventOut[port].setObjName(portName);
+    this->m_from_textEventOut[port].setObjName(portName.toChar());
 #endif
   }
 #endif
@@ -233,15 +221,13 @@ void QueuedSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_timeGetOut[port].setObjName(portName);
+    this->m_from_timeGetOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -265,15 +251,13 @@ void QueuedSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_tlmOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_tlmOut[port].setObjName(portName);
+    this->m_from_tlmOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -297,15 +281,13 @@ void QueuedSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsOut[port].setObjName(portName);
+    this->m_from_noArgsOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -329,15 +311,13 @@ void QueuedSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsReturnOut[port].setObjName(portName);
+    this->m_from_noArgsReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -361,15 +341,13 @@ void QueuedSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedOut[port].setObjName(portName);
+    this->m_from_typedOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -393,15 +371,13 @@ void QueuedSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedReturnOut[port].setObjName(portName);
+    this->m_from_typedReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -425,15 +401,13 @@ void QueuedSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_serialOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_serialOut[port].setObjName(portName);
+    this->m_from_serialOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -452,15 +426,13 @@ void QueuedSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_cmdIn[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_cmdIn[port].setObjName(portName);
+    this->m_to_cmdIn[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -479,15 +451,13 @@ void QueuedSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsAsync[port].setObjName(portName);
+    this->m_to_noArgsAsync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -506,15 +476,13 @@ void QueuedSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsGuarded[port].setObjName(portName);
+    this->m_to_noArgsGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -533,15 +501,13 @@ void QueuedSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnGuarded[port].setObjName(portName);
+    this->m_to_noArgsReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -560,15 +526,13 @@ void QueuedSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnSync[port].setObjName(portName);
+    this->m_to_noArgsReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -587,15 +551,13 @@ void QueuedSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsSync[port].setObjName(portName);
+    this->m_to_noArgsSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -614,15 +576,13 @@ void QueuedSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsync[port].setObjName(portName);
+    this->m_to_typedAsync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -641,15 +601,13 @@ void QueuedSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncAssert[port].setObjName(portName);
+    this->m_to_typedAsyncAssert[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -668,15 +626,13 @@ void QueuedSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncBlockPriority[port].setObjName(portName);
+    this->m_to_typedAsyncBlockPriority[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -695,15 +651,13 @@ void QueuedSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncDropPriority[port].setObjName(portName);
+    this->m_to_typedAsyncDropPriority[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -722,15 +676,13 @@ void QueuedSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedGuarded[port].setObjName(portName);
+    this->m_to_typedGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -749,15 +701,13 @@ void QueuedSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnGuarded[port].setObjName(portName);
+    this->m_to_typedReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -776,15 +726,13 @@ void QueuedSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnSync[port].setObjName(portName);
+    this->m_to_typedReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -803,15 +751,13 @@ void QueuedSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedSync[port].setObjName(portName);
+    this->m_to_typedSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -830,15 +776,13 @@ void QueuedSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_serialAsync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_serialAsync[port].setObjName(portName);
+    this->m_to_serialAsync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -857,15 +801,13 @@ void QueuedSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_serialAsyncAssert[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_serialAsyncAssert[port].setObjName(portName);
+    this->m_to_serialAsyncAssert[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -884,15 +826,13 @@ void QueuedSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_serialAsyncBlockPriority[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_serialAsyncBlockPriority[port].setObjName(portName);
+    this->m_to_serialAsyncBlockPriority[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -911,15 +851,13 @@ void QueuedSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_serialAsyncDropPriority[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_serialAsyncDropPriority[port].setObjName(portName);
+    this->m_to_serialAsyncDropPriority[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -938,15 +876,13 @@ void QueuedSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_serialGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_serialGuarded[port].setObjName(portName);
+    this->m_to_serialGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -965,15 +901,13 @@ void QueuedSerialTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_serialSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_serialSync[port].setObjName(portName);
+    this->m_to_serialSync[port].setObjName(portName.toChar());
 #endif
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSerialTesterBase.ref.cpp
@@ -33,12 +33,6 @@ void QueuedSerialTesterBase ::
     this->m_from_cmdRegOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_cmdRegOut[%" PRI_PlatformIntType "]",
@@ -63,12 +57,6 @@ void QueuedSerialTesterBase ::
     this->m_from_cmdResponseOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_cmdResponseOut[%" PRI_PlatformIntType "]",
@@ -93,12 +81,6 @@ void QueuedSerialTesterBase ::
     this->m_from_eventOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_eventOut[%" PRI_PlatformIntType "]",
@@ -123,12 +105,6 @@ void QueuedSerialTesterBase ::
     this->m_from_prmGetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_prmGetOut[%" PRI_PlatformIntType "]",
@@ -153,12 +129,6 @@ void QueuedSerialTesterBase ::
     this->m_from_prmSetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_prmSetOut[%" PRI_PlatformIntType "]",
@@ -184,12 +154,6 @@ void QueuedSerialTesterBase ::
     this->m_from_textEventOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_textEventOut[%" PRI_PlatformIntType "]",
@@ -215,12 +179,6 @@ void QueuedSerialTesterBase ::
     this->m_from_timeGetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
@@ -245,12 +203,6 @@ void QueuedSerialTesterBase ::
     this->m_from_tlmOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_tlmOut[%" PRI_PlatformIntType "]",
@@ -275,12 +227,6 @@ void QueuedSerialTesterBase ::
     this->m_from_noArgsOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
@@ -305,12 +251,6 @@ void QueuedSerialTesterBase ::
     this->m_from_noArgsReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
@@ -335,12 +275,6 @@ void QueuedSerialTesterBase ::
     this->m_from_typedOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
@@ -365,12 +299,6 @@ void QueuedSerialTesterBase ::
     this->m_from_typedReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
@@ -395,12 +323,6 @@ void QueuedSerialTesterBase ::
     this->m_from_serialOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_serialOut[%" PRI_PlatformIntType "]",
@@ -420,12 +342,6 @@ void QueuedSerialTesterBase ::
     this->m_to_cmdIn[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_cmdIn[%" PRI_PlatformIntType "]",
@@ -445,12 +361,6 @@ void QueuedSerialTesterBase ::
     this->m_to_noArgsAsync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
@@ -470,12 +380,6 @@ void QueuedSerialTesterBase ::
     this->m_to_noArgsGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
@@ -495,12 +399,6 @@ void QueuedSerialTesterBase ::
     this->m_to_noArgsReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
@@ -520,12 +418,6 @@ void QueuedSerialTesterBase ::
     this->m_to_noArgsReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
@@ -545,12 +437,6 @@ void QueuedSerialTesterBase ::
     this->m_to_noArgsSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
@@ -570,12 +456,6 @@ void QueuedSerialTesterBase ::
     this->m_to_typedAsync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsync[%" PRI_PlatformIntType "]",
@@ -595,12 +475,6 @@ void QueuedSerialTesterBase ::
     this->m_to_typedAsyncAssert[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
@@ -620,12 +494,6 @@ void QueuedSerialTesterBase ::
     this->m_to_typedAsyncBlockPriority[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
@@ -645,12 +513,6 @@ void QueuedSerialTesterBase ::
     this->m_to_typedAsyncDropPriority[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
@@ -670,12 +532,6 @@ void QueuedSerialTesterBase ::
     this->m_to_typedGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
@@ -695,12 +551,6 @@ void QueuedSerialTesterBase ::
     this->m_to_typedReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
@@ -720,12 +570,6 @@ void QueuedSerialTesterBase ::
     this->m_to_typedReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
@@ -745,12 +589,6 @@ void QueuedSerialTesterBase ::
     this->m_to_typedSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",
@@ -770,12 +608,6 @@ void QueuedSerialTesterBase ::
     this->m_to_serialAsync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_serialAsync[%" PRI_PlatformIntType "]",
@@ -795,12 +627,6 @@ void QueuedSerialTesterBase ::
     this->m_to_serialAsyncAssert[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_serialAsyncAssert[%" PRI_PlatformIntType "]",
@@ -820,12 +646,6 @@ void QueuedSerialTesterBase ::
     this->m_to_serialAsyncBlockPriority[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_serialAsyncBlockPriority[%" PRI_PlatformIntType "]",
@@ -845,12 +665,6 @@ void QueuedSerialTesterBase ::
     this->m_to_serialAsyncDropPriority[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_serialAsyncDropPriority[%" PRI_PlatformIntType "]",
@@ -870,12 +684,6 @@ void QueuedSerialTesterBase ::
     this->m_to_serialGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_serialGuarded[%" PRI_PlatformIntType "]",
@@ -895,12 +703,6 @@ void QueuedSerialTesterBase ::
     this->m_to_serialSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_serialSync[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSyncProductsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSyncProductsTesterBase.ref.cpp
@@ -39,15 +39,13 @@ void QueuedSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_productRequestOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_productRequestOut[port].setObjName(portName);
+    this->m_from_productRequestOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -71,15 +69,13 @@ void QueuedSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_productSendOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_productSendOut[port].setObjName(portName);
+    this->m_from_productSendOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -103,15 +99,13 @@ void QueuedSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_timeGetOut[port].setObjName(portName);
+    this->m_from_timeGetOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -135,15 +129,13 @@ void QueuedSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsOut[port].setObjName(portName);
+    this->m_from_noArgsOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -167,15 +159,13 @@ void QueuedSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsReturnOut[port].setObjName(portName);
+    this->m_from_noArgsReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -199,15 +189,13 @@ void QueuedSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedOut[port].setObjName(portName);
+    this->m_from_typedOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -231,15 +219,13 @@ void QueuedSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedReturnOut[port].setObjName(portName);
+    this->m_from_typedReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -258,15 +244,13 @@ void QueuedSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_productRecvIn[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_productRecvIn[port].setObjName(portName);
+    this->m_to_productRecvIn[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -285,15 +269,13 @@ void QueuedSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsAsync[port].setObjName(portName);
+    this->m_to_noArgsAsync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -312,15 +294,13 @@ void QueuedSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsGuarded[port].setObjName(portName);
+    this->m_to_noArgsGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -339,15 +319,13 @@ void QueuedSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnGuarded[port].setObjName(portName);
+    this->m_to_noArgsReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -366,15 +344,13 @@ void QueuedSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnSync[port].setObjName(portName);
+    this->m_to_noArgsReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -393,15 +369,13 @@ void QueuedSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsSync[port].setObjName(portName);
+    this->m_to_noArgsSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -420,15 +394,13 @@ void QueuedSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsync[port].setObjName(portName);
+    this->m_to_typedAsync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -447,15 +419,13 @@ void QueuedSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncAssert[port].setObjName(portName);
+    this->m_to_typedAsyncAssert[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -474,15 +444,13 @@ void QueuedSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncBlockPriority[port].setObjName(portName);
+    this->m_to_typedAsyncBlockPriority[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -501,15 +469,13 @@ void QueuedSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncDropPriority[port].setObjName(portName);
+    this->m_to_typedAsyncDropPriority[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -528,15 +494,13 @@ void QueuedSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedGuarded[port].setObjName(portName);
+    this->m_to_typedGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -555,15 +519,13 @@ void QueuedSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnGuarded[port].setObjName(portName);
+    this->m_to_typedReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -582,15 +544,13 @@ void QueuedSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnSync[port].setObjName(portName);
+    this->m_to_typedReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -609,15 +569,13 @@ void QueuedSyncProductsTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedSync[port].setObjName(portName);
+    this->m_to_typedSync[port].setObjName(portName.toChar());
 #endif
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSyncProductsTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedSyncProductsTesterBase.ref.cpp
@@ -33,12 +33,6 @@ void QueuedSyncProductsTesterBase ::
     this->m_from_productRequestOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_productRequestOut[%" PRI_PlatformIntType "]",
@@ -63,12 +57,6 @@ void QueuedSyncProductsTesterBase ::
     this->m_from_productSendOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_productSendOut[%" PRI_PlatformIntType "]",
@@ -93,12 +81,6 @@ void QueuedSyncProductsTesterBase ::
     this->m_from_timeGetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
@@ -123,12 +105,6 @@ void QueuedSyncProductsTesterBase ::
     this->m_from_noArgsOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
@@ -153,12 +129,6 @@ void QueuedSyncProductsTesterBase ::
     this->m_from_noArgsReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
@@ -183,12 +153,6 @@ void QueuedSyncProductsTesterBase ::
     this->m_from_typedOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
@@ -213,12 +177,6 @@ void QueuedSyncProductsTesterBase ::
     this->m_from_typedReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
@@ -238,12 +196,6 @@ void QueuedSyncProductsTesterBase ::
     this->m_to_productRecvIn[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_productRecvIn[%" PRI_PlatformIntType "]",
@@ -263,12 +215,6 @@ void QueuedSyncProductsTesterBase ::
     this->m_to_noArgsAsync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
@@ -288,12 +234,6 @@ void QueuedSyncProductsTesterBase ::
     this->m_to_noArgsGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
@@ -313,12 +253,6 @@ void QueuedSyncProductsTesterBase ::
     this->m_to_noArgsReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
@@ -338,12 +272,6 @@ void QueuedSyncProductsTesterBase ::
     this->m_to_noArgsReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
@@ -363,12 +291,6 @@ void QueuedSyncProductsTesterBase ::
     this->m_to_noArgsSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
@@ -388,12 +310,6 @@ void QueuedSyncProductsTesterBase ::
     this->m_to_typedAsync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsync[%" PRI_PlatformIntType "]",
@@ -413,12 +329,6 @@ void QueuedSyncProductsTesterBase ::
     this->m_to_typedAsyncAssert[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
@@ -438,12 +348,6 @@ void QueuedSyncProductsTesterBase ::
     this->m_to_typedAsyncBlockPriority[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
@@ -463,12 +367,6 @@ void QueuedSyncProductsTesterBase ::
     this->m_to_typedAsyncDropPriority[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
@@ -488,12 +386,6 @@ void QueuedSyncProductsTesterBase ::
     this->m_to_typedGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
@@ -513,12 +405,6 @@ void QueuedSyncProductsTesterBase ::
     this->m_to_typedReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
@@ -538,12 +424,6 @@ void QueuedSyncProductsTesterBase ::
     this->m_to_typedReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
@@ -563,12 +443,6 @@ void QueuedSyncProductsTesterBase ::
     this->m_to_typedSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTelemetryTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTelemetryTesterBase.ref.cpp
@@ -33,12 +33,6 @@ void QueuedTelemetryTesterBase ::
     this->m_from_timeGetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
@@ -63,12 +57,6 @@ void QueuedTelemetryTesterBase ::
     this->m_from_tlmOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_tlmOut[%" PRI_PlatformIntType "]",
@@ -93,12 +81,6 @@ void QueuedTelemetryTesterBase ::
     this->m_from_noArgsOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
@@ -123,12 +105,6 @@ void QueuedTelemetryTesterBase ::
     this->m_from_noArgsReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
@@ -153,12 +129,6 @@ void QueuedTelemetryTesterBase ::
     this->m_from_typedOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
@@ -183,12 +153,6 @@ void QueuedTelemetryTesterBase ::
     this->m_from_typedReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
@@ -208,12 +172,6 @@ void QueuedTelemetryTesterBase ::
     this->m_to_noArgsAsync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
@@ -233,12 +191,6 @@ void QueuedTelemetryTesterBase ::
     this->m_to_noArgsGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
@@ -258,12 +210,6 @@ void QueuedTelemetryTesterBase ::
     this->m_to_noArgsReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
@@ -283,12 +229,6 @@ void QueuedTelemetryTesterBase ::
     this->m_to_noArgsReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
@@ -308,12 +248,6 @@ void QueuedTelemetryTesterBase ::
     this->m_to_noArgsSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
@@ -333,12 +267,6 @@ void QueuedTelemetryTesterBase ::
     this->m_to_typedAsync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsync[%" PRI_PlatformIntType "]",
@@ -358,12 +286,6 @@ void QueuedTelemetryTesterBase ::
     this->m_to_typedAsyncAssert[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
@@ -383,12 +305,6 @@ void QueuedTelemetryTesterBase ::
     this->m_to_typedAsyncBlockPriority[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
@@ -408,12 +324,6 @@ void QueuedTelemetryTesterBase ::
     this->m_to_typedAsyncDropPriority[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
@@ -433,12 +343,6 @@ void QueuedTelemetryTesterBase ::
     this->m_to_typedGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
@@ -458,12 +362,6 @@ void QueuedTelemetryTesterBase ::
     this->m_to_typedReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
@@ -483,12 +381,6 @@ void QueuedTelemetryTesterBase ::
     this->m_to_typedReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
@@ -508,12 +400,6 @@ void QueuedTelemetryTesterBase ::
     this->m_to_typedSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTelemetryTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTelemetryTesterBase.ref.cpp
@@ -39,15 +39,13 @@ void QueuedTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_timeGetOut[port].setObjName(portName);
+    this->m_from_timeGetOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -71,15 +69,13 @@ void QueuedTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_tlmOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_tlmOut[port].setObjName(portName);
+    this->m_from_tlmOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -103,15 +99,13 @@ void QueuedTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsOut[port].setObjName(portName);
+    this->m_from_noArgsOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -135,15 +129,13 @@ void QueuedTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsReturnOut[port].setObjName(portName);
+    this->m_from_noArgsReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -167,15 +159,13 @@ void QueuedTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedOut[port].setObjName(portName);
+    this->m_from_typedOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -199,15 +189,13 @@ void QueuedTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedReturnOut[port].setObjName(portName);
+    this->m_from_typedReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -226,15 +214,13 @@ void QueuedTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsAsync[port].setObjName(portName);
+    this->m_to_noArgsAsync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -253,15 +239,13 @@ void QueuedTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsGuarded[port].setObjName(portName);
+    this->m_to_noArgsGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -280,15 +264,13 @@ void QueuedTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnGuarded[port].setObjName(portName);
+    this->m_to_noArgsReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -307,15 +289,13 @@ void QueuedTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnSync[port].setObjName(portName);
+    this->m_to_noArgsReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -334,15 +314,13 @@ void QueuedTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsSync[port].setObjName(portName);
+    this->m_to_noArgsSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -361,15 +339,13 @@ void QueuedTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsync[port].setObjName(portName);
+    this->m_to_typedAsync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -388,15 +364,13 @@ void QueuedTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncAssert[port].setObjName(portName);
+    this->m_to_typedAsyncAssert[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -415,15 +389,13 @@ void QueuedTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncBlockPriority[port].setObjName(portName);
+    this->m_to_typedAsyncBlockPriority[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -442,15 +414,13 @@ void QueuedTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncDropPriority[port].setObjName(portName);
+    this->m_to_typedAsyncDropPriority[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -469,15 +439,13 @@ void QueuedTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedGuarded[port].setObjName(portName);
+    this->m_to_typedGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -496,15 +464,13 @@ void QueuedTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnGuarded[port].setObjName(portName);
+    this->m_to_typedReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -523,15 +489,13 @@ void QueuedTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnSync[port].setObjName(portName);
+    this->m_to_typedReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -550,15 +514,13 @@ void QueuedTelemetryTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedSync[port].setObjName(portName);
+    this->m_to_typedSync[port].setObjName(portName.toChar());
 #endif
   }
 }

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.cpp
@@ -33,12 +33,6 @@ void QueuedTestTesterBase ::
     this->m_from_cmdRegOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_cmdRegOut[%" PRI_PlatformIntType "]",
@@ -63,12 +57,6 @@ void QueuedTestTesterBase ::
     this->m_from_cmdResponseOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_cmdResponseOut[%" PRI_PlatformIntType "]",
@@ -93,12 +81,6 @@ void QueuedTestTesterBase ::
     this->m_from_eventOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_eventOut[%" PRI_PlatformIntType "]",
@@ -123,12 +105,6 @@ void QueuedTestTesterBase ::
     this->m_from_prmGetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_prmGetOut[%" PRI_PlatformIntType "]",
@@ -153,12 +129,6 @@ void QueuedTestTesterBase ::
     this->m_from_prmSetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_prmSetOut[%" PRI_PlatformIntType "]",
@@ -183,12 +153,6 @@ void QueuedTestTesterBase ::
     this->m_from_productRequestOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_productRequestOut[%" PRI_PlatformIntType "]",
@@ -213,12 +177,6 @@ void QueuedTestTesterBase ::
     this->m_from_productSendOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_productSendOut[%" PRI_PlatformIntType "]",
@@ -244,12 +202,6 @@ void QueuedTestTesterBase ::
     this->m_from_textEventOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_textEventOut[%" PRI_PlatformIntType "]",
@@ -275,12 +227,6 @@ void QueuedTestTesterBase ::
     this->m_from_timeGetOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
@@ -305,12 +251,6 @@ void QueuedTestTesterBase ::
     this->m_from_tlmOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_tlmOut[%" PRI_PlatformIntType "]",
@@ -335,12 +275,6 @@ void QueuedTestTesterBase ::
     this->m_from_noArgsOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
@@ -365,12 +299,6 @@ void QueuedTestTesterBase ::
     this->m_from_noArgsReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
@@ -395,12 +323,6 @@ void QueuedTestTesterBase ::
     this->m_from_typedOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
@@ -425,12 +347,6 @@ void QueuedTestTesterBase ::
     this->m_from_typedReturnOut[port].setPortNum(port);
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
@@ -450,12 +366,6 @@ void QueuedTestTesterBase ::
     this->m_to_cmdIn[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_cmdIn[%" PRI_PlatformIntType "]",
@@ -475,12 +385,6 @@ void QueuedTestTesterBase ::
     this->m_to_productRecvIn[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_productRecvIn[%" PRI_PlatformIntType "]",
@@ -500,12 +404,6 @@ void QueuedTestTesterBase ::
     this->m_to_noArgsAsync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
@@ -525,12 +423,6 @@ void QueuedTestTesterBase ::
     this->m_to_noArgsGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
@@ -550,12 +442,6 @@ void QueuedTestTesterBase ::
     this->m_to_noArgsReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
@@ -575,12 +461,6 @@ void QueuedTestTesterBase ::
     this->m_to_noArgsReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
@@ -600,12 +480,6 @@ void QueuedTestTesterBase ::
     this->m_to_noArgsSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
@@ -625,12 +499,6 @@ void QueuedTestTesterBase ::
     this->m_to_typedAsync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsync[%" PRI_PlatformIntType "]",
@@ -650,12 +518,6 @@ void QueuedTestTesterBase ::
     this->m_to_typedAsyncAssert[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
@@ -675,12 +537,6 @@ void QueuedTestTesterBase ::
     this->m_to_typedAsyncBlockPriority[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
@@ -700,12 +556,6 @@ void QueuedTestTesterBase ::
     this->m_to_typedAsyncDropPriority[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
@@ -725,12 +575,6 @@ void QueuedTestTesterBase ::
     this->m_to_typedGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
@@ -750,12 +594,6 @@ void QueuedTestTesterBase ::
     this->m_to_typedReturnGuarded[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
@@ -775,12 +613,6 @@ void QueuedTestTesterBase ::
     this->m_to_typedReturnSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
@@ -800,12 +632,6 @@ void QueuedTestTesterBase ::
     this->m_to_typedSync[port].init();
 
 #if FW_OBJECT_NAMES == 1
-    // The port name consists of this->m_objName and some extra info.
-    // We expect all of this to fit in FW_OBJ_NAME_MAX_SIZE bytes.
-    // However, the compiler may assume that this->m_objName fills
-    // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
-    // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
-    // bytes to cover the extra info.
     Fw::ObjectName portName;
     portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",

--- a/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/test-base/QueuedTestTesterBase.ref.cpp
@@ -39,15 +39,13 @@ void QueuedTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_cmdRegOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_cmdRegOut[port].setObjName(portName);
+    this->m_from_cmdRegOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -71,15 +69,13 @@ void QueuedTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_cmdResponseOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_cmdResponseOut[port].setObjName(portName);
+    this->m_from_cmdResponseOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -103,15 +99,13 @@ void QueuedTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_eventOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_eventOut[port].setObjName(portName);
+    this->m_from_eventOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -135,15 +129,13 @@ void QueuedTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_prmGetOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_prmGetOut[port].setObjName(portName);
+    this->m_from_prmGetOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -167,15 +159,13 @@ void QueuedTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_prmSetOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_prmSetOut[port].setObjName(portName);
+    this->m_from_prmSetOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -199,15 +189,13 @@ void QueuedTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_productRequestOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_productRequestOut[port].setObjName(portName);
+    this->m_from_productRequestOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -231,15 +219,13 @@ void QueuedTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_productSendOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_productSendOut[port].setObjName(portName);
+    this->m_from_productSendOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -264,15 +250,13 @@ void QueuedTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_textEventOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_textEventOut[port].setObjName(portName);
+    this->m_from_textEventOut[port].setObjName(portName.toChar());
 #endif
   }
 #endif
@@ -297,15 +281,13 @@ void QueuedTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_timeGetOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_timeGetOut[port].setObjName(portName);
+    this->m_from_timeGetOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -329,15 +311,13 @@ void QueuedTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_tlmOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_tlmOut[port].setObjName(portName);
+    this->m_from_tlmOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -361,15 +341,13 @@ void QueuedTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsOut[port].setObjName(portName);
+    this->m_from_noArgsOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -393,15 +371,13 @@ void QueuedTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_noArgsReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_noArgsReturnOut[port].setObjName(portName);
+    this->m_from_noArgsReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -425,15 +401,13 @@ void QueuedTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedOut[port].setObjName(portName);
+    this->m_from_typedOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -457,15 +431,13 @@ void QueuedTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_from_typedReturnOut[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_from_typedReturnOut[port].setObjName(portName);
+    this->m_from_typedReturnOut[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -484,15 +456,13 @@ void QueuedTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_cmdIn[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_cmdIn[port].setObjName(portName);
+    this->m_to_cmdIn[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -511,15 +481,13 @@ void QueuedTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_productRecvIn[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_productRecvIn[port].setObjName(portName);
+    this->m_to_productRecvIn[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -538,15 +506,13 @@ void QueuedTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsAsync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsAsync[port].setObjName(portName);
+    this->m_to_noArgsAsync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -565,15 +531,13 @@ void QueuedTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsGuarded[port].setObjName(portName);
+    this->m_to_noArgsGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -592,15 +556,13 @@ void QueuedTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnGuarded[port].setObjName(portName);
+    this->m_to_noArgsReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -619,15 +581,13 @@ void QueuedTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsReturnSync[port].setObjName(portName);
+    this->m_to_noArgsReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -646,15 +606,13 @@ void QueuedTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_noArgsSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_noArgsSync[port].setObjName(portName);
+    this->m_to_noArgsSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -673,15 +631,13 @@ void QueuedTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsync[port].setObjName(portName);
+    this->m_to_typedAsync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -700,15 +656,13 @@ void QueuedTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncAssert[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncAssert[port].setObjName(portName);
+    this->m_to_typedAsyncAssert[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -727,15 +681,13 @@ void QueuedTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncBlockPriority[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncBlockPriority[port].setObjName(portName);
+    this->m_to_typedAsyncBlockPriority[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -754,15 +706,13 @@ void QueuedTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedAsyncDropPriority[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedAsyncDropPriority[port].setObjName(portName);
+    this->m_to_typedAsyncDropPriority[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -781,15 +731,13 @@ void QueuedTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedGuarded[port].setObjName(portName);
+    this->m_to_typedGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -808,15 +756,13 @@ void QueuedTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnGuarded[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnGuarded[port].setObjName(portName);
+    this->m_to_typedReturnGuarded[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -835,15 +781,13 @@ void QueuedTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedReturnSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedReturnSync[port].setObjName(portName);
+    this->m_to_typedReturnSync[port].setObjName(portName.toChar());
 #endif
   }
 
@@ -862,15 +806,13 @@ void QueuedTestTesterBase ::
     // the entire array, whose size is FW_OBJ_NAME_MAX_SIZE. So to
     // avoid a compiler warning, we provide an extra FW_OBJ_NAME_MAX_SIZE
     // bytes to cover the extra info.
-    char portName[2*FW_OBJ_NAME_MAX_SIZE];
-    (void) snprintf(
-      portName,
-      sizeof(portName),
+    Fw::ObjectName portName;
+    portName.format(
       "%s_to_typedSync[%" PRI_PlatformIntType "]",
-      this->m_objName,
+      this->m_objName.toChar(),
       port
     );
-    this->m_to_typedSync[port].setObjName(portName);
+    this->m_to_typedSync[port].setObjName(portName.toChar());
 #endif
   }
 }


### PR DESCRIPTION
## Change Description

Add in support for `Fw::ObjectName` implementation, instead of raw char arrays.
Corresponding PR in F´ core repo: https://github.com/nasa/fprime/pull/2497

## Rationale

See https://github.com/nasa/fprime/issues/2493