### PR TITLE
Revise C++ code gen for array records

### DIFF
--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveAsyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveAsyncProductsComponentAc.ref.cpp
@@ -102,14 +102,14 @@ Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::
   FW_ASSERT(array != nullptr);
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    sizeof(FwSizeType) +
+    sizeof(FwSizeStoreType) +
     size * ActiveAsyncProducts_Data::SERIALIZED_SIZE;
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->baseId + RecordId::DataArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    status = this->m_dataBuffer.serialize(size);
+    status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
@@ -153,14 +153,14 @@ Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::
   FW_ASSERT(array != nullptr);
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    sizeof(FwSizeType) +
+    sizeof(FwSizeStoreType) +
     size * sizeof(U32);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->baseId + RecordId::U32ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    status = this->m_dataBuffer.serialize(size);
+    status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
@@ -204,17 +204,16 @@ Fw::SerializeStatus ActiveAsyncProductsComponentBase::DpContainer ::
   FW_ASSERT(array != nullptr);
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    sizeof(FwSizeType) +
+    sizeof(FwSizeStoreType) +
     size * sizeof(U8);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->baseId + RecordId::U8ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    status = this->m_dataBuffer.serialize(size);
+    status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    const bool omitSerializedLength = true;
-    status = this->m_dataBuffer.serialize(array, size, omitSerializedLength);
+    status = this->m_dataBuffer.serialize(array, size, Fw::Serialization::OMIT_LENGTH);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     this->m_dataSize += sizeDelta;
   }
@@ -2811,8 +2810,9 @@ void ActiveAsyncProductsComponentBase ::
   // Update the size of the buffer according to the data size
   const FwSizeType packetSize = container.getPacketSize();
   Fw::Buffer buffer = container.getBuffer();
-  FW_ASSERT(packetSize <= buffer.getSize(), packetSize, buffer.getSize());
-  buffer.setSize(packetSize);
+  FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
+      static_cast<FwAssertArgType>(buffer.getSize()));
+  buffer.setSize(static_cast<U32>(packetSize));
   // Send the buffer
   this->productSendOut_out(0, container.getId(), buffer);
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveGetProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveGetProductsComponentAc.ref.cpp
@@ -100,14 +100,14 @@ Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::
   FW_ASSERT(array != nullptr);
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    sizeof(FwSizeType) +
+    sizeof(FwSizeStoreType) +
     size * ActiveGetProducts_Data::SERIALIZED_SIZE;
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->baseId + RecordId::DataArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    status = this->m_dataBuffer.serialize(size);
+    status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
@@ -151,14 +151,14 @@ Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::
   FW_ASSERT(array != nullptr);
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    sizeof(FwSizeType) +
+    sizeof(FwSizeStoreType) +
     size * sizeof(U32);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->baseId + RecordId::U32ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    status = this->m_dataBuffer.serialize(size);
+    status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
@@ -202,17 +202,16 @@ Fw::SerializeStatus ActiveGetProductsComponentBase::DpContainer ::
   FW_ASSERT(array != nullptr);
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    sizeof(FwSizeType) +
+    sizeof(FwSizeStoreType) +
     size * sizeof(U8);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->baseId + RecordId::U8ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    status = this->m_dataBuffer.serialize(size);
+    status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    const bool omitSerializedLength = true;
-    status = this->m_dataBuffer.serialize(array, size, omitSerializedLength);
+    status = this->m_dataBuffer.serialize(array, size, Fw::Serialization::OMIT_LENGTH);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     this->m_dataSize += sizeDelta;
   }
@@ -2660,8 +2659,9 @@ void ActiveGetProductsComponentBase ::
   // Update the size of the buffer according to the data size
   const FwSizeType packetSize = container.getPacketSize();
   Fw::Buffer buffer = container.getBuffer();
-  FW_ASSERT(packetSize <= buffer.getSize(), packetSize, buffer.getSize());
-  buffer.setSize(packetSize);
+  FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
+      static_cast<FwAssertArgType>(buffer.getSize()));
+  buffer.setSize(static_cast<U32>(packetSize));
   // Send the buffer
   this->productSendOut_out(0, container.getId(), buffer);
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveGuardedProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveGuardedProductsComponentAc.ref.cpp
@@ -100,14 +100,14 @@ Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::
   FW_ASSERT(array != nullptr);
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    sizeof(FwSizeType) +
+    sizeof(FwSizeStoreType) +
     size * ActiveGuardedProducts_Data::SERIALIZED_SIZE;
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->baseId + RecordId::DataArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    status = this->m_dataBuffer.serialize(size);
+    status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
@@ -151,14 +151,14 @@ Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::
   FW_ASSERT(array != nullptr);
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    sizeof(FwSizeType) +
+    sizeof(FwSizeStoreType) +
     size * sizeof(U32);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->baseId + RecordId::U32ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    status = this->m_dataBuffer.serialize(size);
+    status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
@@ -202,17 +202,16 @@ Fw::SerializeStatus ActiveGuardedProductsComponentBase::DpContainer ::
   FW_ASSERT(array != nullptr);
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    sizeof(FwSizeType) +
+    sizeof(FwSizeStoreType) +
     size * sizeof(U8);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->baseId + RecordId::U8ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    status = this->m_dataBuffer.serialize(size);
+    status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    const bool omitSerializedLength = true;
-    status = this->m_dataBuffer.serialize(array, size, omitSerializedLength);
+    status = this->m_dataBuffer.serialize(array, size, Fw::Serialization::OMIT_LENGTH);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     this->m_dataSize += sizeDelta;
   }
@@ -2767,8 +2766,9 @@ void ActiveGuardedProductsComponentBase ::
   // Update the size of the buffer according to the data size
   const FwSizeType packetSize = container.getPacketSize();
   Fw::Buffer buffer = container.getBuffer();
-  FW_ASSERT(packetSize <= buffer.getSize(), packetSize, buffer.getSize());
-  buffer.setSize(packetSize);
+  FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
+      static_cast<FwAssertArgType>(buffer.getSize()));
+  buffer.setSize(static_cast<U32>(packetSize));
   // Send the buffer
   this->productSendOut_out(0, container.getId(), buffer);
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveSyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveSyncProductsComponentAc.ref.cpp
@@ -100,14 +100,14 @@ Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::
   FW_ASSERT(array != nullptr);
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    sizeof(FwSizeType) +
+    sizeof(FwSizeStoreType) +
     size * ActiveSyncProducts_Data::SERIALIZED_SIZE;
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->baseId + RecordId::DataArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    status = this->m_dataBuffer.serialize(size);
+    status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
@@ -151,14 +151,14 @@ Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::
   FW_ASSERT(array != nullptr);
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    sizeof(FwSizeType) +
+    sizeof(FwSizeStoreType) +
     size * sizeof(U32);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->baseId + RecordId::U32ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    status = this->m_dataBuffer.serialize(size);
+    status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
@@ -202,17 +202,16 @@ Fw::SerializeStatus ActiveSyncProductsComponentBase::DpContainer ::
   FW_ASSERT(array != nullptr);
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    sizeof(FwSizeType) +
+    sizeof(FwSizeStoreType) +
     size * sizeof(U8);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->baseId + RecordId::U8ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    status = this->m_dataBuffer.serialize(size);
+    status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    const bool omitSerializedLength = true;
-    status = this->m_dataBuffer.serialize(array, size, omitSerializedLength);
+    status = this->m_dataBuffer.serialize(array, size, Fw::Serialization::OMIT_LENGTH);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     this->m_dataSize += sizeDelta;
   }
@@ -2761,8 +2760,9 @@ void ActiveSyncProductsComponentBase ::
   // Update the size of the buffer according to the data size
   const FwSizeType packetSize = container.getPacketSize();
   Fw::Buffer buffer = container.getBuffer();
-  FW_ASSERT(packetSize <= buffer.getSize(), packetSize, buffer.getSize());
-  buffer.setSize(packetSize);
+  FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
+      static_cast<FwAssertArgType>(buffer.getSize()));
+  buffer.setSize(static_cast<U32>(packetSize));
   // Send the buffer
   this->productSendOut_out(0, container.getId(), buffer);
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/ActiveTestComponentAc.ref.cpp
@@ -138,14 +138,14 @@ namespace M {
     FW_ASSERT(array != nullptr);
     const FwSizeType sizeDelta =
       sizeof(FwDpIdType) +
-      sizeof(FwSizeType) +
+      sizeof(FwSizeStoreType) +
       size * M::ActiveTest_Data::SERIALIZED_SIZE;
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
     if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
       const FwDpIdType id = this->baseId + RecordId::DataArrayRecord;
       status = this->m_dataBuffer.serialize(id);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-      status = this->m_dataBuffer.serialize(size);
+      status = this->m_dataBuffer.serializeSize(size);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
       for (FwSizeType i = 0; i < size; i++) {
         status = this->m_dataBuffer.serialize(array[i]);
@@ -189,14 +189,14 @@ namespace M {
     FW_ASSERT(array != nullptr);
     const FwSizeType sizeDelta =
       sizeof(FwDpIdType) +
-      sizeof(FwSizeType) +
+      sizeof(FwSizeStoreType) +
       size * sizeof(U32);
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
     if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
       const FwDpIdType id = this->baseId + RecordId::U32ArrayRecord;
       status = this->m_dataBuffer.serialize(id);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-      status = this->m_dataBuffer.serialize(size);
+      status = this->m_dataBuffer.serializeSize(size);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
       for (FwSizeType i = 0; i < size; i++) {
         status = this->m_dataBuffer.serialize(array[i]);
@@ -240,17 +240,16 @@ namespace M {
     FW_ASSERT(array != nullptr);
     const FwSizeType sizeDelta =
       sizeof(FwDpIdType) +
-      sizeof(FwSizeType) +
+      sizeof(FwSizeStoreType) +
       size * sizeof(U8);
     Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
     if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
       const FwDpIdType id = this->baseId + RecordId::U8ArrayRecord;
       status = this->m_dataBuffer.serialize(id);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-      status = this->m_dataBuffer.serialize(size);
+      status = this->m_dataBuffer.serializeSize(size);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-      const bool omitSerializedLength = true;
-      status = this->m_dataBuffer.serialize(array, size, omitSerializedLength);
+      status = this->m_dataBuffer.serialize(array, size, Fw::Serialization::OMIT_LENGTH);
       FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
       this->m_dataSize += sizeDelta;
     }
@@ -5608,8 +5607,9 @@ namespace M {
     // Update the size of the buffer according to the data size
     const FwSizeType packetSize = container.getPacketSize();
     Fw::Buffer buffer = container.getBuffer();
-    FW_ASSERT(packetSize <= buffer.getSize(), packetSize, buffer.getSize());
-    buffer.setSize(packetSize);
+    FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
+        static_cast<FwAssertArgType>(buffer.getSize()));
+    buffer.setSize(static_cast<U32>(packetSize));
     // Send the buffer
     this->productSendOut_out(0, container.getId(), buffer);
   }

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveGetProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveGetProductsComponentAc.ref.cpp
@@ -45,14 +45,14 @@ Fw::SerializeStatus PassiveGetProductsComponentBase::DpContainer ::
   FW_ASSERT(array != nullptr);
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    sizeof(FwSizeType) +
+    sizeof(FwSizeStoreType) +
     size * PassiveGetProducts_Data::SERIALIZED_SIZE;
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->baseId + RecordId::DataArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    status = this->m_dataBuffer.serialize(size);
+    status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
@@ -96,14 +96,14 @@ Fw::SerializeStatus PassiveGetProductsComponentBase::DpContainer ::
   FW_ASSERT(array != nullptr);
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    sizeof(FwSizeType) +
+    sizeof(FwSizeStoreType) +
     size * sizeof(U32);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->baseId + RecordId::U32ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    status = this->m_dataBuffer.serialize(size);
+    status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
@@ -147,17 +147,16 @@ Fw::SerializeStatus PassiveGetProductsComponentBase::DpContainer ::
   FW_ASSERT(array != nullptr);
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    sizeof(FwSizeType) +
+    sizeof(FwSizeStoreType) +
     size * sizeof(U8);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->baseId + RecordId::U8ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    status = this->m_dataBuffer.serialize(size);
+    status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    const bool omitSerializedLength = true;
-    status = this->m_dataBuffer.serialize(array, size, omitSerializedLength);
+    status = this->m_dataBuffer.serialize(array, size, Fw::Serialization::OMIT_LENGTH);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     this->m_dataSize += sizeDelta;
   }
@@ -1841,8 +1840,9 @@ void PassiveGetProductsComponentBase ::
   // Update the size of the buffer according to the data size
   const FwSizeType packetSize = container.getPacketSize();
   Fw::Buffer buffer = container.getBuffer();
-  FW_ASSERT(packetSize <= buffer.getSize(), packetSize, buffer.getSize());
-  buffer.setSize(packetSize);
+  FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
+      static_cast<FwAssertArgType>(buffer.getSize()));
+  buffer.setSize(static_cast<U32>(packetSize));
   // Send the buffer
   this->productSendOut_out(0, container.getId(), buffer);
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveGuardedProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveGuardedProductsComponentAc.ref.cpp
@@ -45,14 +45,14 @@ Fw::SerializeStatus PassiveGuardedProductsComponentBase::DpContainer ::
   FW_ASSERT(array != nullptr);
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    sizeof(FwSizeType) +
+    sizeof(FwSizeStoreType) +
     size * PassiveGuardedProducts_Data::SERIALIZED_SIZE;
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->baseId + RecordId::DataArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    status = this->m_dataBuffer.serialize(size);
+    status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
@@ -96,14 +96,14 @@ Fw::SerializeStatus PassiveGuardedProductsComponentBase::DpContainer ::
   FW_ASSERT(array != nullptr);
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    sizeof(FwSizeType) +
+    sizeof(FwSizeStoreType) +
     size * sizeof(U32);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->baseId + RecordId::U32ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    status = this->m_dataBuffer.serialize(size);
+    status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
@@ -147,17 +147,16 @@ Fw::SerializeStatus PassiveGuardedProductsComponentBase::DpContainer ::
   FW_ASSERT(array != nullptr);
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    sizeof(FwSizeType) +
+    sizeof(FwSizeStoreType) +
     size * sizeof(U8);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->baseId + RecordId::U8ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    status = this->m_dataBuffer.serialize(size);
+    status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    const bool omitSerializedLength = true;
-    status = this->m_dataBuffer.serialize(array, size, omitSerializedLength);
+    status = this->m_dataBuffer.serialize(array, size, Fw::Serialization::OMIT_LENGTH);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     this->m_dataSize += sizeDelta;
   }
@@ -1948,8 +1947,9 @@ void PassiveGuardedProductsComponentBase ::
   // Update the size of the buffer according to the data size
   const FwSizeType packetSize = container.getPacketSize();
   Fw::Buffer buffer = container.getBuffer();
-  FW_ASSERT(packetSize <= buffer.getSize(), packetSize, buffer.getSize());
-  buffer.setSize(packetSize);
+  FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
+      static_cast<FwAssertArgType>(buffer.getSize()));
+  buffer.setSize(static_cast<U32>(packetSize));
   // Send the buffer
   this->productSendOut_out(0, container.getId(), buffer);
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveSyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveSyncProductsComponentAc.ref.cpp
@@ -45,14 +45,14 @@ Fw::SerializeStatus PassiveSyncProductsComponentBase::DpContainer ::
   FW_ASSERT(array != nullptr);
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    sizeof(FwSizeType) +
+    sizeof(FwSizeStoreType) +
     size * PassiveSyncProducts_Data::SERIALIZED_SIZE;
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->baseId + RecordId::DataArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    status = this->m_dataBuffer.serialize(size);
+    status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
@@ -96,14 +96,14 @@ Fw::SerializeStatus PassiveSyncProductsComponentBase::DpContainer ::
   FW_ASSERT(array != nullptr);
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    sizeof(FwSizeType) +
+    sizeof(FwSizeStoreType) +
     size * sizeof(U32);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->baseId + RecordId::U32ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    status = this->m_dataBuffer.serialize(size);
+    status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
@@ -147,17 +147,16 @@ Fw::SerializeStatus PassiveSyncProductsComponentBase::DpContainer ::
   FW_ASSERT(array != nullptr);
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    sizeof(FwSizeType) +
+    sizeof(FwSizeStoreType) +
     size * sizeof(U8);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->baseId + RecordId::U8ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    status = this->m_dataBuffer.serialize(size);
+    status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    const bool omitSerializedLength = true;
-    status = this->m_dataBuffer.serialize(array, size, omitSerializedLength);
+    status = this->m_dataBuffer.serialize(array, size, Fw::Serialization::OMIT_LENGTH);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     this->m_dataSize += sizeDelta;
   }
@@ -1942,8 +1941,9 @@ void PassiveSyncProductsComponentBase ::
   // Update the size of the buffer according to the data size
   const FwSizeType packetSize = container.getPacketSize();
   Fw::Buffer buffer = container.getBuffer();
-  FW_ASSERT(packetSize <= buffer.getSize(), packetSize, buffer.getSize());
-  buffer.setSize(packetSize);
+  FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
+      static_cast<FwAssertArgType>(buffer.getSize()));
+  buffer.setSize(static_cast<U32>(packetSize));
   // Send the buffer
   this->productSendOut_out(0, container.getId(), buffer);
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/PassiveTestComponentAc.ref.cpp
@@ -45,14 +45,14 @@ Fw::SerializeStatus PassiveTestComponentBase::DpContainer ::
   FW_ASSERT(array != nullptr);
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    sizeof(FwSizeType) +
+    sizeof(FwSizeStoreType) +
     size * PassiveTest_Data::SERIALIZED_SIZE;
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->baseId + RecordId::DataArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    status = this->m_dataBuffer.serialize(size);
+    status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
@@ -96,14 +96,14 @@ Fw::SerializeStatus PassiveTestComponentBase::DpContainer ::
   FW_ASSERT(array != nullptr);
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    sizeof(FwSizeType) +
+    sizeof(FwSizeStoreType) +
     size * sizeof(U32);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->baseId + RecordId::U32ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    status = this->m_dataBuffer.serialize(size);
+    status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
@@ -147,17 +147,16 @@ Fw::SerializeStatus PassiveTestComponentBase::DpContainer ::
   FW_ASSERT(array != nullptr);
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    sizeof(FwSizeType) +
+    sizeof(FwSizeStoreType) +
     size * sizeof(U8);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->baseId + RecordId::U8ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    status = this->m_dataBuffer.serialize(size);
+    status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    const bool omitSerializedLength = true;
-    status = this->m_dataBuffer.serialize(array, size, omitSerializedLength);
+    status = this->m_dataBuffer.serialize(array, size, Fw::Serialization::OMIT_LENGTH);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     this->m_dataSize += sizeDelta;
   }
@@ -4066,8 +4065,9 @@ void PassiveTestComponentBase ::
   // Update the size of the buffer according to the data size
   const FwSizeType packetSize = container.getPacketSize();
   Fw::Buffer buffer = container.getBuffer();
-  FW_ASSERT(packetSize <= buffer.getSize(), packetSize, buffer.getSize());
-  buffer.setSize(packetSize);
+  FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
+      static_cast<FwAssertArgType>(buffer.getSize()));
+  buffer.setSize(static_cast<U32>(packetSize));
   // Send the buffer
   this->productSendOut_out(0, container.getId(), buffer);
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedAsyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedAsyncProductsComponentAc.ref.cpp
@@ -102,14 +102,14 @@ Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::
   FW_ASSERT(array != nullptr);
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    sizeof(FwSizeType) +
+    sizeof(FwSizeStoreType) +
     size * QueuedAsyncProducts_Data::SERIALIZED_SIZE;
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->baseId + RecordId::DataArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    status = this->m_dataBuffer.serialize(size);
+    status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
@@ -153,14 +153,14 @@ Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::
   FW_ASSERT(array != nullptr);
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    sizeof(FwSizeType) +
+    sizeof(FwSizeStoreType) +
     size * sizeof(U32);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->baseId + RecordId::U32ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    status = this->m_dataBuffer.serialize(size);
+    status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
@@ -204,17 +204,16 @@ Fw::SerializeStatus QueuedAsyncProductsComponentBase::DpContainer ::
   FW_ASSERT(array != nullptr);
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    sizeof(FwSizeType) +
+    sizeof(FwSizeStoreType) +
     size * sizeof(U8);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->baseId + RecordId::U8ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    status = this->m_dataBuffer.serialize(size);
+    status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    const bool omitSerializedLength = true;
-    status = this->m_dataBuffer.serialize(array, size, omitSerializedLength);
+    status = this->m_dataBuffer.serialize(array, size, Fw::Serialization::OMIT_LENGTH);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     this->m_dataSize += sizeDelta;
   }
@@ -2811,8 +2810,9 @@ void QueuedAsyncProductsComponentBase ::
   // Update the size of the buffer according to the data size
   const FwSizeType packetSize = container.getPacketSize();
   Fw::Buffer buffer = container.getBuffer();
-  FW_ASSERT(packetSize <= buffer.getSize(), packetSize, buffer.getSize());
-  buffer.setSize(packetSize);
+  FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
+      static_cast<FwAssertArgType>(buffer.getSize()));
+  buffer.setSize(static_cast<U32>(packetSize));
   // Send the buffer
   this->productSendOut_out(0, container.getId(), buffer);
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedGetProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedGetProductsComponentAc.ref.cpp
@@ -100,14 +100,14 @@ Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::
   FW_ASSERT(array != nullptr);
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    sizeof(FwSizeType) +
+    sizeof(FwSizeStoreType) +
     size * QueuedGetProducts_Data::SERIALIZED_SIZE;
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->baseId + RecordId::DataArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    status = this->m_dataBuffer.serialize(size);
+    status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
@@ -151,14 +151,14 @@ Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::
   FW_ASSERT(array != nullptr);
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    sizeof(FwSizeType) +
+    sizeof(FwSizeStoreType) +
     size * sizeof(U32);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->baseId + RecordId::U32ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    status = this->m_dataBuffer.serialize(size);
+    status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
@@ -202,17 +202,16 @@ Fw::SerializeStatus QueuedGetProductsComponentBase::DpContainer ::
   FW_ASSERT(array != nullptr);
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    sizeof(FwSizeType) +
+    sizeof(FwSizeStoreType) +
     size * sizeof(U8);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->baseId + RecordId::U8ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    status = this->m_dataBuffer.serialize(size);
+    status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    const bool omitSerializedLength = true;
-    status = this->m_dataBuffer.serialize(array, size, omitSerializedLength);
+    status = this->m_dataBuffer.serialize(array, size, Fw::Serialization::OMIT_LENGTH);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     this->m_dataSize += sizeDelta;
   }
@@ -2660,8 +2659,9 @@ void QueuedGetProductsComponentBase ::
   // Update the size of the buffer according to the data size
   const FwSizeType packetSize = container.getPacketSize();
   Fw::Buffer buffer = container.getBuffer();
-  FW_ASSERT(packetSize <= buffer.getSize(), packetSize, buffer.getSize());
-  buffer.setSize(packetSize);
+  FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
+      static_cast<FwAssertArgType>(buffer.getSize()));
+  buffer.setSize(static_cast<U32>(packetSize));
   // Send the buffer
   this->productSendOut_out(0, container.getId(), buffer);
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedGuardedProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedGuardedProductsComponentAc.ref.cpp
@@ -100,14 +100,14 @@ Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::
   FW_ASSERT(array != nullptr);
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    sizeof(FwSizeType) +
+    sizeof(FwSizeStoreType) +
     size * QueuedGuardedProducts_Data::SERIALIZED_SIZE;
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->baseId + RecordId::DataArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    status = this->m_dataBuffer.serialize(size);
+    status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
@@ -151,14 +151,14 @@ Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::
   FW_ASSERT(array != nullptr);
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    sizeof(FwSizeType) +
+    sizeof(FwSizeStoreType) +
     size * sizeof(U32);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->baseId + RecordId::U32ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    status = this->m_dataBuffer.serialize(size);
+    status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
@@ -202,17 +202,16 @@ Fw::SerializeStatus QueuedGuardedProductsComponentBase::DpContainer ::
   FW_ASSERT(array != nullptr);
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    sizeof(FwSizeType) +
+    sizeof(FwSizeStoreType) +
     size * sizeof(U8);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->baseId + RecordId::U8ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    status = this->m_dataBuffer.serialize(size);
+    status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    const bool omitSerializedLength = true;
-    status = this->m_dataBuffer.serialize(array, size, omitSerializedLength);
+    status = this->m_dataBuffer.serialize(array, size, Fw::Serialization::OMIT_LENGTH);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     this->m_dataSize += sizeDelta;
   }
@@ -2767,8 +2766,9 @@ void QueuedGuardedProductsComponentBase ::
   // Update the size of the buffer according to the data size
   const FwSizeType packetSize = container.getPacketSize();
   Fw::Buffer buffer = container.getBuffer();
-  FW_ASSERT(packetSize <= buffer.getSize(), packetSize, buffer.getSize());
-  buffer.setSize(packetSize);
+  FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
+      static_cast<FwAssertArgType>(buffer.getSize()));
+  buffer.setSize(static_cast<U32>(packetSize));
   // Send the buffer
   this->productSendOut_out(0, container.getId(), buffer);
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedSyncProductsComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedSyncProductsComponentAc.ref.cpp
@@ -100,14 +100,14 @@ Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::
   FW_ASSERT(array != nullptr);
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    sizeof(FwSizeType) +
+    sizeof(FwSizeStoreType) +
     size * QueuedSyncProducts_Data::SERIALIZED_SIZE;
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->baseId + RecordId::DataArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    status = this->m_dataBuffer.serialize(size);
+    status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
@@ -151,14 +151,14 @@ Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::
   FW_ASSERT(array != nullptr);
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    sizeof(FwSizeType) +
+    sizeof(FwSizeStoreType) +
     size * sizeof(U32);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->baseId + RecordId::U32ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    status = this->m_dataBuffer.serialize(size);
+    status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
@@ -202,17 +202,16 @@ Fw::SerializeStatus QueuedSyncProductsComponentBase::DpContainer ::
   FW_ASSERT(array != nullptr);
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    sizeof(FwSizeType) +
+    sizeof(FwSizeStoreType) +
     size * sizeof(U8);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->baseId + RecordId::U8ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    status = this->m_dataBuffer.serialize(size);
+    status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    const bool omitSerializedLength = true;
-    status = this->m_dataBuffer.serialize(array, size, omitSerializedLength);
+    status = this->m_dataBuffer.serialize(array, size, Fw::Serialization::OMIT_LENGTH);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     this->m_dataSize += sizeDelta;
   }
@@ -2761,8 +2760,9 @@ void QueuedSyncProductsComponentBase ::
   // Update the size of the buffer according to the data size
   const FwSizeType packetSize = container.getPacketSize();
   Fw::Buffer buffer = container.getBuffer();
-  FW_ASSERT(packetSize <= buffer.getSize(), packetSize, buffer.getSize());
-  buffer.setSize(packetSize);
+  FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
+      static_cast<FwAssertArgType>(buffer.getSize()));
+  buffer.setSize(static_cast<U32>(packetSize));
   // Send the buffer
   this->productSendOut_out(0, container.getId(), buffer);
 }

--- a/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/component/base/QueuedTestComponentAc.ref.cpp
@@ -136,14 +136,14 @@ Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::
   FW_ASSERT(array != nullptr);
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    sizeof(FwSizeType) +
+    sizeof(FwSizeStoreType) +
     size * QueuedTest_Data::SERIALIZED_SIZE;
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->baseId + RecordId::DataArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    status = this->m_dataBuffer.serialize(size);
+    status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
@@ -187,14 +187,14 @@ Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::
   FW_ASSERT(array != nullptr);
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    sizeof(FwSizeType) +
+    sizeof(FwSizeStoreType) +
     size * sizeof(U32);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->baseId + RecordId::U32ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    status = this->m_dataBuffer.serialize(size);
+    status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     for (FwSizeType i = 0; i < size; i++) {
       status = this->m_dataBuffer.serialize(array[i]);
@@ -238,17 +238,16 @@ Fw::SerializeStatus QueuedTestComponentBase::DpContainer ::
   FW_ASSERT(array != nullptr);
   const FwSizeType sizeDelta =
     sizeof(FwDpIdType) +
-    sizeof(FwSizeType) +
+    sizeof(FwSizeStoreType) +
     size * sizeof(U8);
   Fw::SerializeStatus status = Fw::FW_SERIALIZE_OK;
   if (this->m_dataBuffer.getBuffLength() + sizeDelta <= this->m_dataBuffer.getBuffCapacity()) {
     const FwDpIdType id = this->baseId + RecordId::U8ArrayRecord;
     status = this->m_dataBuffer.serialize(id);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    status = this->m_dataBuffer.serialize(size);
+    status = this->m_dataBuffer.serializeSize(size);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
-    const bool omitSerializedLength = true;
-    status = this->m_dataBuffer.serialize(array, size, omitSerializedLength);
+    status = this->m_dataBuffer.serialize(array, size, Fw::Serialization::OMIT_LENGTH);
     FW_ASSERT(status == Fw::FW_SERIALIZE_OK, status);
     this->m_dataSize += sizeDelta;
   }
@@ -5606,8 +5605,9 @@ void QueuedTestComponentBase ::
   // Update the size of the buffer according to the data size
   const FwSizeType packetSize = container.getPacketSize();
   Fw::Buffer buffer = container.getBuffer();
-  FW_ASSERT(packetSize <= buffer.getSize(), packetSize, buffer.getSize());
-  buffer.setSize(packetSize);
+  FW_ASSERT(packetSize <= buffer.getSize(), static_cast<FwAssertArgType>(packetSize),
+      static_cast<FwAssertArgType>(buffer.getSize()));
+  buffer.setSize(static_cast<U32>(packetSize));
   // Send the buffer
   this->productSendOut_out(0, container.getId(), buffer);
 }


### PR DESCRIPTION
Use `FwSizeStoreType` to store the array size. Closes #393.

* `check-cpp` passes against https://github.com/bocchino/fprime/commit/cb0f08823c5f8a1d2eec0d11d6ff2cf1b69c5936.
* `FppTest` passes on https://github.com/bocchino/fprime/commit/677c8e7e1b0f5fed95c76ef756dda37fdc660d33.